### PR TITLE
`devcontainer features info <..>` command

### DIFF
--- a/src/spec-configuration/containerFeaturesOCI.ts
+++ b/src/spec-configuration/containerFeaturesOCI.ts
@@ -305,7 +305,7 @@ export async function fetchRegistryAuthToken(output: Log, registry: string, ociR
 
 // Lists published versions/tags of a feature 
 // Specification: https://github.com/opencontainers/distribution-spec/blob/v1.0.1/spec.md#content-discovery
-export async function getPublishedVersions(featureRef: OCIFeatureRef, output: Log, filteredAndSorted: boolean = false): Promise<string[] | undefined> {
+export async function getPublishedVersions(featureRef: OCIFeatureRef, output: Log, sorted: boolean = false): Promise<string[] | undefined> {
 	try {
 		const url = `https://${featureRef.registry}/v2/${featureRef.namespace}/${featureRef.id}/tags/list`;
 
@@ -331,7 +331,7 @@ export async function getPublishedVersions(featureRef: OCIFeatureRef, output: Lo
 		const response = await request(options);
 		const publishedVersionsResponse: OCITagList = JSON.parse(response.toString());
 
-		if (!filteredAndSorted) {
+		if (!sorted) {
 			return publishedVersionsResponse.tags;
 		}
 

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -27,6 +27,7 @@ import { generateFeaturesConfig, getContainerFeaturesFolder } from '../spec-conf
 import { featuresTestOptions, featuresTestHandler } from './featuresCLI/test';
 import { featuresPackageHandler, featuresPackageOptions } from './featuresCLI/package';
 import { featuresPublishHandler, featuresPublishOptions } from './featuresCLI/publish';
+import { featuresInfoHandler, featuresInfoOptions } from './featuresCLI/info';
 
 const defaultDefaultUserEnvProbe: UserEnvProbe = 'loginInteractiveShell';
 
@@ -56,6 +57,7 @@ const defaultDefaultUserEnvProbe: UserEnvProbe = 'loginInteractiveShell';
 		y.command('test', 'Test features', featuresTestOptions, featuresTestHandler);
 		y.command('package <target>', 'Package features', featuresPackageOptions, featuresPackageHandler);
 		y.command('publish <target>', 'Package and publish features', featuresPublishOptions, featuresPublishHandler);
+		y.command('info <featureId>', 'Fetch info on a feature', featuresInfoOptions, featuresInfoHandler);
 	});
 	y.command(restArgs ? ['exec', '*'] : ['exec <cmd> [args..]'], 'Execute a command on a running dev container', execOptions, execHandler);
 	y.epilog(`devcontainer@${version} ${packageFolder}`);

--- a/src/spec-node/featuresCLI/info.ts
+++ b/src/spec-node/featuresCLI/info.ts
@@ -43,7 +43,7 @@ async function featuresInfo({
 
 	const featureOciRef = getFeatureRef(output, featureId);
 
-	const publishedVersions = await getPublishedVersions(featureOciRef, output);
+	const publishedVersions = await getPublishedVersions(featureOciRef, output, true);
 	if (!publishedVersions || publishedVersions.length === 0) {
 		if (outputFormat === 'json') {
 			output.raw(JSON.stringify({}), LogLevel.Info);

--- a/src/spec-node/featuresCLI/info.ts
+++ b/src/spec-node/featuresCLI/info.ts
@@ -1,0 +1,64 @@
+import path from 'path';
+import { Argv } from 'yargs';
+import { CLIHost } from '../../spec-common/cliHost';
+import { getFeatureRef, getPublishedVersions } from '../../spec-configuration/containerFeaturesOCI';
+import { LogLevel, mapLogLevel } from '../../spec-utils/log';
+import { createLog } from '../devContainers';
+import { UnpackArgv } from '../devContainersSpecCLI';
+import { getPackageConfig } from '../utils';
+
+export function featuresInfoOptions(y: Argv) {
+	return y
+		.options({
+			'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
+		})
+		.positional('featureId', { type: 'string', demandOption: true, description: 'Feature Id' })
+		.check(_argv => {
+			return true;
+		});
+}
+
+export type FeaturesInfoArgs = UnpackArgv<ReturnType<typeof featuresInfoOptions>>;
+export interface FeaturesInfoCommandInput {
+	cliHost: CLIHost;
+	featureId: string;
+}
+
+export function featuresInfoHandler(args: FeaturesInfoArgs) {
+	(async () => await featuresInfo(args))().catch(console.error);
+}
+
+async function featuresInfo({
+	'featureId': featureId,
+	'log-level': inputLogLevel,
+}: FeaturesInfoArgs) {
+	const disposables: (() => Promise<unknown> | undefined)[] = [];
+	const dispose = async () => {
+		await Promise.all(disposables.map(d => d()));
+	};
+
+	const extensionPath = path.join(__dirname, '..', '..', '..');
+	const pkg = await getPackageConfig(extensionPath);
+
+	const output = createLog({
+		logLevel: mapLogLevel(inputLogLevel),
+		logFormat: 'text',
+		log: (str) => process.stdout.write(str),
+		terminalDimensions: undefined,
+	}, pkg, new Date(), disposables);
+
+	const featureOciRef = getFeatureRef(output, featureId);
+
+	const publishedVersions = await getPublishedVersions(featureOciRef, output);
+
+	if (!publishedVersions) {
+		output.write(`No published versions found for feature ${featureId}`, LogLevel.Error);
+		process.exit(1);
+	}
+
+	output.write(`Published versions: ${publishedVersions.join(', ')}`, LogLevel.Info);
+
+
+	await dispose();
+	process.exit(0);
+}


### PR DESCRIPTION
A simple command that uses the local OCI implementation to fetch information on a dev container feature published to an OCI repository.

Today, this command returns all published tags for a given `featureId`.  The output can either be human-formatted (Default), or JSON.

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/23246594/186025530-c2cbc084-4ea9-41c6-9d3f-b8ac87b3dae1.png">
