### PR TITLE
Improve feature installation logs

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -289,7 +289,8 @@ export function getFeatureLayers(featuresConfig: FeaturesConfig) {
 	featuresConfig.featureSets.filter(y => y.internalVersion === '2').forEach(featureSet => {
 		featureSet.features.forEach(feature => {
 			result += generateContainerEnvs(feature);
-			result += `RUN cd /tmp/build-features/${feature.consecutiveId} \\
+			result += `
+RUN cd /tmp/build-features/${feature.consecutiveId} \\
 && chmod +x ./devcontainer-features-install.sh \\
 && ./devcontainer-features-install.sh
 

--- a/src/spec-configuration/containerFeaturesOCI.ts
+++ b/src/spec-configuration/containerFeaturesOCI.ts
@@ -62,7 +62,6 @@ export function getOCIFeatureSet(output: Log, identifier: string, options: boole
 
 	const feat = {
 		id: featureRef.id,
-		name: featureRef.id,
 		included: true,
 		value: options
 	};

--- a/src/test/configs/example/.devcontainer.json
+++ b/src/test/configs/example/.devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"image": "mcr.microsoft.com/devcontainers/base:latest",
 	"features": {
-		"go": {
+		"ghcr.io/devcontainers/features/go:1": {
 			"version": "latest"
 		}
 	}

--- a/src/test/configs/image-with-features/.devcontainer.json
+++ b/src/test/configs/image-with-features/.devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-16-bullseye",
 	"features": {
-		"docker-in-docker": "latest",
+		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}

--- a/src/test/container-features/configs/dockerfile-with-v2-oci-features/.devcontainer.json
+++ b/src/test/container-features/configs/dockerfile-with-v2-oci-features/.devcontainer.json
@@ -7,7 +7,7 @@
 	},
 	"features": {
 		"terraform": "latest",
-		"ghcr.io/codspace/features/docker-in-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
 		"node": "16"
 	}
 }

--- a/src/test/container-features/e2e.test.ts
+++ b/src/test/container-features/e2e.test.ts
@@ -33,7 +33,9 @@ describe('Dev Container Features E2E (remote)', function () {
                 assert.equal(error.error.code, 1, 'Should fail with exit code 1');
                 const res = JSON.parse(error.stdout);
                 assert.equal(res.outcome, 'error');
-                assert.ok(res.message.indexOf('Failed to fetch tarball') > -1, `Actual error msg:  ${res.message}`);
+                // "Failed to fetch tarball" happens if the test is executed without a $GITHUB_TOKEN
+                // "HTTP 404: Not Found" happens if the test is executed with a $GITHUB_TOKEN
+                assert.ok(res.message.indexOf('Failed to fetch tarball') > -1 || res.message.indexOf('HTTP 404: Not Found') > -1, `Actual error msg:  ${res.message}`);
             }
             assert.equal(success, false, 'expect non-successful call');
         });

--- a/src/test/container-features/featureHelpers.test.ts
+++ b/src/test/container-features/featureHelpers.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import * as path from 'path';
 import { DevContainerFeature } from '../../spec-configuration/configuration';
-import { getBackwardCompatibleFeatureId, processFeatureIdentifier } from '../../spec-configuration/containerFeaturesConfiguration';
+import { Feature, FeatureSet, getBackwardCompatibleFeatureId, getFeatureInstallWrapperScript, processFeatureIdentifier } from '../../spec-configuration/containerFeaturesConfiguration';
 import { OCIFeatureRef } from '../../spec-configuration/containerFeaturesOCI';
 import { getSafeId } from '../../spec-node/containerFeatures';
 import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
@@ -379,7 +379,6 @@ describe('validate processFeatureIdentifier', async function () {
 	});
 });
 
-
 describe('validate function getBackwardCompatibleFeatureId', () => {
     it('should map the migrated (old shorthand syntax) features to ghcr.io/devcontainers/features/*', () => {
         let id = 'node';
@@ -441,5 +440,140 @@ describe('validate function getBackwardCompatibleFeatureId', () => {
 		mappedId = getBackwardCompatibleFeatureId(id);
 
         assert.strictEqual(mappedId, expectedId);
+    });
+});
+
+describe('validate function getFeatureInstallWrapperScript', () => {
+	it('returns a valid script when optional feature values do not exist', () => {
+        const feature: Feature = {
+			id: 'test',
+			value: {},
+			included: true,
+			name: undefined,
+			description: undefined,
+			version: undefined,
+			documentationURL: undefined,
+		};
+		const set: FeatureSet = {
+			features: [feature],
+			sourceInformation: {
+				type: 'file-path',
+				resolvedFilePath: '',
+				userFeatureId: './test',
+				userFeatureIdWithoutVersion: './test'
+			}
+		};
+		const options: string[] = [];
+
+		const expected =
+`#!/bin/sh
+set -e
+
+on_exit () {
+	[ $? -eq 0 ] && exit
+	echo 'ERROR: Feature "" (./test) failed to install! Look at the documentation at  for help troubleshooting this error.'
+}
+
+trap on_exit EXIT
+
+echo ===========================================================================
+echo 'Feature       : '
+echo 'Description   : '
+echo 'Id            : ./test'
+echo 'Version       : '
+echo 'Documentation : '
+echo 'Options       :'
+echo ''
+echo ===========================================================================
+
+set -a
+. ./devcontainer-features.env
+set +a
+
+chmod +x ./install.sh
+./install.sh
+`;
+
+		const actual = getFeatureInstallWrapperScript(feature, set, options);
+		assert.equal(actual, expected);
+    });
+
+	it('returns a valid script when expected feature values do exist', () => {
+        const feature: Feature = {
+			id: 'test',
+			value: {
+				version: 'latest',
+				otherOption: true
+			},
+			included: true,
+			name: 'My Test Feature',
+			description: 'This is an awesome feature (with ""quotes" for \'escaping\' test)',
+			version: '1.2.3',
+			documentationURL: 'https://my-test-feature.localhost',
+		};
+		const set: FeatureSet = {
+			features: [feature],
+			sourceInformation: {
+				type: 'oci',
+				userFeatureId: 'ghcr.io/my-org/my-repo/test:1',
+				userFeatureIdWithoutVersion: 'ghcr.io/my-org/my-repo/test',
+				featureRef: {
+					registry: 'ghcr.io',
+					owner: 'my-org',
+					namespace: 'my-org/my-repo',
+					path: 'my-org/my-repo/test',
+					resource: 'ghcr.io/my-org/my-repo/test',
+					id: 'test',
+					version: '1.2.3',
+				},
+				manifest: {
+					schemaVersion: 1,
+					mediaType: '',
+					config: {
+						digest: '',
+						mediaType: '',
+						size: 0,
+					},
+					layers: [],
+				}
+			}
+		};
+		const options = [
+			'VERSION=latest',
+			'OTHEROPTION=true',
+		];
+
+		const expected =
+`#!/bin/sh
+set -e
+
+on_exit () {
+	[ $? -eq 0 ] && exit
+	echo 'ERROR: Feature "My Test Feature" (ghcr.io/my-org/my-repo/test) failed to install! Look at the documentation at https://my-test-feature.localhost for help troubleshooting this error.'
+}
+
+trap on_exit EXIT
+
+echo ===========================================================================
+echo 'Feature       : My Test Feature'
+echo 'Description   : This is an awesome feature (with ""quotes" for '\\''escaping'\\'' test)'
+echo 'Id            : ghcr.io/my-org/my-repo/test'
+echo 'Version       : 1.2.3'
+echo 'Documentation : https://my-test-feature.localhost'
+echo 'Options       :'
+echo '    VERSION=latest
+    OTHEROPTION=true'
+echo ===========================================================================
+
+set -a
+. ./devcontainer-features.env
+set +a
+
+chmod +x ./install.sh
+./install.sh
+`;
+
+		const actual = getFeatureInstallWrapperScript(feature, set, options);
+		assert.equal(actual, expected);
     });
 });

--- a/src/test/container-features/featureHelpers.test.ts
+++ b/src/test/container-features/featureHelpers.test.ts
@@ -471,13 +471,13 @@ set -e
 
 on_exit () {
 	[ $? -eq 0 ] && exit
-	echo 'ERROR: Feature "" (./test) failed to install! Look at the documentation at  for help troubleshooting this error.'
+	echo 'ERROR: Feature "Unknown" (./test) failed to install!'
 }
 
 trap on_exit EXIT
 
 echo ===========================================================================
-echo 'Feature       : '
+echo 'Feature       : Unknown'
 echo 'Description   : '
 echo 'Id            : ./test'
 echo 'Version       : '

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -123,9 +123,11 @@ RUN cd /tmp/build-features/second_2 \\
 
         // getFeatureLayers
         const actualLayers = getFeatureLayers(featuresConfig);
-        const expectedLayers = `RUN cd /tmp/build-features/color_3 \\
+        const expectedLayers = `
+RUN cd /tmp/build-features/color_3 \\
 && chmod +x ./devcontainer-features-install.sh \\
 && ./devcontainer-features-install.sh
+
 
 RUN cd /tmp/build-features/hello_4 \\
 && chmod +x ./devcontainer-features-install.sh \\

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -6,6 +6,7 @@ import { mkdirpLocal } from '../../spec-utils/pfs';
 import { DevContainerConfig } from '../../spec-configuration/configuration';
 import { URI } from 'vscode-uri';
 import { getLocalCacheFolder } from '../../spec-node/utils';
+import { shellExec } from '../testUtils';
 
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
 
@@ -21,7 +22,7 @@ describe('validate generateFeaturesConfig()', function () {
         return './src/test/container-features/example-v1-features-sets/simple';
     };
 
-    it('should correctly return a featuresConfig with just local features', async function () {
+    it('should correctly return a featuresConfig with v1 local features', async function () {
 
         const version = 'unittest';
         const tmpFolder: string = path.join(await getLocalCacheFolder(), 'container-features', `${version}-${Date.now()}`);
@@ -75,6 +76,60 @@ describe('validate generateFeaturesConfig()', function () {
 RUN cd /tmp/build-features/second_2 \\
 && chmod +x ./install.sh \\
 && ./install.sh
+
+`;
+        assert.strictEqual(actualLayers, expectedLayers);
+    });
+
+    it('should correctly return a featuresConfig with v2 local features', async function () {
+        const version = 'unittest';
+        const tmpFolder: string = path.join(await getLocalCacheFolder(), 'container-features', `${version}-${Date.now()}`);
+        await mkdirpLocal(tmpFolder);
+
+        const devcontainerFolder = path.resolve(tmpFolder, '.devcontainer');
+        await mkdirpLocal(devcontainerFolder);
+        await shellExec(`cp -R ./src/test/container-features/example-v2-features-sets/simple/src/* ${devcontainerFolder}`);
+
+        const config: DevContainerConfig = {
+            configFilePath: URI.from({ 'path': path.resolve(devcontainerFolder, 'devcontainer.json'), scheme: 'file' }),
+            dockerFile: '.',
+            features: {
+                './color': {
+                    'favorite': 'gold'
+                },
+                './hello': {
+                    'greeting': 'howdy'
+                },
+            },
+        };
+        
+        const featuresConfig = await generateFeaturesConfig({...params, cwd: tmpFolder}, tmpFolder, config, localFeaturesFolder);
+        if (!featuresConfig) {
+            assert.fail();
+        }
+
+        assert.strictEqual(featuresConfig?.featureSets.length, 2);
+
+        const first = featuresConfig.featureSets[0].features.find((f) => f.id === 'color');
+        assert.exists(first);
+
+        const second = featuresConfig.featureSets[1].features.find((f) => f.id === 'hello');
+        assert.exists(second);
+
+        assert.isObject(first?.value);
+        assert.isObject(second?.value);
+
+        // -- Test containerFeatures.ts helper functions
+
+        // getFeatureLayers
+        const actualLayers = getFeatureLayers(featuresConfig);
+        const expectedLayers = `RUN cd /tmp/build-features/color_1 \\
+&& chmod +x ./devcontainer-features-install.sh \\
+&& ./devcontainer-features-install.sh
+
+RUN cd /tmp/build-features/hello_2 \\
+&& chmod +x ./devcontainer-features-install.sh \\
+&& ./devcontainer-features-install.sh
 
 `;
         assert.strictEqual(actualLayers, expectedLayers);

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -123,11 +123,11 @@ RUN cd /tmp/build-features/second_2 \\
 
         // getFeatureLayers
         const actualLayers = getFeatureLayers(featuresConfig);
-        const expectedLayers = `RUN cd /tmp/build-features/color_1 \\
+        const expectedLayers = `RUN cd /tmp/build-features/color_3 \\
 && chmod +x ./devcontainer-features-install.sh \\
 && ./devcontainer-features-install.sh
 
-RUN cd /tmp/build-features/hello_2 \\
+RUN cd /tmp/build-features/hello_4 \\
 && chmod +x ./devcontainer-features-install.sh \\
 && ./devcontainer-features-install.sh
 


### PR DESCRIPTION
Add a header to the output logs for each feature that is executed to provide info about the feature

Example:
```
#15 [dev_containers_target_stage 4/4] RUN cd /tmp/build-features/docker-in-docker_2 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh
#15 0.521 ===========================================================================
#15 0.521 Feature       : Docker (Docker-in-Docker)
#15 0.521 Description   : Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.
#15 0.521 Id            : ghcr.io/devcontainers/features/docker-in-docker
#15 0.521 Version       : 1.0.4
#15 0.521 Documentation : https://github.com/devcontainers/features/tree/main/src/docker-in-docker
#15 0.521 Options       :
#15 0.521     VERSION=latest
#15 0.521     MOBY=true
#15 0.521     DOCKERDASHCOMPOSEVERSION=v1
#15 0.521 ===========================================================================
#15 0.669 DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES=buster bullseye bionic focal jammy
#15 0.669 Distro codename  'bullseye'  matched filter  'buster bullseye bionic focal jammy'
#15 0.675 Running apt-get update...
#15 0.714 Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
...
```

In order to print out feature information in the middle of the docker build, we are now injecting a wrapper script as the command to `RUN` instead of directly invoking the feature's `install.sh`. The wrapper script prints the header, sources the `devcontainer-features.env` and then invokes the feature's `install.sh`. This simplifies the `RUN` command in the Dockerfile and gives us a nice spot to handle both before and after a feature executes.

If a feature fails to install, a clear error message is printed saying which feature failed with a pointer to the documentation for that feature. This is accomplished with `trap on_exit EXIT` that runs the `on_exit()` function before the script exits.

Added unit and e2e tests to cover the v2 feature install path.

Fixes: https://github.com/devcontainers/cli/issues/170