### PR TITLE
Update examples to use mergedConfiguration so image labels work

### DIFF
--- a/example-usage/ci-app-build-script/build-application.sh
+++ b/example-usage/ci-app-build-script/build-application.sh
@@ -2,7 +2,6 @@
 set -e
 cd "$(dirname $0)"
 
-
 build_date="$(date +%s)"
 
 # Create a label for use during cleanup since the devcontainer CLI does 
@@ -13,8 +12,11 @@ id_label="ci-container=${build_date}"
 devcontainer up --id-label ${id_label} --workspace-folder ../workspace
 set +e
 devcontainer exec --id-label ${id_label} --workspace-folder ../workspace scripts/execute-app-build.sh
+build_exit_code=$?
 set -e
 
 # Clean up. 
 echo "\nCleaning up..."
 docker rm -f $(docker ps -aq --filter label=${id_label})
+
+exit ${build_exit_code}

--- a/example-usage/tool-openvscode-server/server/init-openvscode-server.sh
+++ b/example-usage/tool-openvscode-server/server/init-openvscode-server.sh
@@ -4,7 +4,7 @@ cd "$(dirname $0)"
 
 if [ ! -e "$HOME/.openvscodeserver/bin" ]; then
     echo "Downloading openvscode-server..."
-    curl -fsSL https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.69.2/openvscode-server-v1.69.2-linux-x64.tar.gz -o /tmp/openvscode-server.tar.gz
+    curl -fsSL https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.72.2/openvscode-server-v1.72.2-linux-x64.tar.gz -o /tmp/openvscode-server.tar.gz
     mkdir -p "$HOME/.openvscodeserver"
     echo "Extracting..."
     tar --strip 1 -xzf /tmp/openvscode-server.tar.gz -C "$HOME/.openvscodeserver/"
@@ -21,12 +21,10 @@ if [ "$(ps -ef | grep '\.openvscode-server' | wc -l)" = "1" ]; then
     tmp_dir="$(mktemp -d)"
     mkdir -p "${tmp_dir}" "$HOME"/.openvscode-server/data/Machine
 
-    # Get list of extensions to install - Also include VS Code list for features and legacy location
+    # Get list of extensions to install - [Optional] Also extensions from vscode set 
     extensions=( $(jq -r -M '[
-        .configuration.customizations?.openvscodeserver?.extensions[]?,
-        .featuresConfiguration?.featureSets[]?.features[]?.customizations?.openvscodeserver?.extensions[]?,
-        .featuresConfiguration?.featureSets[]?.features[]?.customizations?.vscode?.extensions[]?,
-        .featuresConfiguration?.featureSets[]?.features[]?.extensions[]?
+        .mergedConfiguration.customizations?.openvscodeserver[]?.extensions[]?,
+        .mergedConfiguration.customizations?.vscode[]?.extensions[]?
         ] | .[]
     ' /server/configuration.json ) )
     # Install extensions
@@ -38,12 +36,10 @@ if [ "$(ps -ef | grep '\.openvscode-server' | wc -l)" = "1" ]; then
         set -e
     fi
 
-    # Get openvscode-server machine settings.json - Also include VS Code settings for features and legacy location
+    # Get openvscode-server machine settings.json - [Optional] Also include VS Code settings
     settings="$(jq -M '[
-        .configuration.customizations?.openvscodeserver?.settings?,
-        .featuresConfiguration?.featureSets[]?.features[]?.customizations?.openvscodeserver?.settings?,
-        .featuresConfiguration?.featureSets[]?.features[]?.customizations?.vscode?.settings?,
-        .featuresConfiguration?.featureSets[]?.features[]?.settings?
+        .mergedConfiguration.customizations?.openvscodeserver[]?.settings?,
+        .mergedConfiguration.customizations?.vscode[]?.settings?
         ] | add
     ' /server/configuration.json)"
     # Place settings in right spot

--- a/example-usage/tool-openvscode-server/server/init-openvscode-server.sh
+++ b/example-usage/tool-openvscode-server/server/init-openvscode-server.sh
@@ -36,7 +36,7 @@ if [ "$(ps -ef | grep '\.openvscode-server' | wc -l)" = "1" ]; then
         set -e
     fi
 
-    # Get openvscode-server machine settings.json - [Optional] Also include VS Code settings
+    # Get openvscode-server machine settings.json - [Optional] Also settings from `vscode.settings` property
     settings="$(jq -M '[
         .mergedConfiguration.customizations?.openvscodeserver[]?.settings?,
         .mergedConfiguration.customizations?.vscode[]?.settings?

--- a/example-usage/tool-openvscode-server/server/init-openvscode-server.sh
+++ b/example-usage/tool-openvscode-server/server/init-openvscode-server.sh
@@ -21,7 +21,7 @@ if [ "$(ps -ef | grep '\.openvscode-server' | wc -l)" = "1" ]; then
     tmp_dir="$(mktemp -d)"
     mkdir -p "${tmp_dir}" "$HOME"/.openvscode-server/data/Machine
 
-    # Get list of extensions to install - [Optional] Also extensions from vscode set 
+    # Get list of extensions to install - [Optional] Also set of extensions from `vscode.extensions` property
     extensions=( $(jq -r -M '[
         .mergedConfiguration.customizations?.openvscodeserver[]?.extensions[]?,
         .mergedConfiguration.customizations?.vscode[]?.extensions[]?

--- a/example-usage/tool-openvscode-server/start.sh
+++ b/example-usage/tool-openvscode-server/start.sh
@@ -8,7 +8,7 @@ if [ "$1" = "true" ]; then
 fi
 
 # Save off effective config for use in the container
-devcontainer read-configuration --include-features-configuration --log-format json --workspace-folder ../workspace 2>/dev/null > server/configuration.json
+devcontainer read-configuration --include-merged-configuration --log-format json --workspace-folder ../workspace 2>/dev/null > server/configuration.json
 
 devcontainer up $remove_flag --mount "type=bind,source=$(pwd)/server,target=/server"  --workspace-folder ../workspace
 devcontainer exec --workspace-folder ../workspace /server/init-openvscode-server.sh

--- a/example-usage/tool-vscode-server/server/init-vscode-server.sh
+++ b/example-usage/tool-vscode-server/server/init-vscode-server.sh
@@ -36,27 +36,23 @@ if ! pidof code-server > /dev/null 2>&1; then
 
     # Get list of extensions - including legacy spots for backwards compatibility.
     extensions=( $(jq -r -M '[
-        .configuration.customizations?.vscode?.extensions[]?,
-        .featuresConfiguration?.featureSets[]?.features[]?.customizations?.vscode?.extensions[]?,
-        .configuration.extensions[]?,
-        .featuresConfiguration?.featureSets[]?.features[]?.extensions[]?
+        .mergedConfiguration.customizations?.vscode[]?.extensions[]?,
+        .mergedConfiguration.extensions[]?
         ] | .[]
     ' /server/configuration.json ) )
     # Install extensions
     if [ "${extensions[0]}" != "" ] && [ "${extensions[0]}" != "null" ] ; then  
         set +e
         for extension in "${extensions[@]}"; do
-            "$INSTALL_LOCATION/code-server" serve-local --accept-server-license-terms --install-extension ${extension}
+            "$INSTALL_LOCATION/code-server" serve-local --accept-server-license-terms --install-extension "${extension}"
         done
         set -e
     fi
 
     # Get VS Code machine settings - including legacy spots for backwards compatibility.
     settings="$(jq -M '[
-        .configuration.customizations?.vscode?.settings?,
-        .featuresConfiguration?.featureSets[]?.features[]?.customizations?.vscode?.settings?,
-        .configuration.settings?,
-        .featuresConfiguration?.featureSets[]?.features[]?.settings?
+        .mergedConfiguration.customizations?.vscode[]?.settings?,
+        .mergedConfiguration.settings?
         ] | add
     ' /server/configuration.json)"
     # Place settings in right spot

--- a/example-usage/tool-vscode-server/start.sh
+++ b/example-usage/tool-vscode-server/start.sh
@@ -8,7 +8,8 @@ if [ "$1" = "true" ]; then
 fi
 
 # Save off effective config for use in the container
-devcontainer read-configuration --include-features-configuration --log-format json --workspace-folder ../workspace 2>/dev/null > server/configuration.json
+devcontainer read-configuration --include-merged-configuration --log-format json --workspace-folder ../workspace 2>/dev/null > server/configuration.json
 
 devcontainer up $remove_flag --mount "type=bind,source=$(pwd)/server,target=/server" --workspace-folder ../workspace
+
 devcontainer exec --workspace-folder ../workspace /server/init-vscode-server.sh


### PR DESCRIPTION
Takes advantage of the new mergedConfiguration section in config output to simplify the script and pick up image label info.

Also made a minor tweak to properly return the right exit code from the CI example.