### PR TITLE
Support running lifecycle scripts in parallel

### DIFF
--- a/src/test/configs/dockerfile-with-parallel-commands/.devcontainer.json
+++ b/src/test/configs/dockerfile-with-parallel-commands/.devcontainer.json
@@ -6,15 +6,15 @@
 		}
 	},
 	"postCreateCommand": {
-		"post-create-command-1": "touch /tmp/postCreateCommand1.testmarker",
-		"post-create-command-2": "touch /tmp/postCreateCommand2.testmarker"
+		"post-create-command-1": "touch /tmp/postCreateCommand1.testmarker && echo post create command 1",
+		"post-create-command-2": "touch /tmp/postCreateCommand2.testmarker && echo post create command 2"
 	},
 	"postStartCommand": {
-		"post-start-command-1": "touch /tmp/postStartCommand1.testmarker",
-		"post-start-command-2": "touch /tmp/postStartCommand2.testmarker"
+		"post-start-command-1": "touch /tmp/postStartCommand1.testmarker && echo post start command 1",
+		"post-start-command-2": "touch /tmp/postStartCommand2.testmarker && echo post start command 2"
 	},
 	"postAttachCommand": {
-		"post-attach-command-1": "touch /tmp/postAttachCommand1.testmarker",
-		"post-attach-command-2": "touch /tmp/postAttachCommand2.testmarker"
+		"post-attach-command-1": "touch /tmp/postAttachCommand1.testmarker && echo post attach command 1",
+		"post-attach-command-2": "touch /tmp/postAttachCommand2.testmarker && echo post attach command 2"
 	},
 }

--- a/src/test/configs/dockerfile-with-parallel-commands/.devcontainer.json
+++ b/src/test/configs/dockerfile-with-parallel-commands/.devcontainer.json
@@ -1,0 +1,20 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { 
+			"VARIANT": "16-bullseye"
+		}
+	},
+	"postCreateCommand": {
+		"post-create-command-1": "touch /tmp/postCreateCommand1.testmarker",
+		"post-create-command-2": "touch /tmp/postCreateCommand2.testmarker"
+	},
+	"postStartCommand": {
+		"post-start-command-1": "touch /tmp/postStartCommand1.testmarker",
+		"post-start-command-2": "touch /tmp/postStartCommand2.testmarker"
+	},
+	"postAttachCommand": {
+		"post-attach-command-1": "touch /tmp/postAttachCommand1.testmarker",
+		"post-attach-command-2": "touch /tmp/postAttachCommand2.testmarker"
+	},
+}

--- a/src/test/configs/dockerfile-with-parallel-commands/Dockerfile
+++ b/src/test/configs/dockerfile-with-parallel-commands/Dockerfile
@@ -5,7 +5,7 @@ ARG VARIANT="16-bullseye"
 # Target should skip this layer
 FROM alpine as false-start 
 
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT} as desired-image
+FROM mcr.microsoft.com/devcontainers/typescript-node:0-${VARIANT} as desired-image
 
 RUN echo "||test-content||" | sudo tee /var/test-marker
 

--- a/src/test/configs/dockerfile-with-parallel-commands/Dockerfile
+++ b/src/test/configs/dockerfile-with-parallel-commands/Dockerfile
@@ -1,0 +1,13 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License. See License.txt in the project root for license information.
+ARG VARIANT="16-bullseye"
+
+# Target should skip this layer
+FROM alpine as false-start 
+
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT} as desired-image
+
+RUN echo "||test-content||" | sudo tee /var/test-marker
+
+# Target should skip this layer
+FROM alpine as false-finish 


### PR DESCRIPTION
Implementation of https://github.com/devcontainers/spec/pull/89.

Allow lifecycle scripts to be run in parallel by specifying them as objects.

@chrmarti and I talked through the problem of how to avoid interleaving output from commands running in parallel and landed on holding command output until the command completes and then writing it. Non-object form commands will still stream their output as they're running.

Example `devcontainer.json`:
```jsonc
{
        // ...
	"postCreateCommand": {
		"post-create-command-1": "touch /tmp/postCreateCommand1.testmarker && echo post create command 1",
		"post-create-command-2": "touch /tmp/postCreateCommand2.testmarker && echo post create command 2"
	},
	"postStartCommand": {
		"post-start-command-1": "touch /tmp/postStartCommand1.testmarker && echo post start command 1",
		"post-start-command-2": "touch /tmp/postStartCommand2.testmarker && echo post start command 2"
	},
	"postAttachCommand": {
		"post-attach-command-1": "touch /tmp/postAttachCommand1.testmarker && echo post attach command 1",
		"post-attach-command-2": "touch /tmp/postAttachCommand2.testmarker && echo post attach command 2"
	},
}

```

Output:
```
$ devcontainer up --workspace-folder src/test/configs/dockerfile-with-parallel-commands --remove-existing-container
[17 ms] @devcontainers/cli 0.16.0. Node.js v16.17.0. linux 5.4.0-1090-azure x64.
[803 ms] Start: Run: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-node/container-features/0.16.0-1664309392278/Dockerfile-with-features -t vsc-dockerfile-with-parallel-commands-f30a1f9a1b44ae6ea95dcf0128049ed1 --target dev_containers_target_stage --build-arg VARIANT=16-bullseye --build-arg _DEV_CONTAINERS_BASE_IMAGE=false-finish /workspaces/cli/src/test/configs/dockerfile-with-parallel-commands
[+] Building 0.2s (6/6) FINISHED                                                
 => [internal] load build definition from Dockerfile-with-features         0.1s
 => => transferring dockerfile: 1.32kB                                     0.0s
 => [internal] load .dockerignore                                          0.2s
 => => transferring context: 2B                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:latest           0.0s
 => CACHED [false-finish 1/1] FROM docker.io/library/alpine                0.0s
 => exporting to image                                                     0.0s
 => => exporting layers                                                    0.0s
 => => writing image sha256:7c2b0bd54d75e0fb21de7ba17795725667bcce2f51682  0.0s
 => => naming to docker.io/library/vsc-dockerfile-with-parallel-commands-  0.0s
 => exporting cache                                                        0.0s
 => => preparing build cache for export                                    0.0s
[1309 ms] Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,source=/workspaces/cli,target=/workspaces/cli -l devcontainer.local_folder=/workspaces/cli/src/test/configs/dockerfile-with-parallel-commands --entrypoint /bin/sh vsc-dockerfile-with-parallel-commands-f30a1f9a1b44ae6ea95dcf0128049ed1 -c echo Container started
Container started
Running the postCreateCommand from devcontainer.json...

Running post-create-command-2 from devcontainer.json...
post create command 2

Running post-create-command-1 from devcontainer.json...
post create command 1

Running the postStartCommand from devcontainer.json...

Running post-start-command-1 from devcontainer.json...
post start command 1

Running post-start-command-2 from devcontainer.json...
post start command 2

Running the postAttachCommand from devcontainer.json...

Running post-attach-command-2 from devcontainer.json...
post attach command 2

Running post-attach-command-1 from devcontainer.json...
post attach command 1

{"outcome":"success","containerId":"00ea949c1ca2aaaa7afa61a4765b28bc892a918eabcd008aed0c83a87f2010f2","remoteUser":"root","remoteWorkspaceFolder":"/workspaces/cli/src/test/configs/dockerfile-with-parallel-commands"}
```