### PR TITLE
Add --cache-from to build/up commands

### DIFF
--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -43,6 +43,7 @@ export interface ProvisionOptions {
 	additionalMounts: Mount[];
 	updateRemoteUserUIDDefault: UpdateRemoteUserUIDDefault;
 	remoteEnv: Record<string, string>;
+	additionalCacheFroms: string[];
 }
 
 export async function launch(options: ProvisionOptions, disposables: (() => Promise<unknown> | undefined)[]) {
@@ -133,6 +134,7 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		additionalMounts,
 		userRepositoryConfigurationPaths: [],
 		updateRemoteUserUIDDefault,
+		additionalCacheFroms: options.additionalCacheFroms,
 	};
 }
 

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -160,8 +160,8 @@ export async function findDevContainer(params: DockerCLIParameters | DockerResol
 	return details.filter(container => container.State.Status !== 'removing')[0];
 }
 
-export async function buildImage(buildParams: DockerResolverParameters | DockerCLIParameters, config: DevContainerFromDockerfileConfig, baseImageName: string, noCache: boolean) {
-	const { cliHost, output } = 'cliHost' in buildParams ? buildParams : buildParams.common;
+export async function buildImage(buildParams: DockerResolverParameters, config: DevContainerFromDockerfileConfig, baseImageName: string, noCache: boolean) {
+	const { cliHost, output } = buildParams.common;
 	const dockerfileUri = getDockerfilePath(cliHost, config);
 	const dockerfilePath = await uriToWSLFsPath(dockerfileUri, cliHost);
 	if (!cliHost.isFile(dockerfilePath)) {
@@ -185,6 +185,7 @@ export async function buildImage(buildParams: DockerResolverParameters | DockerC
 			}
 		}
 	}
+	buildParams.additionalCacheFroms.forEach(cacheFrom => args.push('--cache-from', cacheFrom));
 	const buildArgs = config.build?.args;
 	if (buildArgs) {
 		for (const key in buildArgs) {

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -67,6 +67,7 @@ export interface DockerResolverParameters {
 	userRepositoryConfigurationPaths: string[];
 	additionalMounts: Mount[];
 	updateRemoteUserUIDDefault: UpdateRemoteUserUIDDefault;
+	additionalCacheFroms: string[];
 }
 
 export interface ResolverResult {


### PR DESCRIPTION
Add `--cache-from` option to `build` and `up` commands.

This allows additional potential layer cache images to be specified. One scenario where this could be useful is in CI builds where you may want to have different a tag for builds for a PR, but still pick up previously built images with that tag (even though not specified in `devcontainer.json`/`docker-compose.yml`