### PR TITLE
Include imageName in build command output

### DIFF
--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -305,6 +305,7 @@ async function doBuild({
 			throw new ContainerError({ description: `Dev container config (${uriToFsPath(configFile || getDefaultDevContainerConfigPath(cliHost, workspace!.configFolderPath), cliHost.platform)}) not found.` });
 		}
 		const { config } = configs;
+		let imageNameResult = '';
 
 		if (isDockerFileConfig(config)) {
 	
@@ -317,6 +318,9 @@ async function doBuild({
 	
 			if (argImageName) {
 				await dockerPtyCLI(params, 'tag', updatedImageName, argImageName);
+				imageNameResult = argImageName;
+			} else {
+				imageNameResult = updatedImageName;
 			}
 		} else if ('dockerComposeFile' in config) {
 	
@@ -347,6 +351,9 @@ async function doBuild({
 			
 			if (argImageName) {
 				await dockerPtyCLI(params, 'tag', updatedImageName, argImageName);
+				imageNameResult = argImageName;
+			} else {
+				imageNameResult = updatedImageName;
 			}
 		} else {
 			
@@ -355,11 +362,15 @@ async function doBuild({
 	
 			if (argImageName) {
 				await dockerPtyCLI(params, 'tag', updatedImageName, argImageName);
+				imageNameResult = argImageName;
+			} else {
+				imageNameResult = updatedImageName;
 			}
 		}
 
 		return {
 			outcome: 'success' as 'success',
+			imageName: imageNameResult,
 			dispose,
 		};
 	} catch (originalError) {


### PR DESCRIPTION
Update the output for the `build` command to include an `imageName` property that returns the name of the built image.

This allows consuming tools to work with the built image without needing to know the conventions used in the build step (and regardless of the type of dev container). 