### PR TITLE
Fail test run if an expected scenarios test script is missing

### DIFF
--- a/src/spec-node/featuresCLI/testCommandImpl.ts
+++ b/src/spec-node/featuresCLI/testCommandImpl.ts
@@ -207,8 +207,7 @@ async function doScenario(pathToTestDir: string, args: FeaturesTestCommandInput,
 		// Check if we have a scenario test script, otherwise skip.
 		const scenarioTestScript = path.join(pathToTestDir, `${scenarioName}.sh`);
 		if (!(await cliHost.isFile(scenarioTestScript))) {
-			log(`No scenario test script found at path ${scenarioTestScript}, skipping scenario...`);
-			continue;
+			fail(`No scenario test script found at path '${scenarioTestScript}'.  Either add a script to the test folder, or remove from scenarios.json.`);
 		}
 
 		// Create Container


### PR DESCRIPTION
closes https://github.com/devcontainers/cli/issues/213

This will only happen in error, so fail the entire test if it happens.