### PR TITLE
add more detail to the output of publish commands

### DIFF
--- a/src/spec-node/featuresCLI/publish.ts
+++ b/src/spec-node/featuresCLI/publish.ts
@@ -92,7 +92,10 @@ async function featuresPublish({
 
         result = {
             ...result,
-            [f.id]: publishResult,
+            [f.id]: {
+                ...publishResult,
+                version: f.version,
+            }
         };
     }
 

--- a/src/spec-node/featuresCLI/publish.ts
+++ b/src/spec-node/featuresCLI/publish.ts
@@ -90,12 +90,14 @@ async function featuresPublish({
             process.exit(1);
         }
 
+        const thisResult = (publishResult?.digest && publishResult?.publishedVersions.length > 0) ? {
+            ...publishResult,
+            version: f.version,
+        } : {};
+
         result = {
             ...result,
-            [f.id]: {
-                ...publishResult,
-                version: f.version,
-            }
+            [f.id]: thisResult,
         };
     }
 

--- a/src/spec-node/templatesCLI/publish.ts
+++ b/src/spec-node/templatesCLI/publish.ts
@@ -93,7 +93,10 @@ async function templatesPublish({
 
         result = {
             ...result,
-            [t.id]: publishResult,
+            [t.id]: {
+                ...publishResult,
+                version: t.version,
+            }
         };
     }
 

--- a/src/spec-node/templatesCLI/publish.ts
+++ b/src/spec-node/templatesCLI/publish.ts
@@ -91,12 +91,14 @@ async function templatesPublish({
             process.exit(1);
         }
 
+        const thisResult = (publishResult?.digest && publishResult?.publishedVersions?.length > 0) ? {
+            ...publishResult,
+            version: t.version,
+        } : {};
+
         result = {
             ...result,
-            [t.id]: {
-                ...publishResult,
-                version: t.version,
-            }
+            [t.id]: thisResult,
         };
     }
 

--- a/src/test/container-features/containerFeaturesOCIPush.test.ts
+++ b/src/test/container-features/containerFeaturesOCIPush.test.ts
@@ -126,13 +126,15 @@ describe('Test OCI Push Helper Functions', () => {
 		assert.deepEqual(res, expected);
 
 		// Generate entire manifest to be able to calculate content digest
-		const { manifestStr, digest } = await calculateManifestAndContentDigest(output, res, undefined);
+		const digestContainer = await calculateManifestAndContentDigest(output, res, undefined);
+		const contentDigest = digestContainer.contentDigest;
+		const manifestStr = digestContainer.manifestStr;
 
 		// 'Expected' is taken from intermediate value in oras reference implementation, before hash calculation
 		assert.strictEqual('{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.devcontainers","digest":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","size":0},"layers":[{"mediaType":"application/vnd.devcontainers.layer.v1+tar","digest":"sha256:b2006e7647191f7b47222ae48df049c6e21a4c5a04acfad0c4ef614d819de4c5","size":15872,"annotations":{"org.opencontainers.image.title":"go.tgz"}}]}', manifestStr);
 
 		// This is the canonical digest of the manifest
-		assert.strictEqual('9726054859c13377c4c3c3c73d15065de59d0c25d61d5652576c0125f2ea8ed3', digest);
+		assert.strictEqual('9726054859c13377c4c3c3c73d15065de59d0c25d61d5652576c0125f2ea8ed3', contentDigest);
 	});
 
 	it('Can fetch an artifact from a digest reference', async () => {

--- a/src/test/container-features/featuresCLICommands.test.ts
+++ b/src/test/container-features/featuresCLICommands.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 import { isLocalFile, readLocalFile } from '../../spec-utils/pfs';
 import { ExecResult, shellExec } from '../testUtils';
-import { getSermanticVersions } from '../../spec-node/collectionCommonUtils/publishCommandImpl';
+import { getSemanticVersions } from '../../spec-node/collectionCommonUtils/publishCommandImpl';
 import { getRef, getPublishedVersions } from '../../spec-configuration/containerCollectionsOCI';
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
 
@@ -416,7 +416,7 @@ describe('test function getSermanticVersions', () => {
 		let publishedVersions: string[] = [];
 		let expectedSemVer = ['1', '1.0', '1.0.0', 'latest'];
 
-		let semanticVersions = getSermanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
@@ -425,7 +425,7 @@ describe('test function getSermanticVersions', () => {
 		let publishedVersions = ['1', '1.0', '1.0.0', 'latest'];
 		let expectedSemVer = ['1', '1.0', '1.0.1', 'latest'];
 
-		let semanticVersions = getSermanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
@@ -434,7 +434,7 @@ describe('test function getSermanticVersions', () => {
 		let publishedVersions = ['1', '1.0', '1.0.0', '1.0.1', 'latest'];
 		let expectedSemVer = ['1', '1.1', '1.1.0', 'latest'];
 
-		let semanticVersions = getSermanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
@@ -443,7 +443,7 @@ describe('test function getSermanticVersions', () => {
 		let publishedVersions = ['1', '1.0', '1.0.0', 'latest'];
 		let expectedSemVer = ['2', '2.0', '2.0.0', 'latest'];
 
-		let semanticVersions = getSermanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
@@ -452,7 +452,7 @@ describe('test function getSermanticVersions', () => {
 		let publishedVersions = ['1', '1.0', '1.0.0', '1.0.1', '1.1', '1.1.0', '2', '2.0', '2.0.0', 'latest'];
 		let expectedSemVer = ['1.0', '1.0.2'];
 
-		let semanticVersions = getSermanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
@@ -461,7 +461,7 @@ describe('test function getSermanticVersions', () => {
 		let publishedVersions = ['1', '1.0', '1.0.0', '2', '2.0', '2.0.0', 'latest'];
 		let expectedSemVer = ['1', '1.0', '1.0.1'];
 
-		let semanticVersions = getSermanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
@@ -469,7 +469,7 @@ describe('test function getSermanticVersions', () => {
 		let version = '1.0.1';
 		let publishedVersions = ['1', '1.0', '1.0.0', '1.0.1', '2', '2.0', '2.0.0', 'latest'];
 
-		let semanticVersions = getSermanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
 		assert.isUndefined(semanticVersions);
 	});
 });


### PR DESCRIPTION
Adds more detail to the result printed at the of `devcontainer features|templates publish`.  Notably, will now emit the `version` (which will be a subset of `publishVersions`) and the manifest digest of the artifact (a SHA256 hash of the manifest, which includes the contents)).

The `version` is useful for https://github.com/devcontainers/features/issues/113, and the digest seems generally useful to have moving forward.

```json
{
  "color": {
    "publishedVersions": [
      "1",
      "1.0",
      "1.0.0",
      "latest"
    ],
    "digest": "b5d0ae81ff657720ee3656c3c4c0ab3794c78bb9efb1551ebf3068b3a29632b5",
    "version": "1.0.0"
  },
  "hello": {
    "publishedVersions": [
      "1",
      "1.0",
      "1.0.0",
      "latest"
    ],
    "digest": "ba3755f8fbde068787eeb5a8377d103c983090a481f1e937e0ce60ec8996bd8a",
    "version": "1.0.0"
  }
}
```