### PR TITLE
Update error handling for 'build' command to match 'up' command

### DIFF
--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -26,24 +26,50 @@ describe('Dev Containers CLI', function () {
 		assert.ok(res.stdout.indexOf('run-user-commands'), 'Help text is not mentioning run-user-commands.');
 	});
 
-	describe('Command up', () =>{
-
+	describe('Command build', () => {
 		it('should execute successfully with valid config', async () => {
-			const res = await shellExec(`${cli} up --workspace-folder ${__dirname}/configs/image`);
-			const containerId: string = JSON.parse(res.stdout).containerId;
-			assert.ok(containerId, 'Container id not found.');
-			await shellExec(`docker rm -f ${containerId}`);
+			const res = await shellExec(`${cli} build --workspace-folder ${__dirname}/configs/image`);
+			const response = JSON.parse(res.stdout);
+			assert.equal(response.outcome, 'success');
 		});
 		
 		it('should fail with "not found" error when config is not found', async () => {
+			let success = false;
 			try {
-				await shellExec(`${cli} up --workspace-folder path-that-does-not-exist`);
-				assert.fail('expect exception');
-			} catch(error){
+				await shellExec(`${cli} build --workspace-folder path-that-does-not-exist`);
+				success = true;
+			} catch (error) {
 				assert.equal(error.error.code, 1, 'Should fail with exit code 1');
 				const res = JSON.parse(error.stdout);
+				assert.equal(res.outcome, 'error');
 				assert.match(res.message, /Dev container config \(.*\) not found./);
 			}
+			assert.equal(success, false, 'expect non-successful call');
+		});
+	});
+
+	describe('Command up', () => {
+		it('should execute successfully with valid config', async () => {
+			const res = await shellExec(`${cli} up --workspace-folder ${__dirname}/configs/image`);
+			const response = JSON.parse(res.stdout);
+			assert.equal(response.outcome, 'success');
+			const containerId: string = response.containerId;
+			assert.ok(containerId, 'Container id not found.');
+			await shellExec(`docker rm -f ${containerId}`);
+		});
+
+		it('should fail with "not found" error when config is not found', async () => {
+			let success = false;
+			try {
+				await shellExec(`${cli} up --workspace-folder path-that-does-not-exist`);
+				success = true;
+			} catch (error) {
+				assert.equal(error.error.code, 1, 'Should fail with exit code 1');
+				const res = JSON.parse(error.stdout);
+				assert.equal(res.outcome, 'error');
+				assert.match(res.message, /Dev container config \(.*\) not found./);
+			}
+			assert.equal(success, false, 'expect non-successful call');
 		});
 	});
 


### PR DESCRIPTION
Update the error handling for `dev-container-cli build` to match the behaviour of `dev-container-cli up`:
- return non-zero exit code
- write error info to `stdout`

Includes tests for `up`/`build` to check this behaviour