### PR TITLE
Normalize feature permissions in an intetermediate stage before copying them to the final container

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -205,11 +205,15 @@ export function getContainerFeaturesBaseDockerFile() {
 
 #{nonBuildKitFeatureContentFallback}
 
+FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_feature_content_normalize
+COPY --from=dev_containers_feature_content_source {contentSourceRootPath} /tmp/build-features/
+RUN chmod -R 0600 /tmp/build-features
+
 FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage
 
 USER root
 
-COPY --from=dev_containers_feature_content_source {contentSourceRootPath} /tmp/build-features/
+COPY --from=dev_containers_feature_content_normalize /tmp/build-features /tmp/build-features
 
 #{featureLayer}
 

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -207,7 +207,7 @@ export function getContainerFeaturesBaseDockerFile() {
 
 FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_feature_content_normalize
 COPY --from=dev_containers_feature_content_source {contentSourceRootPath} /tmp/build-features/
-RUN chmod -R 0600 /tmp/build-features
+RUN chmod -R 0700 /tmp/build-features
 
 FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage
 

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -343,8 +343,8 @@ function getFeatureBuildStages(featuresConfig: FeaturesConfig, buildStageScripts
 		.map((featureSet, i) => featureSet.features
 			.filter(f => (includeAllConfiguredFeatures || f.included) && f.value && buildStageScripts[i][f.id]?.hasAcquire)
 			.map(f => `FROM mcr.microsoft.com/vscode/devcontainers/base:0-focal as ${getSourceInfoString(featureSet.sourceInformation)}_${f.id}
-COPY --from=dev_containers_feature_content_source ${path.posix.join(contentSourceRootPath, getSourceInfoString(featureSet.sourceInformation), 'features', f.id)} ${path.posix.join('/tmp/build-features', getSourceInfoString(featureSet.sourceInformation), 'features', f.id)}
-COPY --from=dev_containers_feature_content_source ${path.posix.join(contentSourceRootPath, getSourceInfoString(featureSet.sourceInformation), 'common')} ${path.posix.join('/tmp/build-features', getSourceInfoString(featureSet.sourceInformation), 'common')}
+COPY --from=dev_containers_feature_content_normalize ${path.posix.join(contentSourceRootPath, getSourceInfoString(featureSet.sourceInformation), 'features', f.id)} ${path.posix.join('/tmp/build-features', getSourceInfoString(featureSet.sourceInformation), 'features', f.id)}
+COPY --from=dev_containers_feature_content_normalize ${path.posix.join(contentSourceRootPath, getSourceInfoString(featureSet.sourceInformation), 'common')} ${path.posix.join('/tmp/build-features', getSourceInfoString(featureSet.sourceInformation), 'common')}
 RUN cd ${path.posix.join('/tmp/build-features', getSourceInfoString(featureSet.sourceInformation), 'features', f.id)} && set -a && . ./devcontainer-features.env && set +a && ./bin/acquire`
 			)
 		)


### PR DESCRIPTION
Resolves #153.

Since the underlying problem was that the permissions for features sources became corrupted and invalidated the cache, I added a new build stage that serves only to `COPY` the features sources and `chmod` them to `0600`. This way, by the time the actual work of installing the features is performed the permissions will have been normalized, allowing subsequent runs to use the install layers as cache.

I tested this manually by

1. Building a devcontainer image with this version of the CLI and pushing it to Docker Hub
2. Clearing the buildkit cache (`docker buildx prune -af`)
3. `docker pull`ing the built image back onto my machine from Docker Hub
4. Building the same image with the **release version** of the CLI and a `--cache-from` on the image from Docker Hub, to validate that the cache is not used by the release version. I canceled this build before it could finish, once it was clear the cache was not being used.
5. Building the image with a `--cache-from` again, but using this version of the CLI (the cache was used successfully)

This might be worth adding to tests, but it'd be a bit awkward -- you'd have to basically recreate the process above and then run regexes on the output to see if you got a cache hit. I can take a crack at that, if that's a blocker for merging.

Side note: in case anybody's curious why I used an additional stage instead of simply adding a `RUN chmod -R 0600 /tmp/build-features` after the `COPY`, it's because you don't get the cache without the extra stage -- BuildKit is apparently smart enough to identify when two contexts are equal, but doesn't seem to have the same capability at the individual layer level. [This demo](https://github.com/davidwallacejackson/docker-cache-merge-test) shows this in action.