### PR TITLE
v0.25.1 - Fix regression in `requestResolveHeaders`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes.
 
 ## November 2022
 
+### [0.25.1]
+- Fix regression in https://github.com/devcontainers/cli/pull/298
+
 ### [0.25.0]
 
 - `features test`: Respect image label metadata. (https://github.com/devcontainers/cli/pull/288)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@devcontainers/cli",
 	"description": "Dev Containers CLI",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"bin": {
 		"devcontainer": "devcontainer.js"
 	},

--- a/src/spec-configuration/containerCollectionsOCIPush.ts
+++ b/src/spec-configuration/containerCollectionsOCIPush.ts
@@ -161,14 +161,14 @@ async function putManifestWithTags(output: Log, manifestStr: string, ociRef: OCI
 			data: Buffer.from(manifestStr),
 		};
 
-		let { statusCode, resHeaders } = await requestResolveHeaders(options);
+		let { statusCode, resHeaders } = await requestResolveHeaders(options, output);
 
 		// Retry logic: when request fails with HTTP 429: too many requests
 		if (statusCode === 429) {
 			output.write(`Failed to PUT manifest for tag ${tag} due to too many requests. Retrying...`, LogLevel.Warning);
 			await delay(2000);
 
-			let response = await requestResolveHeaders(options);
+			let response = await requestResolveHeaders(options, output);
 			statusCode = response.statusCode;
 			resHeaders = response.resHeaders;
 		}
@@ -212,7 +212,7 @@ async function putBlob(output: Log, pathToBlob: string, blobPutLocationUriPath: 
 
 	output.write(`Crafted blob url:  ${url}`, LogLevel.Trace);
 
-	const { statusCode } = await requestResolveHeaders({ type: 'PUT', url, headers, data: await readLocalFile(pathToBlob) });
+	const { statusCode } = await requestResolveHeaders({ type: 'PUT', url, headers, data: await readLocalFile(pathToBlob) }, output);
 	if (statusCode !== 201) {
 		output.write(`${statusCode}: Failed to upload blob '${pathToBlob}' to '${url}'`, LogLevel.Error);
 		return false;

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -81,6 +81,8 @@ export function requestResolveHeaders(options: { type: string; url: string; head
 		const req = https.request(reqOptions, res => {
 			res.on('error', reject);
 
+			_output!.write('hello!');
+
 			// Resolve response body
 			const chunks: Buffer[] = [];
 			res.on('data', chunk => chunks.push(chunk as Buffer));
@@ -91,10 +93,13 @@ export function requestResolveHeaders(options: { type: string; url: string; head
 					resBody: Buffer.concat(chunks)
 				});
 			});
-			if (options.data) {
-				req.write(options.data);
-			}
-			req.end();
 		});
+
+		if (options.data) {
+			req.write(options.data);
+		}
+
+		req.on('error', reject);
+		req.end();
 	});
 }

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -81,8 +81,6 @@ export function requestResolveHeaders(options: { type: string; url: string; head
 		const req = https.request(reqOptions, res => {
 			res.on('error', reject);
 
-			_output!.write('hello!');
-
 			// Resolve response body
 			const chunks: Buffer[] = [];
 			res.on('data', chunk => chunks.push(chunk as Buffer));


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/devcontainers/cli/commit/6f76c9518230915ca256320573c891f2f305c537

Example: https://github.com/codspace/random-features/actions/runs/3568551420/jobs/5997547286

Success run of the `publish` command: 
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/23246594/204394965-476c2819-e7fc-454c-b8db-c0e3258ba185.png">
