### PR TITLE
add description property to a Feature

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -18,6 +18,7 @@ const ASSET_NAME = 'devcontainer-features.tgz';
 export interface Feature {
 	id: string;
 	name: string;
+	description?: string;
 	documentationURL?: string;
 	options?: Record<string, FeatureOption>;
 	buildArg?: string; // old properties for temporary compatibility


### PR DESCRIPTION
We are currently working on the `devcontainer/features` repository. In this repo I aim to auto-generate documentation given a feature's `devcontainer-feature.json`.  To store more metadata useful for a README, I hope to add a new, optional attribute called "description".

This property is already included in the [features proposal](https://github.com/devcontainers/spec/blob/main/proposals/devcontainer-features.md#devcontainer-featurejson-properties)