### PR TITLE
Preserve bash history across instances

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,3 +4,13 @@ ARG VARIANT="16-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
 
 RUN mkdir -p /workspaces && chown node:node /workspaces
+
+ARG USERNAME=node
+USER $USERNAME
+
+# Save command line history
+RUN echo "export HISTFILE=/home/$USERNAME/commandhistory/.bash_history" >> "/home/$USERNAME/.bashrc" \
+	&& echo "export PROMPT_COMMAND='history -a'" >> "/home/$USERNAME/.bashrc" \
+	&& mkdir -p /home/$USERNAME/commandhistory \
+	&& touch /home/$USERNAME/commandhistory/.bash_history \
+	&& chown -R $USERNAME /home/$USERNAME/commandhistory

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,10 @@
 			"VARIANT": "16-bullseye"
 		}
 	},
+	"mounts": [
+		// Keep command history across instances
+		"source=dev-containers-cli-bashhistory,target=/home/node/commandhistory"
+	],
 
 	"postCreateCommand": "yarn install",
 


### PR DESCRIPTION
Add a volume for the container and configure bash to store history on it so that bash history isn't lost across container instances