### PR TITLE
'v1' features regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@devcontainers/cli",
 	"description": "Dev Containers CLI",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"bin": {
 		"devcontainer": "devcontainer.js"
 	},

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -538,6 +538,37 @@ export async function parseFeatureIdentifier(output: Log, env: NodeJS.ProcessEnv
 		return newFeaturesSet;
 	}
 
+	// remote tar file
+	if (type === 'direct-tarball') {
+		output.write(`Remote tar file found.`);
+		let input = userFeature.id.replace(/\/+$/, '');
+		const featureIdDelimiter = input.lastIndexOf('#');
+		const id = input.substring(featureIdDelimiter + 1);
+
+		if (id === '' || !allowedFeatureIdRegex.test(id)) {
+			output.write(`Parse error. Specify a feature id with alphanumeric, dash, or underscore characters. Provided: ${id}.`, LogLevel.Error);
+			return undefined;
+		}
+
+		const tarballUri = new URL.URL(input.substring(0, featureIdDelimiter)).toString();
+		let feat: Feature = {
+			id: id,
+			name: userFeature.id,
+			value: userFeature.options,
+			included: true,
+		};
+
+		let newFeaturesSet: FeatureSet = {
+			sourceInformation: {
+				type: 'direct-tarball',
+				tarballUri: tarballUri
+			},
+			features: [feat],
+		};
+
+		return newFeaturesSet;
+	}
+
 	// If its a valid path
 	if (type === 'file-path') {
 		output.write(`Local disk feature.`);
@@ -569,37 +600,6 @@ export async function parseFeatureIdentifier(output: Log, env: NodeJS.ProcessEnv
 	// (6) Oci Identifier
 	if (type === 'oci' && manifest) {
 		let newFeaturesSet: FeatureSet = getOCIFeatureSet(output, userFeature.id, userFeature.options, manifest);
-		return newFeaturesSet;
-	}
-
-	// remote tar file
-	if (type === 'direct-tarball') {
-		output.write(`Remote tar file found.`);
-		let input = userFeature.id.replace(/\/+$/, '');
-		const featureIdDelimiter = input.lastIndexOf('#');
-		const id = input.substring(featureIdDelimiter + 1);
-
-		if (id === '' || !allowedFeatureIdRegex.test(id)) {
-			output.write(`Parse error. Specify a feature id with alphanumeric, dash, or underscore characters. Provided: ${id}.`, LogLevel.Error);
-			return undefined;
-		}
-
-		const tarballUri = new URL.URL(input.substring(0, featureIdDelimiter)).toString();
-		let feat: Feature = {
-			id: id,
-			name: userFeature.id,
-			value: userFeature.options,
-			included: true,
-		};
-
-		let newFeaturesSet: FeatureSet = {
-			sourceInformation: {
-				type: 'direct-tarball',
-				tarballUri: tarballUri
-			},
-			features: [feat],
-		};
-
 		return newFeaturesSet;
 	}
 

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -710,7 +710,9 @@ async function fetchFeatures(params: { extensionPath: string; cwd: string; outpu
 				await cpDirectoryLocal(localFeaturesFolder, featCachePath);
 
 				if (!(await parseDevContainerFeature(output, featureSet, feature, featCachePath))) {
-					output.write(`ERR: Failed to parse feature.`, LogLevel.Error);
+					const err = `Failed to parse feature '${featureDebugId}'. Please check your devcontainer.json 'features' attribute.`;
+					output.write(err, LogLevel.Error);
+					throw new Error(err);
 				}
 				continue;
 			}
@@ -721,7 +723,9 @@ async function fetchFeatures(params: { extensionPath: string; cwd: string; outpu
 				const executionPath = featureSet.sourceInformation.isRelative ? path.join(params.cwd, featureSet.sourceInformation.filePath) : featureSet.sourceInformation.filePath;
 
 				if (!(await parseDevContainerFeature(output, featureSet, feature, featCachePath))) {
-					output.write(`ERR: Failed to parse feature.`, LogLevel.Error);
+					const err = `Failed to parse feature '${featureDebugId}'. Please check your devcontainer.json 'features' attribute.`;
+					output.write(err, LogLevel.Error);
+					throw new Error(err);
 				}				
 				await mkdirpLocal(featCachePath);
 				await cpDirectoryLocal(executionPath, featCachePath);
@@ -766,7 +770,9 @@ async function fetchFeatures(params: { extensionPath: string; cwd: string; outpu
 				if (didSucceed) {
 					output.write(`Succeeded fetching ${tarballUri}`, LogLevel.Trace);
 					if (!(await parseDevContainerFeature(output, featureSet, feature, featCachePath))) {
-						output.write(`ERR: Failed to parse feature.`, LogLevel.Error);
+						const err = `Failed to parse feature '${featureDebugId}'. Please check your devcontainer.json 'features' attribute.`;
+						output.write(err, LogLevel.Error);
+						throw new Error(err);
 					}
 					break;
 				}

--- a/src/spec-configuration/containerFeaturesOCI.ts
+++ b/src/spec-configuration/containerFeaturesOCI.ts
@@ -10,10 +10,10 @@ export type HEADERS = { 'authorization'?: string; 'user-agent': string; 'content
 export interface OCIFeatureRef {
     id: string;
     version: string;
-    featureName: string;
     owner: string;
     namespace: string;
     registry: string;
+    resource: string;
 }
 
 export interface OCILayer {
@@ -60,23 +60,23 @@ export function getOCIFeatureSet(output: Log, identifier: string, options: boole
     return featureSet;
 }
 
-export function getFeatureRef(output: Log, identifier: string): OCIFeatureRef {
+export function getFeatureRef(output: Log, resourceAndVersion: string): OCIFeatureRef {
 
     // ex: ghcr.io/codspace/features/ruby:1
-    const splitOnColon = identifier.split(':');
-    const id = splitOnColon[0];
+    const splitOnColon = resourceAndVersion.split(':');
+    const resource = splitOnColon[0];
     const version = splitOnColon[1] ? splitOnColon[1] : 'latest';
 
-    const splitOnSlash = id.split('/');
-    const featureName = splitOnSlash[splitOnSlash.length - 1];
+    const splitOnSlash = resource.split('/');
+
+    const id = splitOnSlash[splitOnSlash.length - 1]; // Aka 'featureName' - Eg: 'ruby'
     const owner = splitOnSlash[1];
     const registry = splitOnSlash[0];
     const namespace = splitOnSlash.slice(1, -1).join('/');
 
-    output.write(`identifier: ${identifier}`, LogLevel.Trace);
+    output.write(`resource: ${resource}`, LogLevel.Trace);
     output.write(`id: ${id}`, LogLevel.Trace);
     output.write(`version: ${version}`, LogLevel.Trace);
-    output.write(`featureName: ${featureName}`, LogLevel.Trace);
     output.write(`owner: ${owner}`, LogLevel.Trace);
     output.write(`namespace: ${namespace}`, LogLevel.Trace);
     output.write(`registry: ${registry}`, LogLevel.Trace);
@@ -84,10 +84,10 @@ export function getFeatureRef(output: Log, identifier: string): OCIFeatureRef {
     return {
         id,
         version,
-        featureName,
         owner,
         namespace,
-        registry
+        registry,
+        resource,
     };
 }
 
@@ -109,9 +109,14 @@ export async function fetchOCIFeatureManifestIfExists(output: Log, env: NodeJS.P
         reference = manifestDigest;
     }
 
-    const manifestUrl = `https://${featureRef.registry}/v2/${featureRef.namespace}/${featureRef.featureName}/manifests/${reference}`;
+    const manifestUrl = `https://${featureRef.registry}/v2/${featureRef.namespace}/${featureRef.id}/manifests/${reference}`;
     output.write(`manifest url: ${manifestUrl}`, LogLevel.Trace);
     const manifest = await getFeatureManifest(output, env, manifestUrl, featureRef, authToken);
+
+    if (!manifest) {
+        output.write('OCI manifest not found', LogLevel.Warning);
+        return;
+    }
 
     if (manifest?.config.mediaType !== 'application/vnd.devcontainers') {
         output.write(`(!) Unexpected manifest media type: ${manifest?.config.mediaType}`, LogLevel.Error);
@@ -132,14 +137,13 @@ export async function fetchOCIFeature(output: Log, env: NodeJS.ProcessEnv, featu
 
     const { featureRef }  = featureSet.sourceInformation; 
 
-    const blobUrl = `https://${featureSet.sourceInformation.featureRef.registry}/v2/${featureSet.sourceInformation.featureRef.namespace}/${featureSet.sourceInformation.featureRef.featureName}/blobs/${featureSet.sourceInformation.manifest?.layers[0].digest}`;
+    const blobUrl = `https://${featureSet.sourceInformation.featureRef.registry}/v2/${featureSet.sourceInformation.featureRef.namespace}/${featureSet.sourceInformation.featureRef.id}/blobs/${featureSet.sourceInformation.manifest?.layers[0].digest}`;
     output.write(`blob url: ${blobUrl}`, LogLevel.Trace);
 
     const success = await getFeatureBlob(output, env, blobUrl, ociCacheDir, featCachePath, featureRef);
 
     if (!success) {
-        output.write(`Failed to download package for ${featureSet.sourceInformation.featureRef.featureName}`, LogLevel.Error);
-        throw new Error(`Failed to download package for ${featureSet.sourceInformation.featureRef.featureName}`);
+        throw new Error(`Failed to download package for ${featureSet.sourceInformation.featureRef.resource}`);
     }
 
     return true;
@@ -152,7 +156,7 @@ export async function getFeatureManifest(output: Log, env: NodeJS.ProcessEnv, ur
             'accept': 'application/vnd.oci.image.manifest.v1+json',
         };
 
-        const auth = authToken ?? await fetchRegistryAuthToken(output, featureRef.registry, featureRef.id, env, 'pull');
+        const auth = authToken ?? await fetchRegistryAuthToken(output, featureRef.registry, featureRef.resource, env, 'pull');
         if (auth) {
             headers['authorization'] = `Bearer ${auth}`;
         }
@@ -185,7 +189,7 @@ export async function getFeatureBlob(output: Log, env: NodeJS.ProcessEnv, url: s
             'accept': 'application/vnd.oci.image.manifest.v1+json',
         };
 
-        const auth = authToken ?? await fetchRegistryAuthToken(output, featureRef.registry, featureRef.id, env, 'pull');
+        const auth = authToken ?? await fetchRegistryAuthToken(output, featureRef.registry, featureRef.resource, env, 'pull');
         if (auth) {
             headers['authorization'] = `Bearer ${auth}`;
         }
@@ -215,7 +219,7 @@ export async function getFeatureBlob(output: Log, env: NodeJS.ProcessEnv, url: s
 }
 
 // https://github.com/oras-project/oras-go/blob/97a9c43c52f9d89ecf5475bc59bd1f96c8cc61f6/registry/remote/auth/scope.go#L60-L74
-export async function fetchRegistryAuthToken(output: Log, registry: string, id: string, env: NodeJS.ProcessEnv, operationScopes: string): Promise<string | undefined> {
+export async function fetchRegistryAuthToken(output: Log, registry: string, resource: string, env: NodeJS.ProcessEnv, operationScopes: string): Promise<string | undefined> {
     const headers: HEADERS = {
         'user-agent': 'devcontainer'
     };
@@ -241,7 +245,7 @@ export async function fetchRegistryAuthToken(output: Log, registry: string, id: 
         headers['authorization'] = `Basic ${base64Encoded}`;
     }
 
-    const url = `https://${registry}/token?scope=repo:${id}:${operationScopes}&service=${registry}`;
+    const url = `https://${registry}/token?scope=repo:${resource}:${operationScopes}&service=${registry}`;
 
     const options = {
         type: 'GET',

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -10,7 +10,7 @@ import * as tar from 'tar';
 import { DevContainerConfig } from '../spec-configuration/configuration';
 import { dockerCLI, dockerPtyCLI, ImageDetails, toExecParameters, toPtyExecParameters } from '../spec-shutdown/dockerUtils';
 import { LogLevel, makeLog, toErrorText } from '../spec-utils/log';
-import { FeaturesConfig, getContainerFeaturesFolder, getContainerFeaturesBaseDockerFile, getFeatureLayers, getFeatureMainValue, getFeatureValueObject, generateFeaturesConfig, getSourceInfoString, collapseFeaturesConfig, Feature, multiStageBuildExploration } from '../spec-configuration/containerFeaturesConfiguration';
+import { FeaturesConfig, getContainerFeaturesFolder, getContainerFeaturesBaseDockerFile, getFeatureLayers, getFeatureMainValue, getFeatureValueObject, generateFeaturesConfig, getSourceInfoString, collapseFeaturesConfig, Feature, multiStageBuildExploration, V1_DEVCONTAINER_FEATURES_FILE_NAME } from '../spec-configuration/containerFeaturesConfiguration';
 import { readLocalFile } from '../spec-utils/pfs';
 import { includeAllConfiguredFeatures } from '../spec-utils/product';
 import { createFeaturesTempFolder, DockerResolverParameters, getCacheFolder, getFolderImageName, inspectDockerImage } from './utils';
@@ -143,7 +143,7 @@ async function createLocalFeatures(params: DockerResolverParameters, dstFolder: 
 	await cliHost.mkdirp(`${dstFolder}/${localCacheBuildFolderName}`);
 	const create = tar.c({
 		cwd: srcFolder,
-		filter: path => (path !== './Dockerfile' && path !== './devcontainer-features.json'),
+		filter: path => (path !== './Dockerfile' && path !== `./${V1_DEVCONTAINER_FEATURES_FILE_NAME}`),
 	}, ['.']);
 	const createExit = new Promise((resolve, reject) => {
 		create.on('error', reject);

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -132,7 +132,7 @@ describe('Dev Containers CLI', function () {
 					assert.equal(error.error.code, 1, 'Should fail with exit code 1');
 					const res = JSON.parse(error.stdout);
 					assert.equal(res.outcome, 'error');
-					assert.match(res.message, /'Failed to fetch tarball'/);
+					assert.match(res.message.replace('\n', ''), /'.*Failed to fetch tarball.*'/);
 				}
 				assert.equal(success, false, 'expect non-successful call');
 			});
@@ -147,7 +147,7 @@ describe('Dev Containers CLI', function () {
 					assert.equal(error.error.code, 1, 'Should fail with exit code 1');
 					const res = JSON.parse(error.stdout);
 					assert.equal(res.outcome, 'error');
-					assert.match(res.message, /'Failed to process feature'/);
+					assert.match(res.message.replace('\n', ''), /'.*Failed to process feature.*'/);
 				}
 				assert.equal(success, false, 'expect non-successful call');
 			});
@@ -501,7 +501,7 @@ describe('Dev Containers CLI', function () {
 				const testFolder = `${__dirname}/configs/dockerfile-with-v2-oci-features`;
 				beforeEach(async () => containerId = (await devContainerUp(testFolder, options)).containerId);
 				afterEach(async () => await devContainerDown({ containerId }));
-				it('should detect ruby installed', async () => {
+				it('should detect docker installed (--privileged flag passed)', async () => {
 					// NOTE: Doing a docker ps will ensure that the --privileged flag was set by the feature
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker ps`);
 					const response = JSON.parse(res.stdout);

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -132,7 +132,7 @@ describe('Dev Containers CLI', function () {
 					assert.equal(error.error.code, 1, 'Should fail with exit code 1');
 					const res = JSON.parse(error.stdout);
 					assert.equal(res.outcome, 'error');
-					assert.match(res.message.replace('\n', ''), /'.*Failed to fetch tarball.*'/);
+					assert.ok(res.message.indexOf('Failed to fetch tarball') > -1, `Actual error msg:  ${res.message}`);
 				}
 				assert.equal(success, false, 'expect non-successful call');
 			});
@@ -147,7 +147,7 @@ describe('Dev Containers CLI', function () {
 					assert.equal(error.error.code, 1, 'Should fail with exit code 1');
 					const res = JSON.parse(error.stdout);
 					assert.equal(res.outcome, 'error');
-					assert.match(res.message.replace('\n', ''), /'.*Failed to process feature.*'/);
+					assert.ok(res.message.indexOf('Failed to process feature') > -1, `Actual error msg:  ${res.message}`);
 				}
 				assert.equal(success, false, 'expect non-successful call');
 			});

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -132,7 +132,7 @@ describe('Dev Containers CLI', function () {
 					assert.equal(error.error.code, 1, 'Should fail with exit code 1');
 					const res = JSON.parse(error.stdout);
 					assert.equal(res.outcome, 'error');
-					assert.match(res.message, /'Failed to fetch tarball for myfakefeature_1_github-repo after attempting 2 possibilities.'/);
+					assert.match(res.message, /'Failed to fetch tarball'/);
 				}
 				assert.equal(success, false, 'expect non-successful call');
 			});
@@ -147,7 +147,7 @@ describe('Dev Containers CLI', function () {
 					assert.equal(error.error.code, 1, 'Should fail with exit code 1');
 					const res = JSON.parse(error.stdout);
 					assert.equal(res.outcome, 'error');
-					assert.match(res.message, /'Failed to process feature ghcr.io\/devcontainers\/features\/myfakefeature:1'/);
+					assert.match(res.message, /'Failed to process feature'/);
 				}
 				assert.equal(success, false, 'expect non-successful call');
 			});
@@ -466,11 +466,12 @@ describe('Dev Containers CLI', function () {
 				beforeEach(async () => containerId = (await devContainerUp(testFolder, options)).containerId);
 				afterEach(async () => await devContainerDown({ containerId }));
 				it('should have access to installed features (docker)', async () => {
-					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker --version`);
+					// NOTE: Doing a docker ps will ensure that the --privileged flag was set by the feature
+					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker ps`);
 					const response = JSON.parse(res.stdout);
 					console.log(res.stderr);
 					assert.equal(response.outcome, 'success');
-					assert.match(res.stderr, /Docker version/);
+					assert.match(res.stderr, /CONTAINER ID/);
 				});
 				it('should have access to installed features (hello)', async () => {
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} hello`);
@@ -495,17 +496,18 @@ describe('Dev Containers CLI', function () {
 				});
 			});
 
-			describe(`with valid (Dockerfile) config and v2 OCI feature (ruby) [${text}]`, () => {
+			describe(`with valid (Dockerfile) config and v2 OCI feature (dind) [${text}]`, () => {
 				let containerId: string | null = null;
 				const testFolder = `${__dirname}/configs/dockerfile-with-v2-oci-features`;
 				beforeEach(async () => containerId = (await devContainerUp(testFolder, options)).containerId);
 				afterEach(async () => await devContainerDown({ containerId }));
-				it('should have build marker content', async () => {
-					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} ruby --version`);
+				it('should detect ruby installed', async () => {
+					// NOTE: Doing a docker ps will ensure that the --privileged flag was set by the feature
+					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker ps`);
 					const response = JSON.parse(res.stdout);
 					console.log(res.stderr);
 					assert.equal(response.outcome, 'success');
-					assert.match(res.stderr, /ruby.*/);
+					assert.match(res.stderr, /CONTAINER ID/);
 				});
 			});
 
@@ -515,11 +517,12 @@ describe('Dev Containers CLI', function () {
 				beforeEach(async () => composeProjectName = (await devContainerUp(testFolder, options)).composeProjectName);
 				afterEach(async () => await devContainerDown({ composeProjectName }));
 				it('should have access to installed features (docker)', async () => {
-					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker --version`);
+					// NOTE: Doing a docker ps will ensure that the --privileged flag was set by the feature
+					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} docker ps`);
 					const response = JSON.parse(res.stdout);
 					console.log(res.stderr);
 					assert.equal(response.outcome, 'success');
-					assert.match(res.stderr, /Docker version/);
+					assert.match(res.stderr, /CONTAINER ID/);
 				});
 				it('should have access to installed features (hello)', async () => {
 					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} hello`);

--- a/src/test/configs/dockerfile-with-v2-oci-features/.devcontainer.json
+++ b/src/test/configs/dockerfile-with-v2-oci-features/.devcontainer.json
@@ -7,6 +7,6 @@
 	},
 	"features": {
 		"github-cli": "latest",
-		"ghcr.io/codspace/features/ruby:1": {}
+		"ghcr.io/codspace/features/docker-in-docker:1": {}
 	}
 }

--- a/src/test/configs/dockerfile-with-v2-oci-features/.devcontainer.json
+++ b/src/test/configs/dockerfile-with-v2-oci-features/.devcontainer.json
@@ -1,0 +1,12 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "16-bullseye"
+		}
+	},
+	"features": {
+		"github-cli": "latest",
+		"ghcr.io/codspace/features/ruby:1": {}
+	}
+}

--- a/src/test/configs/dockerfile-with-v2-oci-features/Dockerfile
+++ b/src/test/configs/dockerfile-with-v2-oci-features/Dockerfile
@@ -1,0 +1,4 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License. See License.txt in the project root for license information.
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/src/test/configs/invalid-configs/invalid-v1-features/.devcontainer.json
+++ b/src/test/configs/invalid-configs/invalid-v1-features/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "ubuntu",
+    "features": {
+        "devcontainers/features/myfakefeature": "latest"
+    }
+}

--- a/src/test/configs/invalid-configs/invalid-v2-features/.devcontainer.json
+++ b/src/test/configs/invalid-configs/invalid-v2-features/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "image": "ubuntu",
+    "features": {
+        "ghcr.io/devcontainers/features/myfakefeature:1": "latest"
+    }
+}

--- a/src/test/container-features/containerFeaturesOCI.offline.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.offline.test.ts
@@ -10,11 +10,11 @@ describe('Test OCI Pull', () => {
         const feat = getFeatureRef(output, 'ghcr.io/codspace/features/ruby:1');
         output.write(`feat: ${JSON.stringify(feat)}`);
 
-        assert.equal(feat.id, 'ghcr.io/codspace/features/ruby');
-        assert.equal(feat.featureName, 'ruby');
-        assert.equal(feat.owner, 'codspace');
+        assert.equal(feat.id, 'ruby');
         assert.equal(feat.namespace, 'codspace/features');
+        assert.equal(feat.owner, 'codspace');
         assert.equal(feat.registry, 'ghcr.io');
+        assert.equal(feat.resource, 'ghcr.io/codspace/features/ruby');
         assert.equal(feat.version, '1');
     });
 


### PR DESCRIPTION
Fixes a regression in `github-repo` features following the 'v1' pattern. A previous patch (https://github.com/devcontainers/cli/commit/0c22d279529fe88960a761ae1e6997df0d3462e8) only covered the `local-features` case. This aims to make the patch more generic.

This regression was missed in automated unit testing because parse errors in features were previously not a fatal error.  This PR makes failing to parse a feature fatal to the entire image build.  