### PR TITLE
Fix typo in 'installsAfter'

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -40,7 +40,6 @@ export interface Feature {
 	capAdd?: string[];
 	securityOpt?: string[];
 	entrypoint?: string;
-	installAfter?: string[];
 	include?: string[];
 	exclude?: string[];
 	value: boolean | string | Record<string, boolean | string | undefined>; // set programmatically

--- a/src/spec-configuration/containerFeaturesOrder.ts
+++ b/src/spec-configuration/containerFeaturesOrder.ts
@@ -53,7 +53,7 @@ export function computeInstallationOrder(features: FeatureSet[]) {
 
     const nodes = [...nodesById.values()];
     for (const later of nodes) {
-        for (const firstId of later.feature.features[0].installAfter || []) {
+        for (const firstId of later.feature.features[0].installsAfter || []) {
             const first = nodesById.get(firstId);
             // soft dependencies
             if (first) {

--- a/src/test/container-features/containerFeaturesOrder.test.ts
+++ b/src/test/container-features/containerFeaturesOrder.test.ts
@@ -122,7 +122,7 @@ describe('Container features install order', function () {
         }, { message: 'Feature node not found' });
     });
 
-    function installAfter(id: string, ...installAfter: string[]): FeatureSet {
+    function installAfter(id: string, ...installsAfter: string[]): FeatureSet {
         return {
             sourceInformation: {
                 type: 'local-cache',
@@ -131,7 +131,7 @@ describe('Container features install order', function () {
             features: [{
                 id,
                 name: id,
-                installAfter,
+                installsAfter,
                 value: true,
                 included: true,
             }],


### PR DESCRIPTION
This PR fixes the bug reported here:

https://github.com/devcontainers/cli/issues/163

It was just a simple typo.