### PR TITLE
Adds warning logs for the auto-mapped features

### DIFF
--- a/src/test/container-features/featureHelpers.test.ts
+++ b/src/test/container-features/featureHelpers.test.ts
@@ -384,13 +384,13 @@ describe('validate function getBackwardCompatibleFeatureId', () => {
     it('should map the migrated (old shorthand syntax) features to ghcr.io/devcontainers/features/*', () => {
         let id = 'node';
         let expectedId = 'ghcr.io/devcontainers/features/node:1';
-		let mappedId = getBackwardCompatibleFeatureId(id);
+		let mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
 
         id = 'python';
         expectedId = 'ghcr.io/devcontainers/features/python:1';
-		mappedId = getBackwardCompatibleFeatureId(id);
+		mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
     });
@@ -398,13 +398,13 @@ describe('validate function getBackwardCompatibleFeatureId', () => {
     it('should map the renamed (old shorthand syntax) features to ghcr.io/devcontainers/features/*', () => {
         let id = 'golang';
         let expectedId = 'ghcr.io/devcontainers/features/go:1';
-		let mappedId = getBackwardCompatibleFeatureId(id);
+		let mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
 
         id = 'common';
         expectedId = 'ghcr.io/devcontainers/features/common-utils:1';
-		mappedId = getBackwardCompatibleFeatureId(id);
+		mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
     });
@@ -412,13 +412,13 @@ describe('validate function getBackwardCompatibleFeatureId', () => {
     it('should keep the deprecated (old shorthand syntax) features id intact', () => {
         let id = 'fish';
         let expectedId = 'fish';
-		let mappedId = getBackwardCompatibleFeatureId(id);
+		let mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
 
         id = 'maven';
         expectedId = 'maven';
-		mappedId = getBackwardCompatibleFeatureId(id);
+		mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
     });
@@ -426,19 +426,19 @@ describe('validate function getBackwardCompatibleFeatureId', () => {
     it('should keep all other features id intact', () => {
         let id = 'ghcr.io/devcontainers/features/node:1';
         let expectedId = id;
-		let mappedId = getBackwardCompatibleFeatureId(id);
+		let mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
 
         id = 'ghcr.io/user/repo/go:1';
         expectedId = id;
-		mappedId = getBackwardCompatibleFeatureId(id);
+		mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
 
         id = 'ghcr.io/user/repo/go';
         expectedId = id;
-		mappedId = getBackwardCompatibleFeatureId(id);
+		mappedId = getBackwardCompatibleFeatureId(output, id);
 
         assert.strictEqual(mappedId, expectedId);
     });


### PR DESCRIPTION
As the auto-mapping feature is now released in Remote Containers, Codespaces and VS Code as part of the [cutover of Features](https://github.com/microsoft/vscode-dev-containers/issues/1589#issuecomment-1224325477). Adding warning logs for the (old shorthand syntax) Features which existed in [microsoft/vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers)

Sample logs - 
![image](https://user-images.githubusercontent.com/24955913/188983771-6a8cb2d3-ab39-4b4d-a1ef-7c0753c324ef.png)
