### PR TITLE
Properly source feature options

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -244,7 +244,7 @@ export function getFeatureLayers(featuresConfig: FeaturesConfig) {
 			result += `
 				
 RUN cd /tmp/build-features/${feature.consecutiveId} \\
-&& export $(cat devcontainer-features.env | xargs) \\
+&& . ./devcontainer-features.env \\
 && chmod +x ./install.sh \\
 && ./install.sh
 

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -244,7 +244,9 @@ export function getFeatureLayers(featuresConfig: FeaturesConfig) {
 			result += `
 				
 RUN cd /tmp/build-features/${feature.consecutiveId} \\
+&& set -a \\
 && . ./devcontainer-features.env \\
+&& set +a \\
 && chmod +x ./install.sh \\
 && ./install.sh
 

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -346,10 +346,10 @@ function getFeatureEnvVariables(f: Feature) {
 	} else {
 		if (values) {
 			variables.push(...Object.keys(values)
-				.map(name => `${getSafeId(name)}="${values[name]}"`));
+				.map(name => `export ${getSafeId(name)}="${values[name]}"`));
 		}
 		if (f.buildArg) {
-			variables.push(`${f.buildArg}=${getFeatureMainValue(f)}`);
+			variables.push(`export ${f.buildArg}=${getFeatureMainValue(f)}`);
 		}
 		return variables;
 	}	

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -346,10 +346,10 @@ function getFeatureEnvVariables(f: Feature) {
 	} else {
 		if (values) {
 			variables.push(...Object.keys(values)
-				.map(name => `export ${getSafeId(name)}="${values[name]}"`));
+				.map(name => `${getSafeId(name)}="${values[name]}"`));
 		}
 		if (f.buildArg) {
-			variables.push(`export ${f.buildArg}=${getFeatureMainValue(f)}`);
+			variables.push(`${f.buildArg}=${getFeatureMainValue(f)}`);
 		}
 		return variables;
 	}	

--- a/src/test/container-features/configs/dockerfile-with-v2-local-features-no-dev-container-folder/.devcontainer.json
+++ b/src/test/container-features/configs/dockerfile-with-v2-local-features-no-dev-container-folder/.devcontainer.json
@@ -4,7 +4,8 @@
 	},
 	"features": {
 		"./local-features/localFeatureA": {
-			"greeting": "Hello there"
+			"greeting": "Hello there",
+			"punctuation": "!!!!"
 		},
 		"./local-features/localFeatureB": {
 			"favorite": "gold"

--- a/src/test/container-features/configs/dockerfile-with-v2-local-features-no-dev-container-folder/.devcontainer.json
+++ b/src/test/container-features/configs/dockerfile-with-v2-local-features-no-dev-container-folder/.devcontainer.json
@@ -4,7 +4,7 @@
 	},
 	"features": {
 		"./local-features/localFeatureA": {
-			"greeting": "buongiorno"
+			"greeting": "Hello there"
 		},
 		"./local-features/localFeatureB": {
 			"favorite": "gold"

--- a/src/test/container-features/configs/dockerfile-with-v2-local-features-no-dev-container-folder/local-features/localFeatureA/install.sh
+++ b/src/test/container-features/configs/dockerfile-with-v2-local-features-no-dev-container-folder/local-features/localFeatureA/install.sh
@@ -3,6 +3,7 @@
 echo "Activating feature 'localFeatureA'"
 
 GREETING=${GREETING:-undefined}
+PUNCTUATION=${PUNCTUATION:-?????}
 echo "The provided greeting is: $GREETING"
 
 tee /usr/hello.sh > /dev/null \
@@ -10,7 +11,7 @@ tee /usr/hello.sh > /dev/null \
 #!/bin/bash
 RED='\033[0;91m'
 NC='\033[0m' # No Color
-echo -e -n "\${RED}${GREETING}, \$(whoami)!"
+echo -e -n "\${RED}${GREETING}, \$(whoami)${PUNCTUATION}"
 echo -e -n "\${NC}"
 EOF
 

--- a/src/test/container-features/configs/dockerfile-with-v2-local-features-with-dev-container-folder/.devcontainer/devcontainer.json
+++ b/src/test/container-features/configs/dockerfile-with-v2-local-features-with-dev-container-folder/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	},
 	"features": {
 		"./local-features/localFeatureA": {
-			"greeting": "Hello there"
+			"greeting": "Hello there",
+			"punctuation": "!!!!"
 		},
 		"./local-features/localFeatureB": {
 			"favorite": "gold"

--- a/src/test/container-features/configs/dockerfile-with-v2-local-features-with-dev-container-folder/.devcontainer/devcontainer.json
+++ b/src/test/container-features/configs/dockerfile-with-v2-local-features-with-dev-container-folder/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	},
 	"features": {
 		"./local-features/localFeatureA": {
-			"greeting": "buongiorno"
+			"greeting": "Hello there"
 		},
 		"./local-features/localFeatureB": {
 			"favorite": "gold"

--- a/src/test/container-features/configs/dockerfile-with-v2-local-features-with-dev-container-folder/local-features/localFeatureA/install.sh
+++ b/src/test/container-features/configs/dockerfile-with-v2-local-features-with-dev-container-folder/local-features/localFeatureA/install.sh
@@ -3,6 +3,7 @@
 echo "Activating feature 'localFeatureA'"
 
 GREETING=${GREETING:-undefined}
+PUNCTUATION=${PUNCTUATION:-?????}
 echo "The provided greeting is: $GREETING"
 
 tee /usr/hello.sh > /dev/null \
@@ -10,7 +11,7 @@ tee /usr/hello.sh > /dev/null \
 #!/bin/bash
 RED='\033[0;91m'
 NC='\033[0m' # No Color
-echo -e -n "\${RED}${GREETING}, \$(whoami)!"
+echo -e -n "\${RED}${GREETING}, \$(whoami)${PUNCTUATION}"
 echo -e -n "\${NC}"
 EOF
 

--- a/src/test/container-features/e2e.test.ts
+++ b/src/test/container-features/e2e.test.ts
@@ -171,7 +171,7 @@ describe('Dev Container Features E2E (local-path)', function () {
             const response = JSON.parse(res.stdout);
             console.log(res.stderr);
             assert.equal(response.outcome, 'success');
-            assert.match(res.stderr, /Hello there, root!/);
+            assert.match(res.stderr, /Hello there, root!!!!/);
         });
 
         it('should read configuration with features', async () => {
@@ -201,7 +201,7 @@ describe('Dev Container Features E2E (local-path)', function () {
             const response = JSON.parse(res.stdout);
             console.log(res.stderr);
             assert.equal(response.outcome, 'success');
-            assert.match(res.stderr, /Hello there, root!/);
+            assert.match(res.stderr, /Hello there, root!!!!/);
         });
 
         it('should read configuration with features with customizations', async () => {

--- a/src/test/container-features/e2e.test.ts
+++ b/src/test/container-features/e2e.test.ts
@@ -171,7 +171,7 @@ describe('Dev Container Features E2E (local-path)', function () {
             const response = JSON.parse(res.stdout);
             console.log(res.stderr);
             assert.equal(response.outcome, 'success');
-            assert.match(res.stderr, /buongiorno, root!/);
+            assert.match(res.stderr, /Hello there, root!/);
         });
 
         it('should read configuration with features', async () => {
@@ -201,7 +201,7 @@ describe('Dev Container Features E2E (local-path)', function () {
             const response = JSON.parse(res.stdout);
             console.log(res.stderr);
             assert.equal(response.outcome, 'success');
-            assert.match(res.stderr, /buongiorno, root!/);
+            assert.match(res.stderr, /Hello there, root!/);
         });
 
         it('should read configuration with features with customizations', async () => {


### PR DESCRIPTION
Fixes https://github.com/devcontainers/cli/issues/148

Instead of trying to use `xargs` to parse the .env file, directly source the .env file with `set -a` enabled.

```
-a
When this option is on, the export attribute shall be set for each variable to which an assignment is performed;

```

In the generated Dockerfile, this env file is simply sources with the `.` operator (The most portable/POSIX-y way to source https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#dot) 