### PR TITLE
Support for multi-platform builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/*.test.ts",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.test.ts",
 		"test-container-features-offline": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.offline.test.ts",
-		"test-container-features-online": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.online.test.ts"
+		"test-container-features-online": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.online.test.ts",
+		"test-multi-platform-container": "env TS_NODE_PROJECT=test/tsconfig.json npx mocha -r ts-node/register --exit src/test/container-features/multiPlatformContainers.test.ts"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
 		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/*.test.ts",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.test.ts",
 		"test-container-features-offline": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.offline.test.ts",
-		"test-container-features-online": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.online.test.ts",
-		"test-multi-platform-container": "env TS_NODE_PROJECT=test/tsconfig.json npx mocha -r ts-node/register --exit src/test/container-features/multiPlatformContainers.test.ts"
+		"test-container-features-online": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/**/*.online.test.ts"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.3.0",

--- a/src/spec-common/injectHeadless.ts
+++ b/src/spec-common/injectHeadless.ts
@@ -56,6 +56,10 @@ export interface ResolverParameters {
 	backgroundTasks: (Promise<void> | (() => Promise<void>))[];
 	persistedFolder: string; // A path where config can be persisted and restored at a later time. Should default to tmpdir() folder if not provided.
 	remoteEnv: Record<string, string>;
+	enableBuildx: boolean;
+	buildxPlatform: string | undefined;
+	buildxPush: boolean;
+	buildxLoad: boolean;
 }
 
 export interface PostCreate {

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -44,6 +44,10 @@ export interface ProvisionOptions {
 	updateRemoteUserUIDDefault: UpdateRemoteUserUIDDefault;
 	remoteEnv: Record<string, string>;
 	additionalCacheFroms: string[];
+	enableBuildx: boolean;
+	buildxPlatform: string | undefined;
+	buildxPush: boolean;
+	buildxLoad: boolean;
 }
 
 export async function launch(options: ProvisionOptions, disposables: (() => Promise<unknown> | undefined)[]) {
@@ -110,6 +114,10 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		backgroundTasks: [],
 		persistedFolder: persistedFolder || await cliHost.tmpdir(), // Fallback to tmpDir(), even though that isn't 'persistent'
 		remoteEnv,
+		enableBuildx: options.enableBuildx,
+		buildxPlatform: options.buildxPlatform,
+		buildxPush: options.buildxPush,
+		buildxLoad: options.buildxLoad,
 	};
 
 	const dockerPath = options.dockerPath || 'docker';
@@ -135,6 +143,10 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		userRepositoryConfigurationPaths: [],
 		updateRemoteUserUIDDefault,
 		additionalCacheFroms: options.additionalCacheFroms,
+		enableBuildx: common.enableBuildx,
+		buildxPlatform: common.buildxPlatform,
+		buildxPush: common.buildxPush,
+		buildxLoad: common.buildxLoad,
 	};
 }
 

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -262,19 +262,6 @@ async function build(args: BuildArgs) {
 	process.exit(exitCode);
 }
 
-function checkBuildxArgs(buildx?: boolean, platform?: string, push?: boolean, load?: boolean, imageName?: string) {
-	if (!buildx && !platform && !push && !load) {
-		return true;
-	}
-	if (!buildx && ((platform || platform?.length === 0) || push || load)) {
-		return false;
-	}
-	if (buildx && ((platform && platform?.length > 0) || push || load) && !imageName) {
-		return false;
-	}
-	return true;
-}
-
 async function doBuild({
 	'user-data-folder': persistedFolder,
 	'docker-path': dockerPath,
@@ -346,11 +333,6 @@ async function doBuild({
 		let imageNameResult = '';
 
 		if (isDockerFileConfig(config)) {
-			if (!checkBuildxArgs(enableBuildx, buildxPlatform, buildxPush, buildxLoad, argImageName)) {
-				const msg = `'devcontainer build --buildx [--platform | --push | --load] --image-name`;
-				throw new ContainerError({ description: msg });
-			}
-
 			// Build the base image and extend with features etc.
 			const { updatedImageName } = await buildNamedImageAndExtend(params, config, argImageName);
 	

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -237,6 +237,7 @@ function buildOptions(y: Argv) {
 		'no-cache': { type: 'boolean', default: false, description: 'Builds the image with `--no-cache`.' },
 		'image-name': { type: 'string', description: 'Image name.' },
 		'cache-from' : {type: 'string', description: 'Additional image to use as potential layer cache' },
+		'buildx' : {type: 'string', description: 'Multi-build images support.' },
 	});
 }
 

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -346,7 +346,6 @@ async function doBuild({
 		const { config } = configs;
 		let imageNameResult = '';
 
-		debuglog('JCZ testing');
 		if (isDockerFileConfig(config)) {
 			// JCZ todo enable it
 			// if (!checkBuildxArgs(enableBuildx, buildxPlatform, buildxPush, buildxLoad, argImageName)) {
@@ -357,7 +356,7 @@ async function doBuild({
 		
 	
 			// Build the base image and extend with features etc.
-			const { updatedImageName } = await buildNamedImageAndExtend(params, config);
+			const { updatedImageName } = await buildNamedImageAndExtend(params, config, argImageName);
 	
 			if (argImageName) {
 				await dockerPtyCLI(params, 'tag', updatedImageName, argImageName);

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -182,6 +182,10 @@ async function provision({
 		updateRemoteUserUIDDefault,
 		remoteEnv: keyValuesToRecord(addRemoteEnvs),
 		additionalCacheFroms: addCacheFroms,
+		enableBuildx: false,
+		buildxPlatform: undefined,
+		buildxPush: false,
+		buildxLoad: false
 	};
 
 	const result = await doProvision(options);
@@ -259,18 +263,18 @@ async function build(args: BuildArgs) {
 	process.exit(exitCode);
 }
 
-function checkBuildxArgs(buildx?: boolean, platform?: string, push?: boolean, load?: boolean, imageName?: string) {
-	if (!buildx && !platform && !push && !load) {
-		return true;
-	}
-	if (!buildx && ((platform || platform?.length === 0) || push || load)) {
-		return false;
-	}
-	if (buildx && ((platform && platform?.length > 0) || push || load) && !imageName) {
-		return false;
-	}
-	return true;
-}
+// function checkBuildxArgs(buildx?: boolean, platform?: string, push?: boolean, load?: boolean, imageName?: string) {
+// 	if (!buildx && !platform && !push && !load) {
+// 		return true;
+// 	}
+// 	if (!buildx && ((platform || platform?.length === 0) || push || load)) {
+// 		return false;
+// 	}
+// 	if (buildx && ((platform && platform?.length > 0) || push || load) && !imageName) {
+// 		return false;
+// 	}
+// 	return true;
+// }
 
 async function doBuild({
 	'user-data-folder': persistedFolder,
@@ -322,6 +326,10 @@ async function doBuild({
 			updateRemoteUserUIDDefault: 'never',
 			remoteEnv: {},
 			additionalCacheFroms: addCacheFroms,
+			enableBuildx,
+			buildxPlatform,
+			buildxPush,
+			buildxLoad,
 		}, disposables);
 		
 		const { common, dockerCLI, dockerComposeCLI } = params;
@@ -338,12 +346,14 @@ async function doBuild({
 		const { config } = configs;
 		let imageNameResult = '';
 
+		debuglog('JCZ testing');
 		if (isDockerFileConfig(config)) {
-			if (!checkBuildxArgs(enableBuildx, buildxPlatform, buildxPush, buildxLoad, argImageName)) {
-				const msg = `'devcontainer build --buildx [--platform | --push | --load] --image-name`;
-				console.error(msg);
-				throw new ContainerError({ description: msg });
-			}
+			// JCZ todo enable it
+			// if (!checkBuildxArgs(enableBuildx, buildxPlatform, buildxPush, buildxLoad, argImageName)) {
+			// 	const msg = `'devcontainer build --buildx [--platform | --push | --load] --image-name`;
+			// 	console.error(msg);
+			// 	throw new ContainerError({ description: msg });
+			// }
 		
 	
 			// Build the base image and extend with features etc.
@@ -536,6 +546,10 @@ async function doRunUserCommands({
 			updateRemoteUserUIDDefault: 'never',
 			remoteEnv: keyValuesToRecord(addRemoteEnvs),
 			additionalCacheFroms: [],
+			enableBuildx: false,
+			buildxPlatform: undefined,
+			buildxPush: false,
+			buildxLoad: false,
 		}, disposables);
 
 		const { common } = params;
@@ -779,6 +793,10 @@ async function doExec({
 			updateRemoteUserUIDDefault: 'never',
 			remoteEnv: keyValuesToRecord(addRemoteEnvs),
 			additionalCacheFroms: [],
+			enableBuildx: false,
+			buildxPlatform: undefined,
+			buildxPush: false,
+			buildxLoad: false,
 		}, disposables);
 
 		const { common } = params;

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -13,6 +13,7 @@ import { LogLevel, Log, makeLog } from '../spec-utils/log';
 import { extendImage, updateRemoteUserUID } from './containerFeatures';
 import { Mount, CollapsedFeaturesConfig } from '../spec-configuration/containerFeaturesConfiguration';
 import { includeAllConfiguredFeatures } from '../spec-utils/product';
+import { debuglog } from 'util';
 
 export const hostFolderLabel = 'devcontainer.local_folder'; // used to label containers created from a workspace/folder
 
@@ -171,6 +172,11 @@ async function buildImage(buildParams: DockerResolverParameters, config: DevCont
 	const dockerfilePath = await uriToWSLFsPath(dockerfileUri, cliHost);
 	if (!cliHost.isFile(dockerfilePath)) {
 		throw new ContainerError({ description: `Dockerfile (${dockerfilePath}) not found.` });
+	}
+	// JCZ check for buildx and expand DockerResolverParameters
+	if (buildParams.enableBuildx === true) {
+		debuglog('JCZ enable buildx');
+		return;
 	}
 
 	const args = ['build', '-f', dockerfilePath, '-t', baseImageName];

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -174,21 +174,18 @@ async function buildImage(buildParams: DockerResolverParameters, config: DevCont
 	}
 
 	let args = ['build', '-f', dockerfilePath, '-t', baseImageName];
-	if (buildParams.enableBuildx) {
-		console.debug('jcz enable buildx');
-		if (buildParams.enableBuildx && argImageName) {
-			args = ['buildx', 'build'];
-			if (buildParams?.buildxPlatform) {
-				args.push('--platform', buildParams.buildxPlatform);
-			}
-			if (buildParams?.buildxPush) {
-				args.push('--push');
-			}
-			if (buildParams?.buildxLoad) {
-				args.push('--load');
-			}
-			args.push('-f', dockerfilePath, '-t', argImageName);
+	if (buildParams.enableBuildx && argImageName) {
+		args = ['buildx', 'build'];
+		if (buildParams.buildxPlatform) {
+			args.push('--platform', buildParams.buildxPlatform);
 		}
+		if (buildParams.buildxPush) {
+			args.push('--push');
+		}
+		if (buildParams.buildxLoad) {
+			args.push('--load');
+		}
+		args.push('-f', dockerfilePath, '-t', argImageName);
 	}
 
 	const target = config.build?.target;

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -68,6 +68,10 @@ export interface DockerResolverParameters {
 	additionalMounts: Mount[];
 	updateRemoteUserUIDDefault: UpdateRemoteUserUIDDefault;
 	additionalCacheFroms: string[];
+	enableBuildx: boolean;
+	buildxPlatform: string | undefined;
+	buildxPush: boolean;
+	buildxLoad: boolean;
 }
 
 export interface ResolverResult {


### PR DESCRIPTION
# [Work Item ID](https://github.com/microsoft/vscode-remote-release/issues/5652)

## Description

---

Enhance  `devcontainer` CLI **build** command by adding an option to build multi-platform container images and to push them to a container registry.

devcontainer build command will be enhanced with the following arguments:
**--buildx** enable to use buildx arguments [boolean][default: false]
**--platform** value1, value2.  Comma delimited string with platform types [string]. 
i.e. value: **linux/amd64,linux/arm64**
**--push** push to a container registry  [boolean] [default: false]
**--load** load builded image to images [boolean] [default: false]

## PR Checklist

---

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran the lint checks which produced no new errors nor warnings for my changes.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

---

- [ ] Yes
- [x] No

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.

## Testing

>   - What OS was used for testing: Window and MacOS
>   - Which test sets were used: mocka and manual testing
>   - Description of test scenarios that you have tried.
manual: Build images and upload them to container registry (docker hub)


Manual testing:

```bash
node devcontainer.js build --workspace-folder ../demo_container/ --buildx --platform linux/arm64,linux/amd64 --push --image-name dockerhubuname/test1:v1

[+] Building 1.9s (9/9) FINISHED                                                
 => [internal] load build definition from Dockerfile                       0.0s
 => => transferring dockerfile: 245B                                       0.0s
...
 => => pushing manifest for docker.io/dockerhubuname/test1:v1@sha256:00b62d3859  0.4s
 => [auth] dockerhubuname/test1:pull,push token for registry-1.docker.io         0.0s
 => [auth] dockerhubuname/test1:pull,push token for registry-1.docker.io         0.0s
````
List manifest from container registry

```bash
docker buildx imagetools inspect dockerhubuname/test1:v1
Name:      docker.io/dockerhubuname/test1:v1
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:00b62d385953096b5b09ba1458d0e2467b53b3c6d2409958a67eabd68f4fa0a0
           
Manifests: 
  Name:      docker.io/dockerhubuname/test1:v1@sha256:a18591ab9c4d416b9ee5b86c1b66c5ff9b89f8b8b522bc3d26db1395bd736f34
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
             
  Name:      docker.io/dockerhubuname/test1:v1@sha256:4ae8b07ea9a8c61da4a06548d758fc27709408b79d52d293bdc0edb940041576
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64

```
---


## Other information or known dependencies

---
n/a