### PR TITLE
Prep for multi-stage build for docker-compose

### DIFF
--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -55,9 +55,10 @@ export async function launch(options: ProvisionOptions, disposables: (() => Prom
 	const start = output.start(text);
 	const result = await resolve(params, options.configFile, options.overrideConfigFile, options.idLabels);
 	output.stop(text, start);
-	const { dockerContainerId } = result;
+	const { dockerContainerId, composeProjectName } = result;
 	return {
 		containerId: dockerContainerId!,
+		composeProjectName,
 		remoteUser: result.properties.user,
 		remoteWorkspaceFolder: result.properties.remoteWorkspaceFolder,
 		finishBackgroundTasks: async () => {

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -81,6 +81,7 @@ async function _openDockerComposeDevContainer(params: DockerResolverParameters, 
 			tunnelInformation: common.isLocalContainer ? getTunnelInformation(container) : {},
 			dockerParams: params,
 			dockerContainerId: container.Id,
+			composeProjectName: projectName,
 		};
 
 	} catch (originalError) {

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -175,7 +175,6 @@ async function startContainer(params: DockerResolverParameters, buildParams: Doc
 	// Try to restore the 'third' docker-compose file and featuresConfig from persisted storage.
 	// This file may have been generated upon a Codespace creation.
 	let didRestoreFromPersistedShare = false;
-	let collapsedFeaturesConfig: CollapsedFeaturesConfig | undefined = undefined;
 	const labels = container?.Config?.Labels;
 	output.write(`PersistedPath=${persistedFolder}, ContainerHasLabels=${!!labels}`);
 
@@ -255,7 +254,6 @@ async function startContainer(params: DockerResolverParameters, buildParams: Doc
 	await started;
 	return {
 		containerId: (await findComposeContainer(params, projectName, config.service))!,
-		collapsedFeaturesConfig,
 	};
 }
 

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -81,6 +81,7 @@ export interface ResolverResult {
 	isTrusted?: boolean;
 	dockerParams: DockerResolverParameters | undefined;
 	dockerContainerId: string | undefined;
+	composeProjectName?: string;
 }
 
 export async function startEventSeen(params: DockerResolverParameters, labels: Record<string, string>, canceled: Promise<void>, output: Log, trace: boolean) {

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -24,13 +24,16 @@ describe('Dev Containers CLI', function () {
 		const res = await shellExec(`${cli} up --workspace-folder ${workspaceFolder}${buildkitOption}`);
 		const response = JSON.parse(res.stdout);
 		assert.equal(response.outcome, 'success');
-		const containerId = response.containerId;
+		const { containerId, composeProjectName } = response;
 		assert.ok(containerId, 'Container id not found.');
-		return containerId;
+		return { containerId, composeProjectName };
 	}
-	async function devContainerDown(containerId: string | null) {
-		if (containerId !== null) {
-			await shellExec(`docker rm -f ${containerId}`);
+	async function devContainerDown(options: { containerId?: string | null; composeProjectName?: string | null }) {
+		if (options.containerId) {
+			await shellExec(`docker rm -f ${options.containerId}`);
+		}
+		if (options.composeProjectName) {
+			await shellExec(`docker compose --project-name ${options.composeProjectName} down`);
 		}
 	}
 	before('Install', async () => {
@@ -105,8 +108,8 @@ describe('Dev Containers CLI', function () {
 		describe('with valid config', () => {
 			let containerId: string | null = null;
 			const testFolder = `${__dirname}/configs/image`;
-			beforeEach(async () => containerId = await devContainerUp(testFolder));
-			afterEach(async () => await devContainerDown(containerId));
+			beforeEach(async () => containerId = (await devContainerUp(testFolder)).containerId);
+			afterEach(async () => await devContainerDown({ containerId }));
 			it('should execute successfully', async () => {
 				const res = await shellExec(`${cli} run-user-commands --workspace-folder ${testFolder}`);
 				const response = JSON.parse(res.stdout);
@@ -134,8 +137,8 @@ describe('Dev Containers CLI', function () {
 			describe(`with valid (image) config [${text}]`, () => {
 				let containerId: string | null = null;
 				const testFolder = `${__dirname}/configs/image`;
-				beforeEach(async () => containerId = await devContainerUp(testFolder, options));
-				afterEach(async () => await devContainerDown(containerId));
+				beforeEach(async () => containerId = (await devContainerUp(testFolder, options)).containerId);
+				afterEach(async () => await devContainerDown({ containerId }));
 				it('should execute successfully', async () => {
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} echo hi`);
 					const response = JSON.parse(res.stdout);
@@ -145,8 +148,8 @@ describe('Dev Containers CLI', function () {
 			describe(`with valid (image) config containing features [${text}]`, () => {
 				let containerId: string | null = null;
 				const testFolder = `${__dirname}/configs/image-with-features`;
-				beforeEach(async () => containerId = await devContainerUp(testFolder, options));
-				afterEach(async () => await devContainerDown(containerId));
+				beforeEach(async () => containerId = (await devContainerUp(testFolder, options)).containerId);
+				afterEach(async () => await devContainerDown({ containerId }));
 				it('should have access to installed features (docker)', async () => {
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker --version`);
 					const response = JSON.parse(res.stdout);
@@ -165,8 +168,8 @@ describe('Dev Containers CLI', function () {
 			describe(`with valid (Dockerfile) config containing features [${text}]`, () => {
 				let containerId: string | null = null;
 				const testFolder = `${__dirname}/configs/dockerfile-with-features`;
-				beforeEach(async () => containerId = await devContainerUp(testFolder, options));
-				afterEach(async () => await devContainerDown(containerId));
+				beforeEach(async () => containerId = (await devContainerUp(testFolder, options)).containerId);
+				afterEach(async () => await devContainerDown({ containerId }));
 				it('should have access to installed features (docker)', async () => {
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker --version`);
 					const response = JSON.parse(res.stdout);
@@ -186,8 +189,8 @@ describe('Dev Containers CLI', function () {
 			describe(`with valid (Dockerfile) config with target [${text}]`, () => {
 				let containerId: string | null = null;
 				const testFolder = `${__dirname}/configs/dockerfile-with-target`;
-				beforeEach(async () => containerId = await devContainerUp(testFolder, options));
-				afterEach(async () => await devContainerDown(containerId));
+				beforeEach(async () => containerId = (await devContainerUp(testFolder, options)).containerId);
+				afterEach(async () => await devContainerDown({ containerId }));
 				it('should have marker content', async () => {
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} cat /tmp/test-marker`);
 					const response = JSON.parse(res.stdout);
@@ -198,10 +201,10 @@ describe('Dev Containers CLI', function () {
 			});
 
 			describe(`with valid (docker-compose) config containing features [${text}]`, () => {
-				let containerId: string | null = null;
+				let composeProjectName: string | null = null;
 				const testFolder = `${__dirname}/configs/compose-with-features`;
-				beforeEach(async () => containerId = await devContainerUp(testFolder, options));
-				afterEach(async () => await devContainerDown(containerId));
+				beforeEach(async () => composeProjectName = (await devContainerUp(testFolder, options)).composeProjectName);
+				afterEach(async () => await devContainerDown({ composeProjectName }));
 				it('should have access to installed features (docker)', async () => {
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker --version`);
 					const response = JSON.parse(res.stdout);
@@ -223,8 +226,8 @@ describe('Dev Containers CLI', function () {
 		describe('with valid (Dockerfile) config containing #syntax (BuildKit)', () => { // ensure existing '# syntax' lines are handled
 			let containerId: string | null = null;
 			const testFolder = `${__dirname}/configs/dockerfile-with-syntax`;
-			beforeEach(async () => containerId = await devContainerUp(testFolder, { useBuildKit: true }));
-			afterEach(async () => await devContainerDown(containerId));
+			beforeEach(async () => containerId = (await devContainerUp(testFolder, { useBuildKit: true })).containerId);
+			afterEach(async () => await devContainerDown({ containerId }));
 			it('should have access to installed features (docker)', async () => {
 				const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker --version`);
 				const response = JSON.parse(res.stdout);

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -196,6 +196,28 @@ describe('Dev Containers CLI', function () {
 					assert.match(res.stderr, /||test-content||/);
 				});
 			});
+
+			describe(`with valid (docker-compose) config containing features [${text}]`, () => {
+				let containerId: string | null = null;
+				const testFolder = `${__dirname}/configs/compose-with-features`;
+				beforeEach(async () => containerId = await devContainerUp(testFolder, options));
+				afterEach(async () => await devContainerDown(containerId));
+				it('should have access to installed features (docker)', async () => {
+					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker --version`);
+					const response = JSON.parse(res.stdout);
+					console.log(res.stderr);
+					assert.equal(response.outcome, 'success');
+					assert.match(res.stderr, /Docker version/);
+				});
+				it('should have access to installed features (hello)', async () => {
+					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} hello`);
+					const response = JSON.parse(res.stdout);
+					console.log(res.stderr);
+					assert.equal(response.outcome, 'success');
+					assert.match(res.stderr, /howdy, node/);
+				});
+			});
+
 		});
 
 		describe('with valid (Dockerfile) config containing #syntax (BuildKit)', () => { // ensure existing '# syntax' lines are handled

--- a/src/test/configs/compose-with-features/.devcontainer/Dockerfile
+++ b/src/test/configs/compose-with-features/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)
+ARG MONGO_TOOLS_VERSION=5.0
+RUN . /etc/os-release \
+    && if [ "${VERSION_CODENAME}" = "buster" ] && [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+        curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
+        && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+        && apt-get install -y mongodb-database-tools mongodb-mongosh \
+        && apt-get clean -y && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"
+
+
+

--- a/src/test/configs/compose-with-features/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-with-features/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/javascript-node-mongo
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version
+{
+	"name": "Node.js & Mongo DB",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"mongodb.mongodb-vscode"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [3000, 27017],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	"features": {
+		"docker-in-docker": "latest",
+		"codspace/myfeatures/helloworld": {
+			"greeting": "howdy"
+		}
+	}
+}

--- a/src/test/configs/compose-with-features/.devcontainer/docker-compose.yml
+++ b/src/test/configs/compose-with-features/.devcontainer/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Update 'VARIANT' to pick an LTS version of Node.js: 18, 16, 14.
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 16-bullseye
+    volumes:
+      - ..:/workspace:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: node
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: mongo:latest
+    restart: unless-stopped
+    volumes:
+      - mongodb-data:/data/db
+    # Uncomment to change startup options
+    # environment:
+    #  MONGO_INITDB_ROOT_USERNAME: root
+    #  MONGO_INITDB_ROOT_PASSWORD: example
+    #  MONGO_INITDB_DATABASE: your-database-here
+
+    # Add "forwardPorts": ["27017"] to **devcontainer.json** to forward MongoDB locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  mongodb-data: null


### PR DESCRIPTION
Tracking progress towards multi-stage builds  (#10)

- Add a test for docker-compose, with container features
- Remove unused `collapsedFeaturesConfig` return value from `startContainer` function
- Include `composeProjectName` in output when starting a docker-compose dev container (and use that to stop the compose projects in tests)