### PR TITLE
`template apply` - auto-replace template default options if they exist in metadata file

### DIFF
--- a/src/spec-configuration/containerFeaturesOCI.ts
+++ b/src/spec-configuration/containerFeaturesOCI.ts
@@ -47,9 +47,9 @@ export async function fetchOCIFeature(output: Log, env: NodeJS.ProcessEnv, featu
 	const blobUrl = `https://${featureSet.sourceInformation.featureRef.registry}/v2/${featureSet.sourceInformation.featureRef.path}/blobs/${featureSet.sourceInformation.manifest?.layers[0].digest}`;
 	output.write(`blob url: ${blobUrl}`, LogLevel.Trace);
 
-	const files = await getBlob(output, env, blobUrl, ociCacheDir, featCachePath, featureRef);
+	const blobResult = await getBlob(output, env, blobUrl, ociCacheDir, featCachePath, featureRef);
 
-	if (!files) {
+	if (!blobResult) {
 		throw new Error(`Failed to download package for ${featureSet.sourceInformation.featureRef.resource}`);
 	}
 

--- a/src/spec-configuration/containerTemplatesConfiguration.ts
+++ b/src/spec-configuration/containerTemplatesConfiguration.ts
@@ -16,16 +16,16 @@ export interface Template {
 
 export type TemplateOption = {
 	type: 'boolean';
-	default: boolean;
+	default?: boolean;
 	description?: string;
 } | {
 	type: 'string';
-	default: boolean;
 	enum?: string[];
+	default?: string;
 	description?: string;
 } | {
 	type: 'string';
-	default: boolean;
+	default?: string;
 	proposals?: string[];
 	description?: string;
 };

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -42,7 +42,8 @@ describe('Test OCI Pull', () => {
 
     it('Download a feature', async () => {
         const featureRef = getRef(output, 'ghcr.io/codspace/features/ruby:1.0.13');
-        const files = await getBlob(output, process.env, 'https://ghcr.io/v2/codspace/features/ruby/blobs/sha256:8f59630bd1ba6d9e78b485233a0280530b3d0a44338f472206090412ffbd3efb', '/tmp', '/tmp/featureTest', featureRef);
-        assert.isArray(files);
+        const blobResult = await getBlob(output, process.env, 'https://ghcr.io/v2/codspace/features/ruby/blobs/sha256:8f59630bd1ba6d9e78b485233a0280530b3d0a44338f472206090412ffbd3efb', '/tmp', '/tmp/featureTest', featureRef);
+        assert.isDefined(blobResult);
+        assert.isArray(blobResult?.files);
     });
 });

--- a/src/test/container-templates/containerTemplatesOCI.test.ts
+++ b/src/test/container-templates/containerTemplatesOCI.test.ts
@@ -8,12 +8,12 @@ import { readLocalFile } from '../../spec-utils/pfs';
 describe('fetchTemplate', async function () {
 	this.timeout('120s');
 
-	it('succeeds on docker-from-docker template without Features', async () => {
+	it('template apply docker-from-docker without features and with user options', async () => {
 
 		// https://github.com/devcontainers/templates/tree/main/src/docker-from-docker
 		const selectedTemplate: SelectedTemplate = {
 			id: 'ghcr.io/devcontainers/templates/docker-from-docker:latest',
-			options: { 'installZsh': 'false', 'upgradePackages': 'true', 'dockerVersion': '20.10', 'moby': 'true', 'enableNonRootDocker': 'true' },
+			options: { 'installZsh': 'false', 'upgradePackages': 'true', 'dockerVersion': '20.10', 'moby': 'true' },
 			features: []
 		};
 
@@ -37,8 +37,36 @@ describe('fetchTemplate', async function () {
 		assert.match(file, /"ghcr.io\/devcontainers\/features\/docker-from-docker:1": {\n/);
 	});
 
+	it('template apply docker-from-docker without features and without user options (default only)', async () => {
 
-	it('succeeds on docker-from-docker template with Features', async () => {
+		// https://github.com/devcontainers/templates/tree/main/src/docker-from-docker
+		const selectedTemplate: SelectedTemplate = {
+			id: 'ghcr.io/devcontainers/templates/docker-from-docker:latest',
+			options: {},
+			features: []
+		};
+
+		const dest = path.relative(process.cwd(), path.join(__dirname, 'tmp2'));
+		const files = await fetchTemplate(output, selectedTemplate, dest);
+		assert.ok(files);
+		// Should only container 1 file '.devcontainer.json'.  The other 3 in this repo should be ignored.
+		assert.strictEqual(files.length, 1);
+
+		// Read File
+		const file = (await readLocalFile(path.join(dest, files[0]))).toString();
+		assert.match(file, /"name": "Docker from Docker"/);
+		assert.match(file, /"installZsh": "true"/);
+		assert.match(file, /"upgradePackages": "false"/);
+		assert.match(file, /"version": "latest"/);
+		assert.match(file, /"moby": "true"/);
+		assert.match(file, /"enableNonRootDocker": "true"/);
+
+		// Assert that the Features included in the template were not removed.
+		assert.match(file, /"ghcr.io\/devcontainers\/features\/common-utils:1": {\n/);
+		assert.match(file, /"ghcr.io\/devcontainers\/features\/docker-from-docker:1": {\n/);
+	});
+
+	it('template apply docker-from-docker with features and with user options', async () => {
 
 		// https://github.com/devcontainers/templates/tree/main/src/docker-from-docker
 		const selectedTemplate: SelectedTemplate = {
@@ -70,7 +98,7 @@ describe('fetchTemplate', async function () {
 		assert.match(file, /"ghcr.io\/devcontainers\/features\/azure-cli:1": {}/);
 	});
 
-	it('succeeds on anaconda-postgres template with Features', async () => {
+	it('template apply docker-from-docker with features and with user options', async () => {
 
 		// https://github.com/devcontainers/templates/tree/main/src/anaconda-postgres
 		const selectedTemplate: SelectedTemplate = {
@@ -79,7 +107,7 @@ describe('fetchTemplate', async function () {
 			features: [{ id: 'ghcr.io/devcontainers/features/azure-cli:1', options: {} }, { id: 'ghcr.io/devcontainers/features/git:1', options: { 'version': 'latest', ppa: true } }]
 		};
 
-		const dest = path.relative(process.cwd(), path.join(__dirname, 'tmp2'));
+		const dest = path.relative(process.cwd(), path.join(__dirname, 'tmp4'));
 		const files = await fetchTemplate(output, selectedTemplate, dest);
 		assert.ok(files);
 		// Expected:


### PR DESCRIPTION
When applying a template, this change now looks for the associated `devcontainer-template.json` in the received tarball and applies the default values if a user had not overwritten the value.