### PR TITLE
Create home folder if it doesn't exist during updateUID

### DIFF
--- a/scripts/updateUID.Dockerfile
+++ b/scripts/updateUID.Dockerfile
@@ -26,6 +26,9 @@ RUN eval $(sed -n "s/${REMOTE_USER}:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/
 		if [ "$OLD_GID" != "$NEW_GID" ]; then \
 			sed -i -e "s/\([^:]*:[^:]*:\)${OLD_GID}:/\1${NEW_GID}:/" /etc/group; \
 		fi; \
+		if [ ! -d "$HOME_FOLDER" ]; then \
+			mkhomedir_helper ${REMOTE_USER}; \
+		fi; \
 		chown -R $NEW_UID:$NEW_GID $HOME_FOLDER; \
 	fi;
 


### PR DESCRIPTION
Fixes #109.

We could either skip chowning or create the home folder.
I find the latter to be more useful because otherwise vscode will complain it can't create stuff in the non-existing home folder.