### PR TITLE
use preferred syntax for docker-in-docker feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
 	"remoteUser": "node",
 	
 	"features": {
-		"docker-in-docker": "latest"
+		"ghcr.io/devcontainers/features/docker-in-docker:1": {}
 	},
 	
 	"customizations": {


### PR DESCRIPTION
We prefer using the full OCI reference to the major version of the feature, over the older style syntax (that we are phasing out).