### PR TITLE
emit a JSON summary of the result of the `features publish` command

### DIFF
--- a/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
+++ b/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
@@ -44,7 +44,7 @@ export async function doPublishCommand(version: string, ociRef: OCIRef, outputDi
 	const publishedVersions = await getPublishedVersions(ociRef, output);
 
 	if (!publishedVersions) {
-		return false;
+		return;
 	}
 
 	const semanticVersions: string[] | undefined = getSermanticVersions(version, publishedVersions, output);
@@ -54,11 +54,11 @@ export async function doPublishCommand(version: string, ociRef: OCIRef, outputDi
 		const pathToTgz = path.join(outputDir, getArchiveName(ociRef.id, collectionType));
 		if (! await pushOCIFeatureOrTemplate(output, ociRef, pathToTgz, semanticVersions, collectionType)) {
 			output.write(`(!) ERR: Failed to publish ${collectionType}: '${ociRef.resource}'`, LogLevel.Error);
-			return false;
+			return;
 		}
 	}
-	output.write(`Published ${collectionType}: ${ociRef.id}...`, LogLevel.Info);
-	return true;
+	output.write(`Published ${collectionType}: '${ociRef.id}'`, LogLevel.Info);
+	return semanticVersions ?? []; // Not an error if no versions were published, likely they just already existed and were skipped.
 }
 
 export async function doPublishMetadata(collectionRef: OCICollectionRef, outputDir: string, output: Log, collectionType: string) {

--- a/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
+++ b/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
@@ -70,6 +70,6 @@ export async function doPublishMetadata(collectionRef: OCICollectionRef, outputD
 		output.write(`(!) ERR: Failed to publish collection metadata: ${OCICollectionFileName}`, LogLevel.Error);
 		return false;
 	}
-	output.write('Published collection metadata...', LogLevel.Info);
+	output.write('Published collection metadata.', LogLevel.Info);
 	return true;
 }

--- a/src/spec-node/featuresCLI/package.ts
+++ b/src/spec-node/featuresCLI/package.ts
@@ -35,7 +35,7 @@ async function featuresPackage({
 	const output = createLog({
 		logLevel: mapLogLevel(inputLogLevel),
 		logFormat: 'text',
-		log: (str) => process.stdout.write(str),
+		log: (str) => process.stderr.write(str),
 		terminalDimensions: undefined,
 	}, pkg, new Date(), disposables);
 

--- a/src/spec-node/featuresCLI/publish.ts
+++ b/src/spec-node/featuresCLI/publish.ts
@@ -84,7 +84,7 @@ async function featuresPublish({
             process.exit(1);
         }
 
-        const publishResult = await doPublishCommand(f.version, featureRef, outputDir, output, collectionType)
+        const publishResult = await doPublishCommand(f.version, featureRef, outputDir, output, collectionType);
         if (!publishResult) {
             output.write(`(!) ERR: Failed to publish '${resource}'`, LogLevel.Error);
             process.exit(1);


### PR DESCRIPTION
setup work for https://github.com/github/codespaces/issues/11247

Emits a JSON object to standard out at the end of a successful `devcontainer features publish` run.  Each Feature is listed and reports the tag(s) that were updated as a result of this publish.  

An empty array `[]` represents publishing being skipped for that Feature (for example if the Feature version was not updated)

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/23246594/204896399-0e1ca5c8-5e3a-4705-914d-4e3873b78550.png">
