### PR TITLE
Continuation of error handling updates

### DIFF
--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -14,7 +14,19 @@ describe('Dev Containers CLI', function () {
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} dev-containers-cli`;
-
+	async function devContainerUp(workspaceFolder: string) {
+		const res = await shellExec(`${cli} up --workspace-folder ${workspaceFolder}`);
+		const response = JSON.parse(res.stdout);
+		assert.equal(response.outcome, 'success');
+		const containerId = response.containerId;
+		assert.ok(containerId, 'Container id not found.');
+		return containerId;
+	}
+	async function devContainerDown(containerId: string | null) {
+		if (containerId !== null) {
+			await shellExec(`docker rm -f ${containerId}`);
+		}
+	};
 	before('Install', async () => {
 		await shellExec(`rm -rf ${tmp}/node_modules`);
 		await shellExec(`mkdir -p ${tmp}`);
@@ -73,22 +85,38 @@ describe('Dev Containers CLI', function () {
 		});
 	});
 
+	describe('Command run-user-commands', () => {
+		describe('with valid config', () => {
+			let containerId: string | null = null;
+			beforeEach(async () => await devContainerUp(`${__dirname}/configs/image`));
+			afterEach(async () => await devContainerDown(containerId));
+			it('should execute successfully', async () => {
+				const res = await shellExec(`${cli} run-user-commands --workspace-folder ${__dirname}/configs/image`);
+				const response = JSON.parse(res.stdout);
+				assert.equal(response.outcome, 'success');
+			});
+		});
+
+		it('should fail with "not found" error when config is not found', async () => {
+			let success = false;
+			try {
+				await shellExec(`${cli} run-user-commands --workspace-folder path-that-does-not-exist`);
+				success = true;
+			} catch (error) {
+				assert.equal(error.error.code, 1, 'Should fail with exit code 1');
+				const res = JSON.parse(error.stdout);
+				assert.equal(res.outcome, 'error');
+				assert.match(res.message, /Dev container config \(.*\) not found./);
+			}
+			assert.equal(success, false, 'expect non-successful call');
+		});
+	});
 
 	describe('Command exec', () => {
 		describe('with valid config', () => {
-			let containerId: string| null = null;
-			beforeEach(async () => {
-				const res = await shellExec(`${cli} up --workspace-folder ${__dirname}/configs/image`);
-				const response = JSON.parse(res.stdout);
-				assert.equal(response.outcome, 'success');
-				containerId = response.containerId;
-				assert.ok(containerId, 'Container id not found.');
-			});
-			afterEach(async () => {
-				if (containerId!==null){
-					await shellExec(`docker rm -f ${containerId}`);
-				}
-			});
+			let containerId: string | null = null;
+			beforeEach(async () => await devContainerUp(`${__dirname}/configs/image`));
+			afterEach(async () => await devContainerDown(containerId));
 			it('should execute successfully', async () => {
 				const res = await shellExec(`${cli} exec --workspace-folder ${__dirname}/configs/image echo hi`);
 				const response = JSON.parse(res.stdout);


### PR DESCRIPTION
Following #1, update the error handling for the `exec` and `run-user-commands` commands to match `build`/`up`

Notes:
- the `read-configuration` command hasn't been updated as the success path returns just the config (i.e.  no enclosing type with `outcome` etc)
- there is potential follow-up work to extract common handling into helper methods