### PR TITLE
Print version and install location at the end of `--help`

### DIFF
--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -31,6 +31,8 @@ const defaultDefaultUserEnvProbe: UserEnvProbe = 'loginInteractiveShell';
 
 (async () => {
 
+	const packageFolder = path.join(__dirname, '..', '..');
+	const version = (await getPackageConfig(packageFolder)).version;
 	const argv = process.argv.slice(2);
 	const restArgs = argv[0] === 'exec' && argv[1] !== '--help'; // halt-at-non-option doesn't work in subcommands: https://github.com/yargs/yargs/issues/1417
 	const y = yargs([])
@@ -41,7 +43,7 @@ const defaultDefaultUserEnvProbe: UserEnvProbe = 'loginInteractiveShell';
 			'halt-at-non-option': restArgs,
 		})
 		.scriptName('devcontainer')
-		.version((await getPackageConfig(path.join(__dirname, '..', '..'))).version)
+		.version(version)
 		.demandCommand()
 		.strict();
 	y.wrap(Math.min(120, y.terminalWidth()));
@@ -54,6 +56,7 @@ const defaultDefaultUserEnvProbe: UserEnvProbe = 'loginInteractiveShell';
 		y.command('package <target>', 'Package features', featuresPackageOptions, featuresPackageHandler);
 	});
 	y.command(restArgs ? ['exec', '*'] : ['exec <cmd> [args..]'], 'Execute a command on a running dev container', execOptions, execHandler);
+	y.epilog(`devcontainer@${version} ${packageFolder}`);
 	y.parse(restArgs ? argv.slice(1) : argv);
 
 })().catch(console.error);
@@ -335,8 +338,8 @@ async function doBuild({
 		}
 		const { config } = configs;
 		let imageNameResult: string[] = [''];
-		
-		// Support multiple use of `--image-name` 
+
+		// Support multiple use of `--image-name`
 		const imageNames = (argImageName && (Array.isArray(argImageName) ? argImageName : [argImageName]) as string[]) || undefined;
 
 		if (isDockerFileConfig(config)) {


### PR DESCRIPTION
Fixes #114

This uses an epilogue inspired by `npm --help`.

With this proposed change, when executed after being globally installed, `devcontainer --help` will print something like:
```
devcontainer <command>

Commands:
  devcontainer up                   Create and run dev container
  devcontainer build [path]         Build a dev container image
  devcontainer run-user-commands    Run user commands
  devcontainer read-configuration   Read configuration
  devcontainer features             Features commands
  devcontainer exec <cmd> [args..]  Execute a command on a running dev container

Options:
  --help     Show help                                                                                         [boolean]
  --version  Show version number                                                                               [boolean]

devcontainer@0.9.1 /usr/local/lib/node_modules/@devcontainers/cli
```