### PR TITLE
Combine `extendImage` into build function for Dockerfile 

### DIFF
--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -16,13 +16,12 @@ import { includeAllConfiguredFeatures } from '../spec-utils/product';
 import { createFeaturesTempFolder, DockerResolverParameters, getFolderImageName, inspectDockerImage } from './utils';
 import { CLIHost } from '../spec-common/cliHost';
 
-export async function extendImage(params: DockerResolverParameters, config: DevContainerConfig, imageName: string, pullImageOnError: boolean, runArgsUser: string | undefined) {
+export async function extendImage(params: DockerResolverParameters, config: DevContainerConfig, imageName: string, pullImageOnError: boolean) {
 	let cache: Promise<ImageDetails> | undefined;
 	const imageDetails = () => cache || (cache = inspectDockerImage(params, imageName, pullImageOnError));
 	const featuresConfig = await generateFeaturesConfig(params.common, (await createFeaturesTempFolder(params.common)), config, async () => (await imageDetails()).Config.Labels || {}, getContainerFeaturesFolder);
 	const collapsedFeaturesConfig = collapseFeaturesConfig(featuresConfig);
-	const updatedImageName0 = await addContainerFeatures(params, featuresConfig, imageName, imageDetails);
-	const updatedImageName = await updateRemoteUserUID(params, config, updatedImageName0, imageDetails, runArgsUser);
+	const updatedImageName = await addContainerFeatures(params, featuresConfig, imageName, imageDetails);
 	return { updatedImageName, collapsedFeaturesConfig, imageDetails };
 }
 
@@ -199,7 +198,7 @@ function getFeatureSafeId(f: Feature) {
 		.toUpperCase();
 }
 
-async function updateRemoteUserUID(params: DockerResolverParameters, config: DevContainerConfig, imageName: string, imageDetails: () => Promise<ImageDetails>, runArgsUser: string | undefined) {
+export async function updateRemoteUserUID(params: DockerResolverParameters, config: DevContainerConfig, imageName: string, imageDetails: () => Promise<ImageDetails>, runArgsUser: string | undefined) {
 	const { common } = params;
 	const { cliHost } = common;
 	if (params.updateRemoteUserUIDDefault === 'never' || !(typeof config.updateRemoteUserUID === 'boolean' ? config.updateRemoteUserUID : params.updateRemoteUserUIDDefault === 'on') || !(cliHost.platform === 'linux' || params.updateRemoteUserUIDOnMacOS && cliHost.platform === 'darwin')) {

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -13,7 +13,7 @@ import { ContainerError } from '../spec-common/errors';
 import { Log, LogLevel, makeLog, mapLogLevel } from '../spec-utils/log';
 import { UnpackPromise } from '../spec-utils/types';
 import { probeRemoteEnv, runPostCreateCommands, runRemoteCommand, UserEnvProbe } from '../spec-common/injectHeadless';
-import { bailOut, buildNamedImageAndExtend, findDevContainer, findUserArg, hostFolderLabel } from './singleContainer';
+import { bailOut, buildNamedImageAndExtend, findDevContainer, hostFolderLabel } from './singleContainer';
 import { extendImage } from './containerFeatures';
 import { DockerCLIParameters, dockerPtyCLI, inspectContainer } from '../spec-shutdown/dockerUtils';
 import { buildDockerCompose, getProjectName, readDockerComposeConfig } from './dockerCompose';
@@ -347,7 +347,7 @@ async function doBuild({
 	
 			const service = composeConfig.services[config.service];
 			const originalImageName = service.image || `${projectName}_${config.service}`;
-			const { updatedImageName } = await extendImage(params, config, originalImageName, !service.build, service.user);
+			const { updatedImageName } = await extendImage(params, config, originalImageName, !service.build);
 			
 			if (argImageName) {
 				await dockerPtyCLI(params, 'tag', updatedImageName, argImageName);
@@ -355,7 +355,7 @@ async function doBuild({
 		} else {
 			
 			await dockerPtyCLI(params, 'pull', config.image);
-			const { updatedImageName } = await extendImage(params, config, config.image, 'image' in config, findUserArg(config.runArgs) || config.containerUser);
+			const { updatedImageName } = await extendImage(params, config, config.image, 'image' in config);
 	
 			if (argImageName) {
 				await dockerPtyCLI(params, 'tag', updatedImageName, argImageName);

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -14,7 +14,7 @@ import { equalPaths, parseVersion, isEarlierVersion } from '../spec-common/commo
 import { ContainerDetails, inspectContainer, listContainers, DockerCLIParameters, dockerCLI, dockerComposeCLI, dockerComposePtyCLI, PartialExecParameters, DockerComposeCLI, ImageDetails } from '../spec-shutdown/dockerUtils';
 import { DevContainerFromDockerComposeConfig, getDockerComposeFilePaths } from '../spec-configuration/configuration';
 import { LogLevel, makeLog, terminalEscapeSequences } from '../spec-utils/log';
-import { extendImage } from './containerFeatures';
+import { extendImage, updateRemoteUserUID } from './containerFeatures';
 import { Mount, CollapsedFeaturesConfig } from '../spec-configuration/containerFeaturesConfiguration';
 import { includeAllConfiguredFeatures } from '../spec-utils/product';
 
@@ -207,7 +207,8 @@ async function startContainer(params: DockerResolverParameters, buildParams: Doc
 	if (!didRestoreFromPersistedShare) {
 		output.write('Generating composeOverrideFile...');
 
-		const { updatedImageName, collapsedFeaturesConfig, imageDetails } = await extendImage(params, config, originalImageName, !service.build, service.user);
+		const { updatedImageName: updatedImageName0, collapsedFeaturesConfig, imageDetails } = await extendImage(params, config, originalImageName, !service.build);
+		const updatedImageName = await updateRemoteUserUID(params, config, updatedImageName0, imageDetails, service.user);
 		const composeOverrideContent = await generateFeaturesComposeOverrideContent(updatedImageName, originalImageName, collapsedFeaturesConfig, config, buildParams, composeFiles, imageDetails, service, idLabels, params.additionalMounts);
 
 		const overrideFileHasContents = !!composeOverrideContent && composeOverrideContent.length > 0 && composeOverrideContent.trim() !== '';


### PR DESCRIPTION
As part of #10, combine the `extendImage` calls for `Dockerfile` dev containers into the build functions

This PR also moves updateRemoteUserUID out of extendImage (i.e. ensure that it only executes when starting the container, not when building the container)
