### PR TITLE
A more spec-compliant/resilient OCI distribution implementation

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -54,8 +54,9 @@ jobs:
           "src/test/cli.exec.nonBuildKit.2.test.ts",
           "src/test/cli.test.ts",
           "src/test/cli.up.test.ts",
+          "src/test/container-features/containerFeaturesOCIPush.test.ts",
           # Run all except the above:
-          "--exclude src/test/container-features/e2e.test.ts --exclude src/test/container-features/featuresCLICommands.test.ts --exclude src/test/container-features/containerFeaturesOrder.test.ts --exclude src/test/cli.build.test.ts --exclude src/test/cli.exec.buildKit.1.test.ts --exclude src/test/cli.exec.buildKit.2.test.ts --exclude src/test/cli.exec.nonBuildKit.1.test.ts --exclude src/test/cli.exec.nonBuildKit.2.test.ts --exclude src/test/cli.test.ts --exclude src/test/cli.up.test.ts 'src/test/**/*.test.ts'",
+          "--exclude src/test/container-features/containerFeaturesOCIPush.test.ts --exclude src/test/container-features/e2e.test.ts --exclude src/test/container-features/featuresCLICommands.test.ts --exclude src/test/container-features/containerFeaturesOrder.test.ts --exclude src/test/cli.build.test.ts --exclude src/test/cli.exec.buildKit.1.test.ts --exclude src/test/cli.exec.buildKit.2.test.ts --exclude src/test/cli.exec.nonBuildKit.1.test.ts --exclude src/test/cli.exec.nonBuildKit.2.test.ts --exclude src/test/cli.test.ts --exclude src/test/cli.up.test.ts 'src/test/**/*.test.ts'",
         ]
     steps:
     - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs
 *.tgz
 tmp
 tmp[0-9]
+tmp/*
 build-tmp
 .DS_Store
 .env

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -168,7 +168,8 @@ export function getCollectionRef(output: Log, registry: string, namespace: strin
 export async function fetchOCIManifestIfExists(output: Log, env: NodeJS.ProcessEnv, ref: OCIRef | OCICollectionRef, manifestDigest?: string, authToken?: string): Promise<OCIManifest | undefined> {
 	// Simple mechanism to avoid making a DNS request for 
 	// something that is not a domain name.
-	if (ref.registry.indexOf('.') < 0) {
+	if (ref.registry.indexOf('.') < 0 && !ref.registry.startsWith('localhost')) {
+		output.write(`ERR: Registry '${ref.registry}' is not a valid domain name or IP address.`, LogLevel.Error);
 		return undefined;
 	}
 
@@ -255,6 +256,7 @@ async function getBasicAuthCredential(output: Log, registry: string, env: NodeJS
 
 	let userToken: string | undefined = undefined;
 	if (!!env['GITHUB_TOKEN'] && registry === 'ghcr.io') {
+		output.write('Using environment GITHUB_TOKEN for auth', LogLevel.Trace);
 		userToken = `USERNAME:${env['GITHUB_TOKEN']}`;
 	} else if (!!env['DEVCONTAINERS_OCI_AUTH']) {
 		// eg: DEVCONTAINERS_OCI_AUTH=domain1|user1|token1,domain2|user2|token2

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -217,6 +217,7 @@ export async function getManifest(output: Log, env: NodeJS.ProcessEnv, url: stri
 
 		return manifest;
 	} catch (e) {
+		output.write(`(!) Failed to fetch manifest: ${e}`, LogLevel.Error);
 		return undefined;
 	}
 }
@@ -243,8 +244,7 @@ async function getBasicAuthCredential(output: Log, registry: string, env: NodeJS
 		return Buffer.from(userToken).toString('base64');
 	}
 
-	// Error
-	output.write(`No authentication credentials found for registry '${registry}'.`, LogLevel.Error);
+	output.write(`No authentication credentials found for registry '${registry}'.`, LogLevel.Warning);
 	return undefined;
 }
 
@@ -263,7 +263,10 @@ async function generateScopeTokenCredential(output: Log, registry: string, ociRe
 		basicAuthTokenBase64 = await getBasicAuthCredential(output, registry, env);
 	}
 
-	headers['authorization'] = `Basic ${basicAuthTokenBase64}`;
+	if (basicAuthTokenBase64) {
+		headers['authorization'] = `Basic ${basicAuthTokenBase64}`;
+	}
+
 
 	const authServer = registry === 'docker.io' ? 'auth.docker.io' : registry;
 	const registryServer = registry === 'docker.io' ? 'registry.docker.io' : registry;

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -230,7 +230,7 @@ export async function fetchAuthorization(output: Log, registry: string, ociRepoP
 	const basicAuthTokenBase64 = await getBasicAuthCredential(output, registry, env);
 	const scopeToken = await generateScopeTokenCredential(output, registry, ociRepoPath, env, operationScopes, basicAuthTokenBase64);
 
-	// Prefer returned a Bearer token retreived from the /token endpoint.
+	// Prefer returned a Bearer token retrieved from the /token endpoint.
 	if (scopeToken) {
 		output.write(`Using scope token for registry '${registry}'`, LogLevel.Trace);
 		return `Bearer ${scopeToken}`;

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -244,6 +244,7 @@ async function getBasicAuthCredential(output: Log, registry: string, env: NodeJS
 		return Buffer.from(userToken).toString('base64');
 	}
 
+	// Represents anonymous access.
 	output.write(`No authentication credentials found for registry '${registry}'.`, LogLevel.Warning);
 	return undefined;
 }

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -222,6 +222,34 @@ export async function getManifest(output: Log, env: NodeJS.ProcessEnv, url: stri
 	}
 }
 
+// Exported Function
+// Will attempt to generate/fetch the correct authorization header for subsequent requests (Bearer or Basic)
+export async function fetchAuthorization(output: Log, registry: string, ociRepoPath: string, env: NodeJS.ProcessEnv, operationScopes: string): Promise<string | undefined> {
+	const basicAuthTokenBase64 = await getBasicAuthCredential(output, registry, env);
+	const scopeToken = await generateScopeTokenCredential(output, registry, ociRepoPath, env, operationScopes, basicAuthTokenBase64);
+
+	// Prefer returned a Bearer token retreived from the /token endpoint.
+	if (scopeToken) {
+		output.write(`Using scope token for registry '${registry}'`, LogLevel.Trace);
+		return `Bearer ${scopeToken}`;
+	}
+
+	// If all we have are Basic auth credentials, return those for the caller to use.
+	if (basicAuthTokenBase64) {
+		output.write(`Using basic auth token for registry '${registry}'`, LogLevel.Trace);
+		return `Basic ${basicAuthTokenBase64}`;
+	}
+
+	// If we have no credentials, and we weren't able to get a scope token anonymously, return undefined.
+	return undefined;
+}
+
+
+// * Internal helper for 'fetchAuthorization(...)'
+// Attempts to get the Basic auth credentials for the provided registry.
+// These may be programatically crafted via environment variables (GITHUB_TOKEN),
+// parsed out of a special DEVCONTAINERS_OCI_AUTH environment variable,
+// TODO: or directly read out of the local docker config file/credential helper.
 async function getBasicAuthCredential(output: Log, registry: string, env: NodeJS.ProcessEnv): Promise<string | undefined> {
 	// TODO: Also read OS keychain/docker config for auth in various registries!
 
@@ -249,8 +277,11 @@ async function getBasicAuthCredential(output: Log, registry: string, env: NodeJS
 	return undefined;
 }
 
+// * Internal helper for 'fetchAuthorization(...)'
 // https://github.com/oras-project/oras-go/blob/97a9c43c52f9d89ecf5475bc59bd1f96c8cc61f6/registry/remote/auth/scope.go#L60-L74
-// Some registries (eg: ghcr.io) expect a scoped token to target resources.
+// Using the provided Basic auth credentials, (or if none, anonymously), to ask the registry's '/token' endpoint for a token.
+// Some registries (eg: ghcr.io) expect a scoped token to target resources and will not operate with just Basic Auth.
+// Other registries (eg: the OCI Reference Implementation) will not return a valid token from '/token'
 async function generateScopeTokenCredential(output: Log, registry: string, ociRepoPath: string, env: NodeJS.ProcessEnv, operationScopes: string, basicAuthTokenBase64: string | undefined = undefined): Promise<string | undefined> {
 	if (registry === 'mcr.microsoft.com') {
 		return undefined;
@@ -268,7 +299,6 @@ async function generateScopeTokenCredential(output: Log, registry: string, ociRe
 		headers['authorization'] = `Basic ${basicAuthTokenBase64}`;
 	}
 
-
 	const authServer = registry === 'docker.io' ? 'auth.docker.io' : registry;
 	const registryServer = registry === 'docker.io' ? 'registry.docker.io' : registry;
 	const url = `https://${authServer}/token?scope=repository:${ociRepoPath}:${operationScopes}&service=${registryServer}`;
@@ -284,7 +314,8 @@ async function generateScopeTokenCredential(output: Log, registry: string, ociRe
 	try {
 		authReq = await request(options, output);
 	} catch (e: any) {
-		output.write(`Unable to request scope token from registry ${registry}: ${e}`, LogLevel.Warning);
+		// This is ok if the registry is trying to speak Basic Auth with us.
+		output.write(`Not used a scoped token for ${registry}: ${e}`, LogLevel.Trace);
 		return;
 	}
 
@@ -304,27 +335,6 @@ async function generateScopeTokenCredential(output: Log, registry: string, ociRe
 		return undefined;
 	}
 	return scopeToken;
-}
-
-
-// Exported Function
-// Will attempt to generate/fetch the correct authorization header for subsequent requests (Bearer or Basic)
-export async function fetchAuthorization(output: Log, registry: string, ociRepoPath: string, env: NodeJS.ProcessEnv, operationScopes: string): Promise<string | undefined> {
-	const basicAuthTokenBase64 = await getBasicAuthCredential(output, registry, env);
-	const scopeToken = await generateScopeTokenCredential(output, registry, ociRepoPath, env, operationScopes, basicAuthTokenBase64);
-
-	if (scopeToken) {
-		output.write(`Using scope token for registry '${registry}'`, LogLevel.Trace);
-		return `Bearer ${scopeToken}`;
-	}
-
-	if (basicAuthTokenBase64) {
-		output.write(`Using basic auth token for registry '${registry}'`, LogLevel.Trace);
-		return `Basic ${basicAuthTokenBase64}`;
-	}
-
-	return undefined;
-
 }
 
 // Lists published versions/tags of a feature/template 

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -218,7 +218,8 @@ export async function getManifest(output: Log, env: NodeJS.ProcessEnv, url: stri
 
 		return manifest;
 	} catch (e) {
-		output.write(`(!) Failed to fetch manifest: ${e}`, LogLevel.Error);
+		// A 404 is expected here if the manifest does not exist on the remote.
+		output.write(`Did not fetch manifest: ${e}`, LogLevel.Trace);
 		return undefined;
 	}
 }

--- a/src/spec-configuration/containerCollectionsOCIPush.ts
+++ b/src/spec-configuration/containerCollectionsOCIPush.ts
@@ -60,12 +60,6 @@ export async function pushOCIFeatureOrTemplate(output: Log, ociRef: OCIRef, path
 		}
 	];
 
-	// Obtain session ID with `/v2/<namespace>/blobs/uploads/` 
-	const blobPutLocationUriPath = await postUploadSessionId(output, ociRef, authorization);
-	if (!blobPutLocationUriPath) {
-		output.write(`Failed to get upload session ID`, LogLevel.Error);
-		return false;
-	}
 
 	for await (const blob of blobsToPush) {
 		const { name, digest } = blob;
@@ -74,6 +68,14 @@ export async function pushOCIFeatureOrTemplate(output: Log, ociRef: OCIRef, path
 
 		// PUT blobs
 		if (!blobExistsConfigLayer) {
+
+			// Obtain session ID with `/v2/<namespace>/blobs/uploads/` 
+			const blobPutLocationUriPath = await postUploadSessionId(output, ociRef, authorization);
+			if (!blobPutLocationUriPath) {
+				output.write(`Failed to get upload session ID`, LogLevel.Error);
+				return false;
+			}
+
 			if (!(await putBlob(output, blobPutLocationUriPath, ociRef, blob, authorization))) {
 				output.write(`Failed to PUT blob '${name}' with digest '${digest}'`, LogLevel.Error);
 				return false;
@@ -122,13 +124,6 @@ export async function pushCollectionMetadata(output: Log, collectionRef: OCIColl
 		return await putManifestWithTags(output, manifest.manifestStr, collectionRef, ['latest'], authorization);
 	}
 
-	// Obtain session ID with `/v2/<namespace>/blobs/uploads/` 
-	const blobPutLocationUriPath = await postUploadSessionId(output, collectionRef, authorization);
-	if (!blobPutLocationUriPath) {
-		output.write(`Failed to get upload session ID`, LogLevel.Error);
-		return false;
-	}
-
 	const blobsToPush = [
 		{
 			name: 'configLayer',
@@ -151,6 +146,14 @@ export async function pushCollectionMetadata(output: Log, collectionRef: OCIColl
 
 		// PUT blobs
 		if (!blobExistsConfigLayer) {
+
+			// Obtain session ID with `/v2/<namespace>/blobs/uploads/` 
+			const blobPutLocationUriPath = await postUploadSessionId(output, collectionRef, authorization);
+			if (!blobPutLocationUriPath) {
+				output.write(`Failed to get upload session ID`, LogLevel.Error);
+				return false;
+			}
+
 			if (!(await putBlob(output, blobPutLocationUriPath, collectionRef, blob, authorization))) {
 				output.write(`Failed to PUT blob '${name}' with digest '${digest}'`, LogLevel.Error);
 				return false;

--- a/src/spec-configuration/containerCollectionsOCIPush.ts
+++ b/src/spec-configuration/containerCollectionsOCIPush.ts
@@ -5,7 +5,8 @@ import { delay } from '../spec-common/async';
 import { headRequest, requestResolveHeaders } from '../spec-utils/httpRequest';
 import { Log, LogLevel } from '../spec-utils/log';
 import { isLocalFile, readLocalFile } from '../spec-utils/pfs';
-import { DEVCONTAINER_COLLECTION_LAYER_MEDIATYPE, DEVCONTAINER_TAR_LAYER_MEDIATYPE, fetchOCIManifestIfExists, fetchRegistryAuthToken, HEADERS, OCICollectionRef, OCILayer, OCIManifest, OCIRef } from './containerCollectionsOCI';
+import { DEVCONTAINER_COLLECTION_LAYER_MEDIATYPE, DEVCONTAINER_TAR_LAYER_MEDIATYPE, fetchOCIManifestIfExists, fetchAuthorization, HEADERS, OCICollectionRef, OCILayer, OCIManifest, OCIRef } from './containerCollectionsOCI';
+import { promisify } from 'util';
 
 // (!) Entrypoint function to push a single feature/template to a registry.
 //     Devcontainer Spec (features) : https://containers.dev/implementors/features-distribution/#oci-registry
@@ -17,8 +18,8 @@ export async function pushOCIFeatureOrTemplate(output: Log, ociRef: OCIRef, path
 	const env = process.env;
 
 	// Generate registry auth token with `pull,push` scopes.
-	const registryAuthToken = await fetchRegistryAuthToken(output, ociRef.registry, ociRef.path, env, 'pull,push');
-	if (!registryAuthToken) {
+	const authorization = await fetchAuthorization(output, ociRef.registry, ociRef.path, env, 'pull,push');
+	if (!authorization) {
 		output.write(`Failed to get registry auth token`, LogLevel.Error);
 		return false;
 	}
@@ -32,10 +33,10 @@ export async function pushOCIFeatureOrTemplate(output: Log, ociRef: OCIRef, path
 	output.write(`Generated manifest: \n${JSON.stringify(manifest?.manifestObj, undefined, 4)}`, LogLevel.Trace);
 
 	// If the exact manifest digest already exists in the registry, we don't need to push individual blobs (it's already there!) 
-	const existingManifest = await fetchOCIManifestIfExists(output, env, ociRef, manifest.digest, registryAuthToken);
+	const existingManifest = await fetchOCIManifestIfExists(output, env, ociRef, manifest.digest, authorization);
 	if (manifest.digest && existingManifest) {
 		output.write(`Not reuploading blobs, digest already exists.`, LogLevel.Trace);
-		return await putManifestWithTags(output, manifest.manifestStr, ociRef, tags, registryAuthToken);
+		return await putManifestWithTags(output, manifest.manifestStr, ociRef, tags, authorization);
 	}
 
 	const blobsToPush = [
@@ -50,7 +51,7 @@ export async function pushOCIFeatureOrTemplate(output: Log, ociRef: OCIRef, path
 	];
 
 	// Obtain session ID with `/v2/<namespace>/blobs/uploads/` 
-	const blobPutLocationUriPath = await postUploadSessionId(output, ociRef, registryAuthToken);
+	const blobPutLocationUriPath = await postUploadSessionId(output, ociRef, authorization);
 	if (!blobPutLocationUriPath) {
 		output.write(`Failed to get upload session ID`, LogLevel.Error);
 		return false;
@@ -58,12 +59,12 @@ export async function pushOCIFeatureOrTemplate(output: Log, ociRef: OCIRef, path
 
 	for await (const blob of blobsToPush) {
 		const { name, digest } = blob;
-		const blobExistsConfigLayer = await checkIfBlobExists(output, ociRef, digest, registryAuthToken);
+		const blobExistsConfigLayer = await checkIfBlobExists(output, ociRef, digest, authorization);
 		output.write(`blob: '${name}' with digest '${digest}'  ${blobExistsConfigLayer ? 'already exists' : 'does not exist'} in registry.`, LogLevel.Trace);
 
 		// PUT blobs
 		if (!blobExistsConfigLayer) {
-			if (!(await putBlob(output, pathToTgz, blobPutLocationUriPath, ociRef, digest, registryAuthToken))) {
+			if (!(await putBlob(output, pathToTgz, blobPutLocationUriPath, ociRef, digest, authorization))) {
 				output.write(`Failed to PUT blob '${name}' with digest '${digest}'`, LogLevel.Error);
 				return false;
 			}
@@ -71,7 +72,7 @@ export async function pushOCIFeatureOrTemplate(output: Log, ociRef: OCIRef, path
 	}
 
 	// Send a final PUT to combine blobs and tag manifest properly.
-	return await putManifestWithTags(output, manifest.manifestStr, ociRef, tags, registryAuthToken);
+	return await putManifestWithTags(output, manifest.manifestStr, ociRef, tags, authorization);
 }
 
 // (!) Entrypoint function to push a collection metadata/overview file for a set of features/templates to a registry.
@@ -83,8 +84,8 @@ export async function pushCollectionMetadata(output: Log, collectionRef: OCIColl
 	output.write(`${JSON.stringify(collectionRef, null, 2)}`, LogLevel.Trace);
 	const env = process.env;
 
-	const registryAuthToken = await fetchRegistryAuthToken(output, collectionRef.registry, collectionRef.path, env, 'pull,push');
-	if (!registryAuthToken) {
+	const authorization = await fetchAuthorization(output, collectionRef.registry, collectionRef.path, env, 'pull,push');
+	if (!authorization) {
 		output.write(`Failed to get registry auth token`, LogLevel.Error);
 		return false;
 	}
@@ -98,14 +99,14 @@ export async function pushCollectionMetadata(output: Log, collectionRef: OCIColl
 	output.write(`Generated manifest: \n${JSON.stringify(manifest?.manifestObj, undefined, 4)}`, LogLevel.Trace);
 
 	// If the exact manifest digest already exists in the registry, we don't need to push individual blobs (it's already there!) 
-	const existingManifest = await fetchOCIManifestIfExists(output, env, collectionRef, manifest.digest, registryAuthToken);
+	const existingManifest = await fetchOCIManifestIfExists(output, env, collectionRef, manifest.digest, authorization);
 	if (manifest.digest && existingManifest) {
 		output.write(`Not reuploading blobs, digest already exists.`, LogLevel.Trace);
-		return await putManifestWithTags(output, manifest.manifestStr, collectionRef, ['latest'], registryAuthToken);
+		return await putManifestWithTags(output, manifest.manifestStr, collectionRef, ['latest'], authorization);
 	}
 
 	// Obtain session ID with `/v2/<namespace>/blobs/uploads/` 
-	const blobPutLocationUriPath = await postUploadSessionId(output, collectionRef, registryAuthToken);
+	const blobPutLocationUriPath = await postUploadSessionId(output, collectionRef, authorization);
 	if (!blobPutLocationUriPath) {
 		output.write(`Failed to get upload session ID`, LogLevel.Error);
 		return false;
@@ -124,12 +125,12 @@ export async function pushCollectionMetadata(output: Log, collectionRef: OCIColl
 
 	for await (const blob of blobsToPush) {
 		const { name, digest } = blob;
-		const blobExistsConfigLayer = await checkIfBlobExists(output, collectionRef, digest, registryAuthToken);
+		const blobExistsConfigLayer = await checkIfBlobExists(output, collectionRef, digest, authorization);
 		output.write(`blob: '${name}' with digest '${digest}'  ${blobExistsConfigLayer ? 'already exists' : 'does not exist'} in registry.`, LogLevel.Trace);
 
 		// PUT blobs
 		if (!blobExistsConfigLayer) {
-			if (!(await putBlob(output, pathToCollectionJson, blobPutLocationUriPath, collectionRef, digest, registryAuthToken))) {
+			if (!(await putBlob(output, pathToCollectionJson, blobPutLocationUriPath, collectionRef, digest, authorization))) {
 				output.write(`Failed to PUT blob '${name}' with digest '${digest}'`, LogLevel.Error);
 				return false;
 			}
@@ -138,13 +139,13 @@ export async function pushCollectionMetadata(output: Log, collectionRef: OCIColl
 
 	// Send a final PUT to combine blobs and tag manifest properly.
 	// Collections are always tagged 'latest'
-	return await putManifestWithTags(output, manifest.manifestStr, collectionRef, ['latest'], registryAuthToken);
+	return await putManifestWithTags(output, manifest.manifestStr, collectionRef, ['latest'], authorization);
 }
 
 // --- Helper Functions
 
 // Spec: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-manifests (PUT /manifests/<ref>)
-async function putManifestWithTags(output: Log, manifestStr: string, ociRef: OCIRef | OCICollectionRef, tags: string[], registryAuthToken: string): Promise<boolean> {
+async function putManifestWithTags(output: Log, manifestStr: string, ociRef: OCIRef | OCICollectionRef, tags: string[], authorization: string): Promise<boolean> {
 	output.write(`Tagging manifest with tags: ${tags.join(', ')}`, LogLevel.Trace);
 
 	for await (const tag of tags) {
@@ -155,7 +156,7 @@ async function putManifestWithTags(output: Log, manifestStr: string, ociRef: OCI
 			type: 'PUT',
 			url,
 			headers: {
-				'Authorization': `Bearer ${registryAuthToken}`,
+				'Authorization': authorization, // Eg: 'Bearer <token>' or 'Basic <token>'
 				'Content-Type': 'application/vnd.oci.image.manifest.v1+json',
 			},
 			data: Buffer.from(manifestStr),
@@ -187,34 +188,43 @@ async function putManifestWithTags(output: Log, manifestStr: string, ociRef: OCI
 }
 
 // Spec: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#post-then-put (PUT <location>?digest=<digest>)
-async function putBlob(output: Log, pathToBlob: string, blobPutLocationUriPath: string, ociRef: OCIRef | OCICollectionRef, digest: string, registryAuthToken: string): Promise<boolean> {
-	output.write(`PUT new blob -> '${digest}'`, LogLevel.Info);
+async function putBlob(output: Log, pathToBlob: string, blobPutLocationUriPath: string, ociRef: OCIRef | OCICollectionRef, digest: string, authorization: string): Promise<boolean> {
 
 	if (!(await isLocalFile(pathToBlob))) {
 		output.write(`Blob ${pathToBlob} does not exist`, LogLevel.Error);
 		return false;
 	}
 
+	const blobSize = (await promisify(fs.stat)(pathToBlob)).size;
+
+	output.write(`PUT new blob -> '${digest}' (size=${blobSize})`, LogLevel.Info);
+
 	const headers: HEADERS = {
 		'user-agent': 'devcontainer',
-		'authorization': `Bearer ${registryAuthToken}`,
+		'authorization': authorization,
 		'content-type': 'application/octet-stream',
+		'content-length': `${blobSize}`
 	};
 
 	// OCI distribution spec is ambiguous on whether we get back an absolute or relative path.
 	let url = '';
-	if (blobPutLocationUriPath.startsWith('https://')) {
+	if (blobPutLocationUriPath.startsWith('https://') || blobPutLocationUriPath.startsWith('http://')) {
 		url = blobPutLocationUriPath;
 	} else {
 		url = `https://${ociRef.registry}${blobPutLocationUriPath}`;
 	}
-	url += `?digest=${digest}`;
+
+	if (url.indexOf('?') === -1) {
+		url += `?digest=${digest}`;
+	} else {
+		url += `&digest=${digest}`;
+	}
 
 	output.write(`Crafted blob url:  ${url}`, LogLevel.Trace);
 
-	const { statusCode } = await requestResolveHeaders({ type: 'PUT', url, headers, data: await readLocalFile(pathToBlob) }, output);
+	const { statusCode, resBody } = await requestResolveHeaders({ type: 'PUT', url, headers, data: await readLocalFile(pathToBlob) }, output);
 	if (statusCode !== 201) {
-		output.write(`${statusCode}: Failed to upload blob '${pathToBlob}' to '${url}'`, LogLevel.Error);
+		output.write(`${statusCode}: Failed to upload blob '${pathToBlob}' to '${url}' -> ${resBody}`, LogLevel.Error);
 		return false;
 	}
 
@@ -288,10 +298,10 @@ export async function calculateDataLayer(output: Log, pathToData: string, mediaT
 
 // Spec: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#checking-if-content-exists-in-the-registry
 //       Requires registry auth token.
-export async function checkIfBlobExists(output: Log, ociRef: OCIRef | OCICollectionRef, digest: string, authToken: string): Promise<boolean> {
+export async function checkIfBlobExists(output: Log, ociRef: OCIRef | OCICollectionRef, digest: string, authorization: string): Promise<boolean> {
 	const headers: HEADERS = {
 		'user-agent': 'devcontainer',
-		'authorization': `Bearer ${authToken}`,
+		'authorization': authorization,
 	};
 
 	const url = `https://${ociRef.registry}/v2/${ociRef.path}/blobs/${digest}`;
@@ -303,10 +313,10 @@ export async function checkIfBlobExists(output: Log, ociRef: OCIRef | OCICollect
 
 // Spec: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#post-then-put
 //       Requires registry auth token.
-async function postUploadSessionId(output: Log, ociRef: OCIRef | OCICollectionRef, authToken: string): Promise<string | undefined> {
+async function postUploadSessionId(output: Log, ociRef: OCIRef | OCICollectionRef, authorization: string): Promise<string | undefined> {
 	const headers: HEADERS = {
 		'user-agent': 'devcontainer',
-		'authorization': `Bearer ${authToken}`,
+		'authorization': authorization
 	};
 
 	const url = `https://${ociRef.registry}/v2/${ociRef.path}/blobs/uploads/`;

--- a/src/spec-configuration/containerCollectionsOCIPush.ts
+++ b/src/spec-configuration/containerCollectionsOCIPush.ts
@@ -175,7 +175,8 @@ async function putManifestWithTags(output: Log, manifestStr: string, ociRef: OCI
 		}
 
 		if (statusCode !== 201) {
-			output.write(`Failed to PUT manifest for tag ${tag}\n${JSON.stringify(resBody, undefined, 4)}`, LogLevel.Error);
+			const parsed = JSON.parse(resBody?.toString() || '{}');
+			output.write(`Failed to PUT manifest for tag ${tag}\n${JSON.stringify(parsed, undefined, 4)}`, LogLevel.Error);
 			return false;
 		}
 
@@ -226,7 +227,8 @@ async function putBlob(output: Log, pathToBlob: string, blobPutLocationUriPath: 
 
 	const { statusCode, resBody } = await requestResolveHeaders({ type: 'PUT', url, headers, data: await readLocalFile(pathToBlob) }, output);
 	if (statusCode !== 201) {
-		output.write(`${statusCode}: Failed to upload blob '${pathToBlob}' to '${url}' \n${JSON.stringify(resBody, undefined, 4)}`, LogLevel.Error);
+		const parsed = JSON.parse(resBody?.toString() || '{}');
+		output.write(`${statusCode}: Failed to upload blob '${pathToBlob}' to '${url}' \n${JSON.stringify(parsed, undefined, 4)}`, LogLevel.Error);
 		return false;
 	}
 
@@ -336,7 +338,8 @@ async function postUploadSessionId(output: Log, ociRef: OCIRef | OCICollectionRe
 	} else {
 		// Any other statusCode besides 202 is unexpected
 		// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes
-		output.write(`${url}: Unexpected status code '${statusCode}' \n${JSON.stringify(resBody, undefined, 4)}`, LogLevel.Error);
+		const parsed = JSON.parse(resBody?.toString() || '{}');
+		output.write(`${url}: Unexpected status code '${statusCode}' \n${JSON.stringify(parsed, undefined, 4)}`, LogLevel.Error);
 		return undefined;
 	}
 }

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -29,12 +29,13 @@ import { FeaturesConfig, generateFeaturesConfig, getContainerFeaturesFolder } fr
 import { featuresTestOptions, featuresTestHandler } from './featuresCLI/test';
 import { featuresPackageHandler, featuresPackageOptions } from './featuresCLI/package';
 import { featuresPublishHandler, featuresPublishOptions } from './featuresCLI/publish';
-import { featuresInfoHandler, featuresInfoOptions } from './featuresCLI/info';
+import { featureInfoTagsHandler, featuresInfoTagsOptions } from './featuresCLI/infoTags';
 import { beforeContainerSubstitute, containerSubstitute } from '../spec-common/variableSubstitution';
 import { getPackageConfig, PackageConfiguration } from '../spec-utils/product';
 import { getDevcontainerMetadata, getImageBuildInfo, getImageMetadataFromContainer, ImageMetadataEntry, mergeConfiguration, MergedDevContainerConfig } from './imageMetadata';
 import { templatesPublishHandler, templatesPublishOptions } from './templatesCLI/publish';
 import { templateApplyHandler, templateApplyOptions } from './templatesCLI/apply';
+import { featuresInfoManifestHandler, featuresInfoManifestOptions } from './featuresCLI/infoManifest';
 
 const defaultDefaultUserEnvProbe: UserEnvProbe = 'loginInteractiveShell';
 
@@ -63,10 +64,13 @@ const mountRegex = /^type=(bind|volume),source=([^,]+),target=([^,]+)(?:,externa
 	y.command('run-user-commands', 'Run user commands', runUserCommandsOptions, runUserCommandsHandler);
 	y.command('read-configuration', 'Read configuration', readConfigurationOptions, readConfigurationHandler);
 	y.command('features', 'Features commands', (y: Argv) => {
-		y.command('test [target]', 'Test features', featuresTestOptions, featuresTestHandler);
-		y.command('package <target>', 'Package features', featuresPackageOptions, featuresPackageHandler);
-		y.command('publish <target>', 'Package and publish features', featuresPublishOptions, featuresPublishHandler);
-		y.command('info <featureId>', 'Fetch info on a feature', featuresInfoOptions, featuresInfoHandler);
+		y.command('test [target]', 'Test Features', featuresTestOptions, featuresTestHandler);
+		y.command('package <target>', 'Package Features', featuresPackageOptions, featuresPackageHandler);
+		y.command('publish <target>', 'Package and publish Features', featuresPublishOptions, featuresPublishHandler);
+		y.command('info', 'Fetch metadata on published Features', (y: Argv) => {
+			y.command('tags <feature>', 'Fetch tags for a specific Feature', featuresInfoTagsOptions, featureInfoTagsHandler);
+			y.command('manifest <feature>', 'Fetch the manifest for a specific Feature', featuresInfoManifestOptions, featuresInfoManifestHandler);
+		});
 	});
 	y.command('templates', 'Templates commands', (y: Argv) => {
 		y.command('apply', 'Apply a template to the project', templateApplyOptions, templateApplyHandler);

--- a/src/spec-node/featuresCLI/infoManifest.ts
+++ b/src/spec-node/featuresCLI/infoManifest.ts
@@ -1,0 +1,53 @@
+import { Argv } from 'yargs';
+import { fetchAuthorization, fetchOCIManifestIfExists, getPublishedVersions, getRef } from '../../spec-configuration/containerCollectionsOCI';
+import { fetchOCIFeatureManifestIfExistsFromUserIdentifier } from '../../spec-configuration/containerFeaturesOCI';
+import { Log, LogLevel, mapLogLevel } from '../../spec-utils/log';
+import { getPackageConfig } from '../../spec-utils/product';
+import { createLog } from '../devContainers';
+import { UnpackArgv } from '../devContainersSpecCLI';
+
+export function featuresInfoManifestOptions(y: Argv) {
+	return y
+		.options({
+			'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
+			'output-format': { choices: ['text' as 'text', 'json' as 'json'], default: 'text', description: 'Output format.' },
+		})
+		.positional('feature', { type: 'string', demandOption: true, description: 'Feature Id' });
+}
+
+export type FeaturesInfoManifestArgs = UnpackArgv<ReturnType<typeof featuresInfoManifestOptions>>;
+
+export function featuresInfoManifestHandler(args: FeaturesInfoManifestArgs) {
+	(async () => await featuresInfoManifest(args))().catch(console.error);
+}
+
+async function featuresInfoManifest({
+	'feature': featureId,
+	'log-level': inputLogLevel,
+	'output-format': outputFormat,
+}: FeaturesInfoManifestArgs) {
+	const disposables: (() => Promise<unknown> | undefined)[] = [];
+	const dispose = async () => {
+		await Promise.all(disposables.map(d => d()));
+	};
+
+	const pkg = getPackageConfig();
+
+	const output = createLog({
+		logLevel: mapLogLevel(inputLogLevel),
+		logFormat: 'text',
+		log: (str) => process.stderr.write(str),
+		terminalDimensions: undefined,
+	}, pkg, new Date(), disposables, true);
+
+
+	const featureRef = getRef(output, featureId);
+	if (!featureRef) {
+		return undefined;
+	}
+	const authorization = await fetchAuthorization(output, featureRef.registry, featureRef.path, process.env, 'pull');
+	const manifest = await fetchOCIManifestIfExists(output, process.env, featureRef, undefined, authorization);
+
+	console.log(JSON.stringify(manifest, undefined, 4));
+	process.exit();
+}

--- a/src/spec-node/featuresCLI/infoManifest.ts
+++ b/src/spec-node/featuresCLI/infoManifest.ts
@@ -1,7 +1,6 @@
 import { Argv } from 'yargs';
-import { fetchAuthorization, fetchOCIManifestIfExists, getPublishedVersions, getRef } from '../../spec-configuration/containerCollectionsOCI';
-import { fetchOCIFeatureManifestIfExistsFromUserIdentifier } from '../../spec-configuration/containerFeaturesOCI';
-import { Log, LogLevel, mapLogLevel } from '../../spec-utils/log';
+import { fetchAuthorization, fetchOCIManifestIfExists, getRef } from '../../spec-configuration/containerCollectionsOCI';
+import { mapLogLevel } from '../../spec-utils/log';
 import { getPackageConfig } from '../../spec-utils/product';
 import { createLog } from '../devContainers';
 import { UnpackArgv } from '../devContainersSpecCLI';
@@ -24,7 +23,6 @@ export function featuresInfoManifestHandler(args: FeaturesInfoManifestArgs) {
 async function featuresInfoManifest({
 	'feature': featureId,
 	'log-level': inputLogLevel,
-	'output-format': outputFormat,
 }: FeaturesInfoManifestArgs) {
 	const disposables: (() => Promise<unknown> | undefined)[] = [];
 	const dispose = async () => {
@@ -49,5 +47,6 @@ async function featuresInfoManifest({
 	const manifest = await fetchOCIManifestIfExists(output, process.env, featureRef, undefined, authorization);
 
 	console.log(JSON.stringify(manifest, undefined, 4));
+	await dispose();
 	process.exit();
 }

--- a/src/spec-node/featuresCLI/infoTags.ts
+++ b/src/spec-node/featuresCLI/infoTags.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { getPublishedVersions, getRef } from '../../spec-configuration/containerCollectionsOCI';
-import { Log, LogLevel, mapLogLevel } from '../../spec-utils/log';
+import { LogLevel, mapLogLevel } from '../../spec-utils/log';
 import { getPackageConfig } from '../../spec-utils/product';
 import { createLog } from '../devContainers';
 import { UnpackArgv } from '../devContainersSpecCLI';

--- a/src/spec-node/featuresCLI/infoTags.ts
+++ b/src/spec-node/featuresCLI/infoTags.ts
@@ -42,9 +42,9 @@ async function featuresInfoTags({
 	const featureOciRef = getRef(output, featureId);
 	if (!featureOciRef) {
 		if (outputFormat === 'json') {
-			output.raw(JSON.stringify({}), LogLevel.Info);
+			console.log(JSON.stringify({}), LogLevel.Info);
 		} else {
-			output.raw(`Failed to parse Feature identifier '${featureId}'\n`, LogLevel.Error);
+			console.log(`Failed to parse Feature identifier '${featureId}'\n`, LogLevel.Error);
 		}
 		process.exit(1);
 	}
@@ -74,9 +74,9 @@ async function featuresInfoTags({
 }
 
 function printAsJson(data: { publishedVersions: string[] }) {
-	console.log(JSON.stringify(data, null, 2), LogLevel.Info);
+	console.log(JSON.stringify(data, null, 2));
 }
 
 function printAsPlainText(data: { publishedVersions: string[] }) {
-	console.log(`Published Versions: \n   ${data.publishedVersions.join('\n   ')}\n`, LogLevel.Info);
+	console.log(`Published Versions: \n   ${data.publishedVersions.join('\n   ')}\n`);
 }

--- a/src/spec-node/featuresCLI/infoTags.ts
+++ b/src/spec-node/featuresCLI/infoTags.ts
@@ -5,26 +5,26 @@ import { getPackageConfig } from '../../spec-utils/product';
 import { createLog } from '../devContainers';
 import { UnpackArgv } from '../devContainersSpecCLI';
 
-export function featuresInfoOptions(y: Argv) {
+export function featuresInfoTagsOptions(y: Argv) {
 	return y
 		.options({
 			'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
 			'output-format': { choices: ['text' as 'text', 'json' as 'json'], default: 'text', description: 'Output format.' },
 		})
-		.positional('featureId', { type: 'string', demandOption: true, description: 'Feature Id' });
+		.positional('feature', { type: 'string', demandOption: true, description: 'Feature Id' });
 }
 
-export type FeaturesInfoArgs = UnpackArgv<ReturnType<typeof featuresInfoOptions>>;
+export type FeaturesInfoTagsArgs = UnpackArgv<ReturnType<typeof featuresInfoTagsOptions>>;
 
-export function featuresInfoHandler(args: FeaturesInfoArgs) {
-	(async () => await featuresInfo(args))().catch(console.error);
+export function featureInfoTagsHandler(args: FeaturesInfoTagsArgs) {
+	(async () => await featuresInfoTags(args))().catch(console.error);
 }
 
-async function featuresInfo({
-	'featureId': featureId,
+async function featuresInfoTags({
+	'feature': featureId,
 	'log-level': inputLogLevel,
 	'output-format': outputFormat,
-}: FeaturesInfoArgs) {
+}: FeaturesInfoTagsArgs) {
 	const disposables: (() => Promise<unknown> | undefined)[] = [];
 	const dispose = async () => {
 		await Promise.all(disposables.map(d => d()));
@@ -35,7 +35,7 @@ async function featuresInfo({
 	const output = createLog({
 		logLevel: mapLogLevel(inputLogLevel),
 		logFormat: 'text',
-		log: (str) => process.stdout.write(str),
+		log: (str) => process.stderr.write(str),
 		terminalDimensions: undefined,
 	}, pkg, new Date(), disposables, true);
 
@@ -52,9 +52,9 @@ async function featuresInfo({
 	const publishedVersions = await getPublishedVersions(featureOciRef, output, true);
 	if (!publishedVersions || publishedVersions.length === 0) {
 		if (outputFormat === 'json') {
-			output.raw(JSON.stringify({}), LogLevel.Info);
+			console.log(JSON.stringify({}), LogLevel.Info);
 		} else {
-			output.raw(`No published versions found for feature '${featureId}'\n`, LogLevel.Error);
+			console.log(`No published versions found for feature '${featureId}'\n`, LogLevel.Error);
 		}
 		process.exit(1);
 	}
@@ -64,19 +64,19 @@ async function featuresInfo({
 	};
 
 	if (outputFormat === 'json') {
-		printAsJson(output, data);
+		printAsJson(data);
 	} else {
-		printAsPlainText(output, data);
+		printAsPlainText(data);
 	}
 
 	await dispose();
 	process.exit(0);
 }
 
-function printAsJson(output: Log, data: { publishedVersions: string[] }) {
-	output.raw(JSON.stringify(data, null, 2), LogLevel.Info);
+function printAsJson(data: { publishedVersions: string[] }) {
+	console.log(JSON.stringify(data, null, 2), LogLevel.Info);
 }
 
-function printAsPlainText(output: Log, data: { publishedVersions: string[] }) {
-	output.raw(`Published Versions: \n   ${data.publishedVersions.join('\n   ')}\n`, LogLevel.Info);
+function printAsPlainText(data: { publishedVersions: string[] }) {
+	console.log(`Published Versions: \n   ${data.publishedVersions.join('\n   ')}\n`, LogLevel.Info);
 }

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -236,7 +236,7 @@ export async function inspectImageInRegistry(output: Log, name: string, authToke
 	};
 
 	if (auth) {
-		headers['authorization'] = `Bearer ${auth}`;
+		headers['authorization'] = auth;
 	}
 
 	const options = {

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -25,7 +25,7 @@ import { Event } from '../spec-utils/event';
 import { Mount } from '../spec-configuration/containerFeaturesConfiguration';
 import { PackageConfiguration } from '../spec-utils/product';
 import { ImageMetadataEntry } from './imageMetadata';
-import { fetchRegistryAuthToken, getManifest, getRef, HEADERS } from '../spec-configuration/containerCollectionsOCI';
+import { fetchAuthorization, getManifest, getRef, HEADERS } from '../spec-configuration/containerCollectionsOCI';
 import { request } from '../spec-utils/httpRequest';
 
 export { getConfigFilePath, getDockerfilePath, isDockerFileConfig, resolveConfigFilePath } from '../spec-configuration/configuration';
@@ -218,7 +218,7 @@ export async function inspectImageInRegistry(output: Log, name: string, authToke
 	if (!ref) {
 		throw new Error(`Could not parse image name '${name}'`);
 	}
-	const auth = authToken ?? await fetchRegistryAuthToken(output, ref.registry, ref.path, process.env, 'pull');
+	const auth = authToken ?? await fetchAuthorization(output, ref.registry, ref.path, process.env, 'pull');
 
 	const registryServer = ref.registry === 'docker.io' ? 'registry-1.docker.io' : ref.registry;
 	const manifestUrl = `https://${registryServer}/v2/${ref.path}/manifests/${ref.version}`;

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -9,7 +9,7 @@ import ProxyAgent from 'proxy-agent';
 import * as url from 'url';
 import { Log, LogLevel } from './log';
 
-export function request(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, output?: Log, plainHTTP = false) {
+export function request(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, output?: Log) {
 	return new Promise<Buffer>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
 		const reqOptions: RequestOptions = {
@@ -20,6 +20,12 @@ export function request(options: { type: string; url: string; headers: Record<st
 			headers: options.headers,
 			agent: new ProxyAgent(),
 		};
+
+		const plainHTTP = parsed.protocol === 'http:' || parsed.hostname === 'localhost';
+		if (output) {
+			output.write('Sending as plain HTTP request', LogLevel.Warning);
+		}
+
 		const req = (plainHTTP ? http : https).request(reqOptions, res => {
 			if (res.statusCode! < 200 || res.statusCode! > 299) {
 				reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
@@ -42,7 +48,7 @@ export function request(options: { type: string; url: string; headers: Record<st
 }
 
 // HTTP HEAD request that returns status code.
-export function headRequest(options: { url: string; headers: Record<string, string> }, output?: Log, plainHTTP = false) {
+export function headRequest(options: { url: string; headers: Record<string, string> }, output?: Log) {
 	return new Promise<number>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
 		const reqOptions: RequestOptions = {
@@ -53,6 +59,11 @@ export function headRequest(options: { url: string; headers: Record<string, stri
 			headers: options.headers,
 			agent: new ProxyAgent(),
 		};
+
+		const plainHTTP = parsed.protocol === 'http:' || parsed.hostname === 'localhost';
+		if (output) {
+			output.write('Sending as plain HTTP request', LogLevel.Warning);
+		}
 
 		const req = (plainHTTP ? http : https).request(reqOptions, res => {
 			res.on('error', reject);
@@ -68,7 +79,7 @@ export function headRequest(options: { url: string; headers: Record<string, stri
 
 // Send HTTP Request.
 // Does not throw on status code, but rather always returns 'statusCode', 'resHeaders', and 'resBody'.
-export function requestResolveHeaders(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, _output?: Log, plainHTTP = false) {
+export function requestResolveHeaders(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, output?: Log) {
 	return new Promise<{ statusCode: number; resHeaders: Record<string, string>; resBody: Buffer }>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
 		const reqOptions: RequestOptions = {
@@ -79,6 +90,12 @@ export function requestResolveHeaders(options: { type: string; url: string; head
 			headers: options.headers,
 			agent: new ProxyAgent(),
 		};
+
+		const plainHTTP = parsed.protocol === 'http:' || parsed.hostname === 'localhost';
+		if (output) {
+			output.write('Sending as plain HTTP request', LogLevel.Warning);
+		}
+
 		const req = (plainHTTP ? http : https).request(reqOptions, res => {
 			res.on('error', reject);
 

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -9,7 +9,7 @@ import ProxyAgent from 'proxy-agent';
 import * as url from 'url';
 import { Log, LogLevel } from './log';
 
-export function request(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, output?: Log, plainHTTP = true) {
+export function request(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, output?: Log, plainHTTP = false) {
 	return new Promise<Buffer>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
 		const reqOptions: RequestOptions = {
@@ -42,7 +42,7 @@ export function request(options: { type: string; url: string; headers: Record<st
 }
 
 // HTTP HEAD request that returns status code.
-export function headRequest(options: { url: string; headers: Record<string, string> }, output?: Log, plainHTTP = true) {
+export function headRequest(options: { url: string; headers: Record<string, string> }, output?: Log, plainHTTP = false) {
 	return new Promise<number>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
 		const reqOptions: RequestOptions = {
@@ -68,7 +68,7 @@ export function headRequest(options: { url: string; headers: Record<string, stri
 
 // Send HTTP Request.
 // Does not throw on status code, but rather always returns 'statusCode', 'resHeaders', and 'resBody'.
-export function requestResolveHeaders(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, _output?: Log, plainHTTP = true) {
+export function requestResolveHeaders(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, _output?: Log, plainHTTP = false) {
 	return new Promise<{ statusCode: number; resHeaders: Record<string, string>; resBody: Buffer }>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
 		const reqOptions: RequestOptions = {

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -30,7 +30,7 @@ export function request(options: { type: string; url: string; headers: Record<st
 			if (res.statusCode! < 200 || res.statusCode! > 299) {
 				reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
 				if (output) {
-					output.write(`HTTP request failed with status code ${res.statusCode}: : ${res.statusMessage}`, LogLevel.Error);
+					output.write(`[-] HTTP request failed with status code ${res.statusCode}: : ${res.statusMessage}`, LogLevel.Error);
 				}
 			} else {
 				res.on('error', reject);

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -22,7 +22,7 @@ export function request(options: { type: string; url: string; headers: Record<st
 		};
 
 		const plainHTTP = parsed.protocol === 'http:' || parsed.hostname === 'localhost';
-		if (output) {
+		if (output && plainHTTP) {
 			output.write('Sending as plain HTTP request', LogLevel.Warning);
 		}
 
@@ -61,7 +61,7 @@ export function headRequest(options: { url: string; headers: Record<string, stri
 		};
 
 		const plainHTTP = parsed.protocol === 'http:' || parsed.hostname === 'localhost';
-		if (output) {
+		if (output && plainHTTP) {
 			output.write('Sending as plain HTTP request', LogLevel.Warning);
 		}
 
@@ -92,7 +92,7 @@ export function requestResolveHeaders(options: { type: string; url: string; head
 		};
 
 		const plainHTTP = parsed.protocol === 'http:' || parsed.hostname === 'localhost';
-		if (output) {
+		if (output && plainHTTP) {
 			output.write('Sending as plain HTTP request', LogLevel.Warning);
 		}
 

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -30,7 +30,7 @@ export function request(options: { type: string; url: string; headers: Record<st
 			if (res.statusCode! < 200 || res.statusCode! > 299) {
 				reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
 				if (output) {
-					output.write(`[-] HTTP request failed with status code ${res.statusCode}: : ${res.statusMessage}`, LogLevel.Error);
+					output.write(`[-] HTTP request failed with status code ${res.statusCode}: : ${res.statusMessage}`, LogLevel.Trace);
 				}
 			} else {
 				res.on('error', reject);

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -5,7 +5,7 @@ import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
 
 describe('getCollectionRef()', async function () {
-    this.timeout('120s');
+    this.timeout('240s');
 
 
     it('valid getCollectionRef()', async () => {


### PR DESCRIPTION
Exercises the `devcontainer features publish` command against the [OCI registry specification's Reference Implementation ](https://hub.docker.com/_/registry), and updates our implementation to more closely follow the specification. 

More specifically, starts a `registry` container (with hardcoded auth generated with htpasswd).

```js
const startRegistryCmd = `docker run -d -p 5000:5000 \
   -v ${resolvedTmpPath}/auth.htpasswd:/etc/docker/registry/auth.htpasswd \
   -e REGISTRY_AUTH="{htpasswd: {realm: localhost, path: /etc/docker/registry/auth.htpasswd}}" \
   --name registry \
   registry`;
```

And then executing the following `publish` command against the registry server running on localhost.

```bash
DEVCONTAINERS_OCI_AUTH='localhost:5000|myuser|mypass' ./${cli} features publish --log-level trace -r localhost:5000 -n octocat/features ${collectionFolder}/src
```

A new class of unit tests will spin up an ephemeral `registry` container and exercise the push and pull operations of our OCI distribution implementation.

### Details on changes made to support Reference Implementation

- Create a new `postUploadSessionId` for each uploaded blob layer.  Previously, a single session ID was created for each manifest, but our implementation now matches the [specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#post-then-put) where it should be generated per blob.  GHCR tolerates re-using the upload ID, but the reference implementation does not.
- Fallback to `Basic` auth if a session token cannot be fetched from the registry.  For GHCR, operations are only accepted with a valid session token from the `/session` endpoint of the registry, whereas the reference implementation talks only with Basic auth credentials.  I don't see the session auth built in the official specification, so my implementation supports both methods, only using Basic auth if the /token endpoint does not return a success code and a valid token from it's JSON response body. 
- Accurately set  the `Content-Length` header when uploading blobs, per the specification. 

#### Additional Changes
- Previously, we were reading the `.tgz` files from disk several times throughout the process. Now, the file is read from disk into a buffer one time, and the buffer is passed around.  This is more efficient.
- The `DEVCONTAINERS_OCI_AUTH` environment variable was always broken (a condition would always result to `false`).  Since there is no way this could be used by any active users (and it is not yet documented), I changed the contract a bit to include a username field, which is necessary to get this variable working with the reference implementation (GHCR ignores this field, which is why it was originally omitted). This variable is exercised in the provided test.
- More clearly surfaces error responses from the registry in logs. Errors are parsed as [JSON](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes) per the specification.
<img width="1720" alt="image" src="https://user-images.githubusercontent.com/23246594/205411770-099aa57e-eb3b-4cf4-a9fe-6dee6d9d3955.png">

- Break out existing `features info` command two new, simple commands `devcontainer info tags` and `devcontainer info manifest`.  These are useful utilities to break out for understanding published Features. They are used in the newly added test.
- The http(s) family of functions will now default to using `http` when communicating with `localhost`, or if the parsed protocol is `http`.
<img width="1457" alt="image" src="https://user-images.githubusercontent.com/23246594/205369080-2cafe15c-ba95-48db-ab80-8c9871ccc0d8.png">
