### PR TITLE
Build command: Support multiple --image-name parameters 

### DIFF
--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -45,7 +45,7 @@ export async function extendImage(params: DockerResolverParameters, config: DevC
 	if (!extendImageDetails || !extendImageDetails.featureBuildInfo) {
 		// no feature extensions - return
 		return {
-			updatedImageName: imageName,
+			updatedImageName: [imageName],
 			collapsedFeaturesConfig: undefined,
 			imageDetails
 		};
@@ -93,7 +93,7 @@ export async function extendImage(params: DockerResolverParameters, config: DevC
 		const infoParams = { ...toExecParameters(params), output: makeLog(output, LogLevel.Info), print: 'continuous' as 'continuous' };
 		await dockerCLI(infoParams, ...args);
 	}
-	return { updatedImageName, collapsedFeaturesConfig, imageDetails };
+	return { updatedImageName:[updatedImageName], collapsedFeaturesConfig, imageDetails };
 }
 
 export async function getExtendImageBuildInfo(params: DockerResolverParameters, config: DevContainerConfig, baseName: string, imageUser: string, imageLabelDetails: () => Promise<{ definition: string | undefined; version: string | undefined }>) {

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -398,11 +398,11 @@ async function doBuild({
 			}
 			if (imageNames) {
 				imageNames.forEach(async function (image) {
-					await dockerPtyCLI(params, 'tag', updatedImageName, image);
+					await dockerPtyCLI(params, 'tag', updatedImageName[0], image);
 				});
 				imageNameResult = imageNames;
 			} else {
-				imageNameResult = [updatedImageName];
+				imageNameResult = updatedImageName;
 			}
 		}
 

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -36,7 +36,6 @@ export async function openDockerfileDevContainer(params: DockerResolverParameter
 			// };
 			await startExistingContainer(params, idLabels, container);
 		} else {
-			// check
 			const res = await buildNamedImageAndExtend(params, config);
 			const updatedImageName = await updateRemoteUserUID(params, config, res.updatedImageName[0], res.imageDetails, findUserArg(config.runArgs) || config.containerUser);
 

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -181,10 +181,8 @@ async function buildAndExtendImage(buildParams: DockerResolverParameters, config
 		args.push('build');
 	}
 	args.push('-f', finalDockerfilePath);
-	
-	baseImageNames.forEach(function(image) {
-			args.push('-t', image);
-	});
+
+	baseImageNames.map(imageName => args.push('-t', imageName));
 
 	const target = config.build?.target;
 	if (target) {

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -36,8 +36,9 @@ export async function openDockerfileDevContainer(params: DockerResolverParameter
 			// };
 			await startExistingContainer(params, idLabels, container);
 		} else {
+			// check
 			const res = await buildNamedImageAndExtend(params, config);
-			const updatedImageName = await updateRemoteUserUID(params, config, res.updatedImageName, res.imageDetails, findUserArg(config.runArgs) || config.containerUser);
+			const updatedImageName = await updateRemoteUserUID(params, config, res.updatedImageName[0], res.imageDetails, findUserArg(config.runArgs) || config.containerUser);
 
 			// collapsedFeaturesConfig = async () => res.collapsedFeaturesConfig;
 
@@ -103,17 +104,17 @@ async function setupContainer(container: ContainerDetails, params: DockerResolve
 function getDefaultName(config: DevContainerFromDockerfileConfig | DevContainerFromImageConfig, params: DockerResolverParameters) {
 	return 'image' in config ? config.image : getFolderImageName(params.common);
 }
-export async function buildNamedImageAndExtend(params: DockerResolverParameters, config: DevContainerFromDockerfileConfig | DevContainerFromImageConfig, argImageName?: string) {
-	const imageName = argImageName ?? getDefaultName(config, params);
+export async function buildNamedImageAndExtend(params: DockerResolverParameters, config: DevContainerFromDockerfileConfig | DevContainerFromImageConfig, argImageNames?: string[]) {
+	const imageNames = argImageNames ?? [getDefaultName(config, params)];
 	params.common.progress(ResolverProgress.BuildingImage);
 	if (isDockerFileConfig(config)) {
-		return await buildAndExtendImage(params, config, imageName, params.buildNoCache ?? false);
+		return await buildAndExtendImage(params, config, imageNames, params.buildNoCache ?? false);
 	}
 	// image-based dev container - extend
-	return await extendImage(params, config, imageName, 'image' in config);
+	return await extendImage(params, config, imageNames[0], 'image' in config);
 }
 
-async function buildAndExtendImage(buildParams: DockerResolverParameters, config: DevContainerFromDockerfileConfig, baseImageName: string, noCache: boolean) {
+async function buildAndExtendImage(buildParams: DockerResolverParameters, config: DevContainerFromDockerfileConfig, baseImageNames: string[], noCache: boolean) {
 	const { cliHost, output } = buildParams.common;
 	const dockerfileUri = getDockerfilePath(cliHost, config);
 	const dockerfilePath = await uriToWSLFsPath(dockerfileUri, cliHost);
@@ -180,7 +181,11 @@ async function buildAndExtendImage(buildParams: DockerResolverParameters, config
 	} else {
 		args.push('build');
 	}
-	args.push('-f', finalDockerfilePath, '-t', baseImageName);
+	args.push('-f', finalDockerfilePath);
+	
+	baseImageNames.forEach(function(image) {
+			args.push('-t', image);
+	});
 
 	const target = config.build?.target;
 	if (target) {
@@ -223,10 +228,10 @@ async function buildAndExtendImage(buildParams: DockerResolverParameters, config
 		throw new ContainerError({ description: 'An error occurred building the image.', originalError: err, data: { fileWithError: dockerfilePath } });
 	}
 
-	const imageDetails = () => inspectDockerImage(buildParams, baseImageName, false);
+	const imageDetails = () => inspectDockerImage(buildParams, baseImageNames[0], false);
 
 	return {
-		updatedImageName: baseImageName,
+		updatedImageName: baseImageNames,
 		collapsedFeaturesConfig: extendImageBuildInfo?.collapsedFeaturesConfig,
 		imageDetails
 	};

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -198,6 +198,39 @@ describe('Dev Containers CLI', function () {
 			}
 			assert.equal(success, false, 'expect non-successful call');
 		});
+
+		it('should succeed with multiple --image-name parameters when DockerFile is present', async () => {
+			const testFolder = `${__dirname}/configs/dockerfile-with-features`;
+			const image1 = 'image-1';
+			const image2 = 'image-2';
+			const res = await shellExec(`${cli} build --workspace-folder ${testFolder} --image-name ${image1} --image-name ${image2}`);
+			const response = JSON.parse(res.stdout);
+			assert.equal(response.outcome, 'success');
+			assert.equal(response.imageName[0], image1);
+			assert.equal(response.imageName[1], image2);
+		});
+
+		it('should succeed with multiple --image-name parameters when dockerComposeFile is present', async () => {
+			const testFolder = `${__dirname}/configs/compose-Dockerfile-alpine`;
+			const image1 = 'image-1';
+			const image2 = 'image-2';
+			const res = await shellExec(`${cli} build --workspace-folder ${testFolder} --image-name ${image1} --image-name ${image2}`);
+			const response = JSON.parse(res.stdout);
+			assert.equal(response.outcome, 'success');
+			assert.equal(response.imageName[0], image1);
+			assert.equal(response.imageName[1], image2);
+		});
+
+		it('should succeed with multiple --image-name parameters when image is present', async () => {
+			const testFolder = `${__dirname}/configs/image`;
+			const image1 = 'image-1';
+			const image2 = 'image-2';
+			const res = await shellExec(`${cli} build --workspace-folder ${testFolder} --image-name ${image1} --image-name ${image2}`);
+			const response = JSON.parse(res.stdout);
+			assert.equal(response.outcome, 'success');
+			assert.equal(response.imageName[0], image1);
+			assert.equal(response.imageName[1], image2);
+		});
 	});
 
 	describe('Command up', () => {


### PR DESCRIPTION
It allows to tag the same image more than once.

eg - `devcontainer build --workspace-folder ./ --image-name alpine3 --image-name alpine3.0`

This is mainly needed for multiple tagging of multi-arch images created with `--platform`.
If the cli creates a multi arch image, and if you retag with `docker tag` then the new image ends up using architecture of the current machine for tagging.

Hence, such multi-arch images needs to be tagged during image build else they won't support multi-architecture platform.