### PR TITLE
Fix issue when using custom BuildKit frontend

### DIFF
--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -272,10 +272,8 @@ async function getFeaturesBuildOptions(params: DockerResolverParameters, devCont
 		.replace('#{copyFeatureBuildStages}', getCopyFeatureBuildStages(featuresConfig, buildStageScripts))
 		.replace('#{devcontainerMetadata}', getDevcontainerMetadataLabel(imageMetadata, common.experimentalImageMetadata))
 		;
-	const syntax = imageBuildInfo.dockerfile?.preamble.directives.syntax;
 	const dockerfilePrefixContent = `${useBuildKitBuildContexts && !(imageBuildInfo.dockerfile && supportsBuildContexts(imageBuildInfo.dockerfile)) ?
-		'# syntax=docker/dockerfile:1.4' :
-		syntax ? `# syntax=${syntax}` : ''}
+		'# syntax=docker/dockerfile:1.4' : ''}
 ARG _DEV_CONTAINERS_BASE_IMAGE=placeholder
 `;
 

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -12,7 +12,6 @@ import { DevContainerConfig, DevContainerFromDockerfileConfig, DevContainerFromI
 import { LogLevel, Log, makeLog } from '../spec-utils/log';
 import { extendImage, getExtendImageBuildInfo, updateRemoteUserUID } from './containerFeatures';
 import { getDevcontainerMetadata, getImageBuildInfoFromDockerfile, getImageMetadataFromContainer, ImageMetadataEntry, mergeConfiguration, MergedDevContainerConfig } from './imageMetadata';
-import { ensureDockerfileHasFinalStageName } from './dockerfileUtils';
 
 export const hostFolderLabel = 'devcontainer.local_folder'; // used to label containers created from a workspace/folder
 
@@ -126,6 +125,7 @@ async function buildAndExtendImage(buildParams: DockerResolverParameters, config
 	const { config } = configWithRaw;
 	const dockerfileUri = getDockerfilePath(cliHost, config);
 	const dockerfilePath = await uriToWSLFsPath(dockerfileUri, cliHost);
+	const buildContextPath = await uriToWSLFsPath(getDockerContextPath(cliHost, config), cliHost)
 	if (!cliHost.isFile(dockerfilePath)) {
 		throw new ContainerError({ description: `Dockerfile (${dockerfilePath}) not found.` });
 	}
@@ -133,18 +133,26 @@ async function buildAndExtendImage(buildParams: DockerResolverParameters, config
 	let dockerfile = (await cliHost.readFile(dockerfilePath)).toString();
 	const originalDockerfile = dockerfile;
 	let baseName = 'dev_container_auto_added_stage_label';
-	if (config.build?.target) {
-		// Explictly set build target for the dev container build features on that
-		baseName = config.build.target;
-	} else {
-		// Use the last stage in the Dockerfile
-		// Find the last line that starts with "FROM" (possibly preceeded by white-space)
-		const { lastStageName, modifiedDockerfile } = ensureDockerfileHasFinalStageName(dockerfile, baseName);
-		baseName = lastStageName;
-		if (modifiedDockerfile) {
-			dockerfile = modifiedDockerfile;
+
+	const intermediateBuildAargs = ["build", "-f", dockerfilePath, "-t"];
+	let intermediateImageName = "vsc_tmp_" + cliHost.path.basename(buildContextPath);
+	intermediateBuildAargs.push(intermediateImageName);
+	intermediateBuildAargs.push(buildContextPath);
+	try {
+		if (buildParams.isTTY) {
+			const infoParams = { ...toPtyExecParameters(buildParams), output: makeLog(output, LogLevel.Info) };
+			await dockerPtyCLI(infoParams, ...intermediateBuildAargs);
+		} else {
+			const infoParams = { ...toExecParameters(buildParams), output: makeLog(output, LogLevel.Info), print: 'continuous' as 'continuous' };
+			await dockerCLI(infoParams, ...intermediateBuildAargs);
 		}
+	} catch (err) {
+		throw new ContainerError({ description: 'An error occurred building the image.', originalError: err, data: { fileWithError: dockerfilePath } });
 	}
+
+	// handle case where the intermediate image is built for a different platform than the default one
+	const { Architecture, Os } = await inspectDockerImage(buildParams, intermediateImageName, false);
+	dockerfile = `FROM --platform=${Os}/${Architecture} ${intermediateImageName} AS ${baseName}\n`;
 
 	const imageBuildInfo = await getImageBuildInfoFromDockerfile(buildParams, originalDockerfile, config.build?.args || {}, config.build?.target, configWithRaw.substitute, buildParams.common.experimentalImageMetadata);
 	const extendImageBuildInfo = await getExtendImageBuildInfo(buildParams, configWithRaw, baseName, imageBuildInfo, undefined, additionalFeatures, false);
@@ -232,7 +240,7 @@ async function buildAndExtendImage(buildParams: DockerResolverParameters, config
 		}
 	}
 	args.push(...additionalBuildArgs);
-	args.push(await uriToWSLFsPath(getDockerContextPath(cliHost, config), cliHost));
+	args.push(buildContextPath);
 	try {
 		if (buildParams.isTTY) {
 			const infoParams = { ...toPtyExecParameters(buildParams), output: makeLog(output, LogLevel.Info) };

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -250,6 +250,8 @@ export async function inspectImageInRegistry(output: Log, name: string, authToke
 	return {
 		Id: manifest.config.digest,
 		Config: obj.config,
+		Os: obj.os,
+		Architecture: obj.architecture,
 	};
 }
 

--- a/src/spec-shutdown/dockerUtils.ts
+++ b/src/spec-shutdown/dockerUtils.ts
@@ -120,6 +120,8 @@ export interface ImageDetails {
 		Entrypoint: string[] | null;
 		Cmd: string[] | null;
 	};
+	Architecture: string;
+	Os: string;
 }
 
 export async function inspectImage(params: DockerCLIParameters | PartialExecParameters | DockerResolverParameters, id: string): Promise<ImageDetails> {

--- a/src/test/dockerUtils.test.ts
+++ b/src/test/dockerUtils.test.ts
@@ -18,6 +18,8 @@ describe('Docker utils', function () {
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);
+		assert.ok(config.Architecture);
+		assert.ok(config.Os);
 	});
 
 	it('inspect image in mcr.microsoft.com', async () => {
@@ -26,6 +28,8 @@ describe('Docker utils', function () {
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);
+		assert.ok(config.Architecture);
+		assert.ok(config.Os);
 		const metadataStr = config.Config.Labels?.['devcontainer.metadata'];
 		assert.ok(metadataStr);
 		const obj = JSON.parse(metadataStr);
@@ -38,6 +42,8 @@ describe('Docker utils', function () {
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);
+		assert.ok(config.Architecture);
+		assert.ok(config.Os);
 	});
 
 	it('qualifies docker.io shorthands', async () => {

--- a/src/test/dockerfileUtils.test.ts
+++ b/src/test/dockerfileUtils.test.ts
@@ -161,7 +161,9 @@ FROM ubuntu:latest as dev
                 },
                 Entrypoint: null,
                 Cmd: null
-            }
+            },
+            Architecture: 'amd64',
+            Os: 'linux',
         };
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
@@ -187,7 +189,9 @@ USER dockerfileUserB
                 Labels: null,
                 Entrypoint: null,
                 Cmd: null
-            }
+            },
+            Architecture: 'amd64',
+            Os: 'linux',
         };
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');


### PR DESCRIPTION
resolves #6848

Changes `buildAndExtendDockerCompose` to build the user specified Dockerfile and extend the image instead of extending the Dockerfile directly

more details in https://github.com/microsoft/vscode-remote-release/issues/6848#issuecomment-1278962610
