### PR TITLE
Sanitize feature input options to be set as `_BUILD_ARG..`

### DIFF
--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -21,8 +21,8 @@ import { createFeaturesTempFolder, DockerResolverParameters, getFolderImageName,
 //	- alpha-numeric values, or
 //  - the '_' character, and
 // 	- a number cannot be the first character 
-export const getSafeId = (str) => str
-	.replace(/[^\\w_]/g, '_')
+export const getSafeId = (str: string) => str
+	.replace(/[^\w_]/g, '_')
 	.replace(/^[\d_]+/g, '_')
 	.toUpperCase(); 
 
@@ -222,7 +222,7 @@ ARG _DEV_CONTAINERS_BASE_IMAGE=mcr.microsoft.com/vscode/devcontainers/base:buste
 				.map(f => {
 					const featuresEnv = [
 						...getFeatureEnvVariables(f),
-						`_BUILD_ARG_${getFeatureSafeId(f)}_TARGETPATH=${path.posix.join('/usr/local/devcontainer-features', getSourceInfoString(featureSet.sourceInformation), f.id)}`
+						`_BUILD_ARG_${getSafeId(f.id)}_TARGETPATH=${path.posix.join('/usr/local/devcontainer-features', getSourceInfoString(featureSet.sourceInformation), f.id)}`
 					]
 						.join('\n');
 					const envPath = cliHost.path.join(dstFolder, getSourceInfoString(featureSet.sourceInformation), 'features', f.id, 'devcontainer-features.env'); // next to bin/acquire
@@ -297,11 +297,10 @@ RUN cd ${path.posix.join('/tmp/build-features', getSourceInfoString(featureSet.s
 function getFeatureEnvVariables(f: Feature) {
 	const values = getFeatureValueObject(f);
 	const idSafe = getSafeId(f.id);
-	const nameSafe = getSafeId(name);
 	const variables = [];
 	if (values) {
 		variables.push(...Object.keys(values)
-			.map(name => `_BUILD_ARG_${idSafe}_${nameSafe}="${values[name]}"`));
+			.map(name => `_BUILD_ARG_${idSafe}_${getSafeId(name)}="${values[name]}"`));
 		variables.push(`_BUILD_ARG_${idSafe}=true`);
 	}
 	if (f.buildArg) {

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -18,9 +18,9 @@ import { createFeaturesTempFolder, DockerResolverParameters, getFolderImageName,
 // Escapes environment variable keys.
 //
 // Environment variables must contain:
-//	- alpha-numeric values, or
-//  - the '_' character, and
-// 	- a number cannot be the first character 
+//      - alpha-numeric values, or
+//      - the '_' character, and
+//      - a number cannot be the first character 
 export const getSafeId = (str: string) => str
 	.replace(/[^\w_]/g, '_')
 	.replace(/^[\d_]+/g, '_')

--- a/src/test/container-features/helpers.offline.test.ts
+++ b/src/test/container-features/helpers.offline.test.ts
@@ -6,14 +6,29 @@ export const output = makeLog(createPlainLog(text => process.stdout.write(text),
 
 describe('getIdSafe should return safe environment variable name', function () {
 
-    it('should replace all "-" with "_"', function () {
+    it('should replace a "-" with "_"', function () {
         const ex = 'option-name';
         assert.strictEqual(getSafeId(ex), 'OPTION_NAME');
     });
 
-    it('should replace all leading numbers', function () {
-        const ex = '12_option-name';
-        assert.strictEqual(getSafeId(ex), '___OPTION_NAME');
+    it('should replace all "-" with "_"', function () {
+        const ex = 'option1-name-with_dashes-';
+        assert.strictEqual(getSafeId(ex), 'OPTION1_NAME_WITH_DASHES_');
+    });
+
+    it('should only be capitalized if no special characters', function () {
+        const ex = 'myOptionName';
+        assert.strictEqual(getSafeId(ex), 'MYOPTIONNAME');
+    });
+
+    it('should delete a leading numbers and add a _', function () {
+        const ex = '1name';
+        assert.strictEqual(getSafeId(ex), '_NAME');
+    });
+
+    it('should delete all leading numbers and add a _', function () {
+        const ex = '12345_option-name';
+        assert.strictEqual(getSafeId(ex), '_OPTION_NAME');
     });
 });
 

--- a/src/test/container-features/helpers.offline.test.ts
+++ b/src/test/container-features/helpers.offline.test.ts
@@ -1,7 +1,21 @@
 import { assert } from 'chai';
 import { getSourceInfoString, parseFeatureIdentifier, SourceInformation } from '../../spec-configuration/containerFeaturesConfiguration';
+import { getSafeId } from '../../spec-node/containerFeatures';
 import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
+
+describe('getIdSafe should return safe environment variable name', function () {
+
+    it('should replace all "-" with "_"', function () {
+        const ex = 'option-name';
+        assert.strictEqual(getSafeId(ex), 'OPTION_NAME');
+    });
+
+    it('should replace all leading numbers', function () {
+        const ex = '12_option-name';
+        assert.strictEqual(getSafeId(ex), '___OPTION_NAME');
+    });
+});
 
 describe('validate function parseRemoteFeatureToDownloadUri', function () {
 


### PR DESCRIPTION
Through experimentation and via the web with out auto-generated `_BUILD_ARG`s, it appears :

`
Environment variable names used by the utilities in the Shell and Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore) from the characters defined in Portable Character Set and do not begin with a digit. Other characters may be permitted by an implementation; applications shall tolerate the presence of such names.
`

This transforms the outputted `_BUILD_ARG_..` in an opinionated way.

cc/ @greggroth