### PR TITLE
Keep dependencies for 3rd-party notices generator (devcontainers/cli#279)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs
 *.tgz
 tmp
 tmp[0-9]
+build-tmp
 .DS_Store
 .env
 output

--- a/build/patch-packagejson.js
+++ b/build/patch-packagejson.js
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+const jsonc = require('jsonc-parser');
+const fs = require('fs');
+const path = require('path');
+
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const packageJsonText = fs.readFileSync(packageJsonPath, 'utf8');
+const packageJson = jsonc.parse(packageJsonText);
+
+const dependencies = {
+	'node-pty': packageJson.dependencies['node-pty'],
+};
+
+const edits = jsonc.modify(packageJsonText, ['dependencies'], dependencies, {});
+const patchedText = jsonc.applyEdits(packageJsonText, edits);
+fs.writeFileSync(packageJsonPath, patchedText);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
 	"scripts": {
 		"compile": "npm-run-all clean-dist definitions compile-dev",
 		"watch": "npm-run-all clean-dist definitions compile-watch",
-		"package": "npm-run-all clean-dist definitions compile-prod npm-pack",
+		"package": "npm-run-all clean-dist definitions compile-prod store-packagejson patch-packagejson npm-pack restore-packagejson",
+		"store-packagejson": "copyfiles package.json build-tmp/",
+		"patch-packagejson": "node build/patch-packagejson.js",
+		"restore-packagejson": "copyfiles --up 1 build-tmp/package.json .",
 		"type-check": "npm-run-all clean-built tsc-b",
 		"type-check-watch": "npm-run-all clean-built tsc-b-w",
 		"compile-prod": "node esbuild.js --production",
@@ -84,12 +87,15 @@
 		"typescript": "^4.5.5",
 		"typescript-formatter": "^7.2.2",
 		"vinyl": "^2.2.1",
-		"vinyl-fs": "^3.0.3",
+		"vinyl-fs": "^3.0.3"
+	},
+	"dependencies": {
 		"chalk": "^4",
 		"follow-redirects": "^1.14.8",
 		"js-yaml": "^4.1.0",
 		"jsonc-parser": "^3.0.0",
 		"ncp": "^2.0.0",
+		"node-pty": "^0.10.1",
 		"proxy-agent": "^5.0.0",
 		"pull-stream": "^3.6.14",
 		"recursive-readdir": "^2.2.2",
@@ -100,8 +106,5 @@
 		"vscode-dev-containers": "https://github.com/microsoft/vscode-dev-containers/releases/download/v0.245.2/vscode-dev-containers-0.245.2.tgz",
 		"vscode-uri": "^3.0.3",
 		"yargs": "~17.0.1"
-	},
-	"dependencies": {
-		"node-pty": "^0.10.1"
 	}
 }


### PR DESCRIPTION
We moved all dependencies but the node-pty native module to devdependencies with the change for bundling (so these don't get installed again when installing from NPM). This also removes them from the 3rd-party notices. This change reverts that part of the change and instead modifies the package.json only when producing the package for NPM.