### PR TITLE
Follow Docker Token Authentication Specification

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -55,8 +55,9 @@ jobs:
           "src/test/cli.test.ts",
           "src/test/cli.up.test.ts",
           "src/test/container-features/containerFeaturesOCIPush.test.ts",
+          "src/test/container-features/registryCompatibilityOCI.test.ts",
           # Run all except the above:
-          "--exclude src/test/container-features/containerFeaturesOCIPush.test.ts --exclude src/test/container-features/e2e.test.ts --exclude src/test/container-features/featuresCLICommands.test.ts --exclude src/test/container-features/containerFeaturesOrder.test.ts --exclude src/test/cli.build.test.ts --exclude src/test/cli.exec.buildKit.1.test.ts --exclude src/test/cli.exec.buildKit.2.test.ts --exclude src/test/cli.exec.nonBuildKit.1.test.ts --exclude src/test/cli.exec.nonBuildKit.2.test.ts --exclude src/test/cli.test.ts --exclude src/test/cli.up.test.ts 'src/test/**/*.test.ts'",
+          "--exclude src/test/container-features/registryCompatibilityOCI.test.ts --exclude src/test/container-features/containerFeaturesOCIPush.test.ts --exclude src/test/container-features/e2e.test.ts --exclude src/test/container-features/featuresCLICommands.test.ts --exclude src/test/container-features/containerFeaturesOrder.test.ts --exclude src/test/cli.build.test.ts --exclude src/test/cli.exec.buildKit.1.test.ts --exclude src/test/cli.exec.buildKit.2.test.ts --exclude src/test/cli.exec.nonBuildKit.1.test.ts --exclude src/test/cli.exec.nonBuildKit.2.test.ts --exclude src/test/cli.test.ts --exclude src/test/cli.up.test.ts 'src/test/**/*.test.ts'",
         ]
     steps:
     - name: Checkout

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -40,6 +40,7 @@ jobs:
           # "src/test/dockerUtils.test.ts",
           # "src/test/imageMetadata.test.ts",
           # "src/test/variableSubstitution.test.ts",
+          # "src/test/container-features/registryCompatibilityOCI.test.ts",
           # # Run all except the above:
           # "--exclude .....",
         ]

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -15,7 +15,7 @@ export const DEVCONTAINER_COLLECTION_LAYER_MEDIATYPE = 'application/vnd.devconta
 export interface CommonParams {
 	env: NodeJS.ProcessEnv;
 	output: Log;
-	cachedAuthHeader?: string;
+	cachedAuthHeader?: Record<string, string>; // <registry, authHeader>
 }
 
 // Represents the unique OCI identifier for a Feature or Template.

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -223,7 +223,7 @@ export async function getManifest(params: CommonParams, url: string, ref: OCIRef
 			return;
 		}
 
-		const { resBody, statusCode } = res.response;
+		const { resBody, statusCode } = res;
 		body = resBody.toString();
 
 		// NOTE: A 404 is expected here if the manifest does not exist on the remote.
@@ -262,7 +262,7 @@ export async function getPublishedVersions(params: CommonParams, ref: OCIRef, so
 			return;
 		}
 
-		const { statusCode, resBody } = res.response;
+		const { statusCode, resBody } = res;
 		const body = resBody.toString();
 
 		// Expected when publishing for the first time
@@ -319,7 +319,7 @@ export async function getBlob(params: CommonParams, url: string, ociCacheDir: st
 			return;
 		}
 
-		const { statusCode, resBody } = res.response;
+		const { statusCode, resBody } = res;
 		if (statusCode > 299) {
 			output.write(`Failed to fetch blob (${url}): ${resBody}`, LogLevel.Error);
 			return;

--- a/src/spec-configuration/containerCollectionsOCIPush.ts
+++ b/src/spec-configuration/containerCollectionsOCIPush.ts
@@ -39,8 +39,6 @@ export async function pushOCIFeatureOrTemplate(params: CommonParams, ociRef: OCI
 
 	output.write(`Generated manifest: \n${JSON.stringify(manifest?.manifestObj, undefined, 4)}`, LogLevel.Trace);
 
-	// TODO: Cache/prefetch authorization header here?
-
 	// If the exact manifest digest already exists in the registry, we don't need to push individual blobs (it's already there!) 
 	const existingManifest = await fetchOCIManifestIfExists(params, ociRef, manifest.contentDigest);
 	if (manifest.contentDigest && existingManifest) {
@@ -114,8 +112,6 @@ export async function pushCollectionMetadata(params: CommonParams, collectionRef
 		return;
 	}
 	output.write(`Generated manifest: \n${JSON.stringify(manifest?.manifestObj, undefined, 4)}`, LogLevel.Trace);
-
-	// TODO: Cache/prefetch authorization header here?
 
 	// If the exact manifest digest already exists in the registry, we don't need to push individual blobs (it's already there!) 
 	const existingManifest = await fetchOCIManifestIfExists(params, collectionRef, manifest.contentDigest);

--- a/src/spec-configuration/containerCollectionsOCIPush.ts
+++ b/src/spec-configuration/containerCollectionsOCIPush.ts
@@ -197,7 +197,7 @@ async function putManifestWithTags(params: CommonParams, manifest: ManifestConta
 
 		// Retry logic: when request fails with HTTP 429: too many requests
 		// TODO: Wrap into `requestEnsureAuthenticated`?
-		if (res.response.statusCode === 429) {
+		if (res.statusCode === 429) {
 			output.write(`Failed to PUT manifest for tag ${tag} due to too many requests. Retrying...`, LogLevel.Warning);
 			await delay(2000);
 
@@ -208,7 +208,7 @@ async function putManifestWithTags(params: CommonParams, manifest: ManifestConta
 			}
 		}
 
-		const { statusCode, resBody, resHeaders } = res.response;
+		const { statusCode, resBody, resHeaders } = res;
 
 		if (statusCode !== 201) {
 			const parsed = JSON.parse(resBody?.toString() || '{}');
@@ -264,7 +264,7 @@ async function putBlob(params: CommonParams, blobPutLocationUriPath: string, oci
 		return false;
 	}
 
-	const { statusCode, resBody } = res.response;
+	const { statusCode, resBody } = res;
 
 	if (statusCode !== 201) {
 		const parsed = JSON.parse(resBody?.toString() || '{}');
@@ -346,7 +346,7 @@ export async function checkIfBlobExists(params: CommonParams, ociRef: OCIRef | O
 		return false;
 	}
 
-	const statusCode = res.response.statusCode;
+	const statusCode = res.statusCode;
 	output.write(`${url}: ${statusCode}`, LogLevel.Trace);
 	return statusCode === 200;
 }
@@ -365,7 +365,7 @@ async function postUploadSessionId(params: CommonParams, ociRef: OCIRef | OCICol
 		return;
 	}
 
-	const { statusCode, resBody, resHeaders } = res.response;
+	const { statusCode, resBody, resHeaders } = res;
 
 	output.write(`${url}: ${statusCode}`, LogLevel.Trace);
 	if (statusCode === 202) {

--- a/src/spec-configuration/containerFeaturesOCI.ts
+++ b/src/spec-configuration/containerFeaturesOCI.ts
@@ -31,14 +31,14 @@ export function tryGetOCIFeatureSet(output: Log, identifier: string, options: bo
 	return featureSet;
 }
 
-export async function fetchOCIFeatureManifestIfExistsFromUserIdentifier(params: CommonParams, identifier: string, manifestDigest?: string, authToken?: string): Promise<OCIManifest | undefined> {
+export async function fetchOCIFeatureManifestIfExistsFromUserIdentifier(params: CommonParams, identifier: string, manifestDigest?: string): Promise<OCIManifest | undefined> {
 	const { output } = params;
 
 	const featureRef = getRef(output, identifier);
 	if (!featureRef) {
 		return undefined;
 	}
-	return await fetchOCIManifestIfExists(params, featureRef, manifestDigest, authToken);
+	return await fetchOCIManifestIfExists(params, featureRef, manifestDigest);
 }
 
 // Download a feature from which a manifest was previously downloaded.

--- a/src/spec-configuration/containerTemplatesOCI.ts
+++ b/src/spec-configuration/containerTemplatesOCI.ts
@@ -41,7 +41,7 @@ export async function fetchTemplate(params: CommonParams, selectedTemplate: Sele
 	output.write(`blob url: ${blobUrl}`, LogLevel.Trace);
 
 	const tmpDir = userProvidedTmpDir || path.join(os.tmpdir(), 'vsch-template-temp', `${Date.now()}`);
-	const blobResult = await getBlob(params, blobUrl, tmpDir, templateDestPath, templateRef, undefined, ['devcontainer-template.json', 'README.md', 'NOTES.md'], 'devcontainer-template.json');
+	const blobResult = await getBlob(params, blobUrl, tmpDir, templateDestPath, templateRef, ['devcontainer-template.json', 'README.md', 'NOTES.md'], 'devcontainer-template.json');
 
 	if (!blobResult) {
 		throw new Error(`Failed to download package for ${templateRef.resource}`);
@@ -121,14 +121,14 @@ export async function fetchTemplate(params: CommonParams, selectedTemplate: Sele
 }
 
 
-async function fetchOCITemplateManifestIfExistsFromUserIdentifier(params: CommonParams, identifier: string, manifestDigest?: string, authToken?: string): Promise<OCIManifest | undefined> {
+async function fetchOCITemplateManifestIfExistsFromUserIdentifier(params: CommonParams, identifier: string, manifestDigest?: string): Promise<OCIManifest | undefined> {
 	const { output } = params;
 
 	const templateRef = getRef(output, identifier);
 	if (!templateRef) {
 		return undefined;
 	}
-	return await fetchOCIManifestIfExists(params, templateRef, manifestDigest, authToken);
+	return await fetchOCIManifestIfExists(params, templateRef, manifestDigest);
 }
 
 function replaceTemplatedValues(output: Log, template: string, options: TemplateOptions) {

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -76,7 +76,7 @@ export async function requestEnsureAuthenticated(params: CommonParams, httpOptio
 			const wwwAuthenticateData = {
 				realm: realmGroup[1],
 				service: serviceGroup[1],
-				operationScopes: scopeGroup[1],
+				scope: scopeGroup[1],
 			};
 
 			const bearerToken = await fetchRegistryBearerToken(params, ociRef, wwwAuthenticateData);
@@ -137,10 +137,9 @@ async function getBasicAuthCredential(params: CommonParams, ociRef: OCIRef | OCI
 }
 
 // https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
-async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | OCICollectionRef, wwwAuthenticateData: { realm: string; service: string; operationScopes: string }): Promise<string | undefined> {
+async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | OCICollectionRef, wwwAuthenticateData: { realm: string; service: string; scope: string }): Promise<string | undefined> {
 	const { output } = params;
-	const { realm, service, operationScopes } = wwwAuthenticateData;
-	const { path } = ociRef;
+	const { realm, service, scope } = wwwAuthenticateData;
 
 	// TODO: Remove this.
 	if (realm.includes('mcr.microsoft.com')) {
@@ -167,7 +166,7 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 	// scope="repository:samalba/my-app:pull,push"
 	// Example:
 	// https://auth.docker.io/token?service=registry.docker.io&scope=repository:samalba/my-app:pull,push
-	const url = `${realm}?service=${service}&scope=repository:${path}:${operationScopes}`;
+	const url = `${realm}?service=${service}&scope=${scope}`;
 	output.write(`[httpOci] Attempting to fetch bearer token from:  ${url}`, LogLevel.Trace);
 
 	const options = {

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -4,104 +4,124 @@ import { CommonParams, OCICollectionRef, OCIRef } from './containerCollectionsOC
 
 export type HEADERS = { 'authorization'?: string; 'user-agent'?: string; 'content-type'?: string; 'accept'?: string; 'content-length'?: string };
 
+// WWW-Authenticate Regex
+// realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull,push"
+// realm="https://ghcr.io/token",service="ghcr.io",scope="repository:devcontainers/features:pull"
+const realmRegex = /realm="([^"]+)"/;
+const serviceRegex = /service="([^"]+)"/;
+const scopeRegex = /scope="([^"]+)"/;
+
+
 // https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate
-export async function requestEnsureAuthenticated(params: CommonParams, httpOptions: { type: string; url: string; headers: HEADERS; data?: Buffer }, ociRef: OCIRef | OCICollectionRef, existingAuthHeader?: string) {
-	const { output } = params;
-	const { registry, path } = ociRef;
+export async function requestEnsureAuthenticated(params: CommonParams, httpOptions: { type: string; url: string; headers: HEADERS; data?: Buffer }, ociRef: OCIRef | OCICollectionRef) {
+	const { output, cachedAuthHeader } = params;
 
 	// -- Update headers
 	httpOptions.headers['user-agent'] = 'devcontainer';
 	// If the user has a cached auth token, attempt to use that first.
-	if (existingAuthHeader) {
-		httpOptions.headers.authorization = existingAuthHeader;
+	if (cachedAuthHeader) {
+		output.write('[httpOci] Applying cachedAuthHeader...', LogLevel.Trace);
+		httpOptions.headers.authorization = cachedAuthHeader;
 	}
 
-	const responseAttempt = await requestResolveHeaders(httpOptions, output);
+	const initialAttemptRes = await requestResolveHeaders(httpOptions, output);
 
 	// For anything except a 401 response
 	// Simply return the original response to the caller.
-	if (responseAttempt.statusCode !== 401) {
+	if (initialAttemptRes.statusCode !== 401) {
+		output.write(`[httpOci] [${initialAttemptRes.statusCode} - Cached/NoAuth: ${httpOptions.url}]`, LogLevel.Trace);
 		return {
-			response: responseAttempt,
-			authHeader: existingAuthHeader, // Let caller cache token for use in future requests.
+			response: initialAttemptRes,
+			authHeader: cachedAuthHeader, // Let caller cache token for use in future requests.
 		};
 	}
 
 	// -- 'responseAttempt' status code was 401 at this point.
 
 	// Attempt to authenticate via WWW-Authenticate Header.
-	const wwwAuthenticate = responseAttempt.resHeaders['WWW-Authenticate'] || responseAttempt.resHeaders['www-authenticate'];
-	if (wwwAuthenticate) {
-		output.write('Attempting to authenticate via WWW-Athenticate header.', LogLevel.Trace);
+	const wwwAuthenticate = initialAttemptRes.resHeaders['WWW-Authenticate'] || initialAttemptRes.resHeaders['www-authenticate'];
+	if (!wwwAuthenticate) {
+		output.write(`[httpOci] ERR: Server did not provide instructions to authentiate! (Required: A 'WWW-Authenticate' Header)`, LogLevel.Error);
+		return;
+	}
 
-		// Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull,push"
-		const wwwAuthenticateParts = wwwAuthenticate.split(' ');
-		if (wwwAuthenticateParts[0] === 'Bearer') {
-			const wwwAuthenticateData = {
-				realm: wwwAuthenticateParts[1].split('=')[1],
-				service: wwwAuthenticateParts[2].split('=')[1],
-				operationScopes: wwwAuthenticateParts[3].split('=')[1],
-			};
-			const bearerToken = await fetchRegistryBearerToken(params, path, wwwAuthenticateData);
-			if (bearerToken) {
-				httpOptions.headers.authorization = `Bearer ${bearerToken}`;
-				const responseWithBearerToken = await requestResolveHeaders(httpOptions, output);
-				if (responseWithBearerToken.statusCode === 401) {
-					// Provided token was not valid.
-					output.write('401 while attempting to authenticate via WWW-Athenticate header.', LogLevel.Trace);
-					return;
-				}
-				return {
-					response: responseWithBearerToken,
-					authHeader: `Bearer ${bearerToken}`, // Let caller cache token for use in future requests.
-				};
+	switch (wwwAuthenticate.split(' ')[0]) {
+		// Basic realm="localhost"
+		case 'Basic':
+
+			output.write(`[httpOci] Attempting to authenticate via 'Basic' auth.`, LogLevel.Trace);
+
+			const basicAuthCredential = await getBasicAuthCredential(params, ociRef);
+			if (!basicAuthCredential) {
+				output.write(`[httpOci] ERR: No basic auth credentials to send for registry service '${ociRef.registry}'`, LogLevel.Error);
 			}
-		}
-	}
 
-	// No WWW-Authenticate Header + 401 from server.
-	// Fall back attempting the request with Basic auth.
-	const basicAuthCredential = await getBasicAuthCredential(params, registry, path);
-	if (basicAuthCredential) {
-		output.write('Attempting to authenticate with Basic Auth Credentials', LogLevel.Trace);
+			httpOptions.headers.authorization = `Basic ${basicAuthCredential}`;
+			break;
 
-		httpOptions.headers.authorization = `Basic ${basicAuthCredential}`;
-		const responseWithBasicAuth = await requestResolveHeaders(httpOptions, output);
-		if (responseWithBasicAuth.statusCode === 401) {
-			// Provided token was not valid.
-			output.write('401 while attempting to with Basic Auth credentials.', LogLevel.Trace);
+		// Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull,push"
+		case 'Bearer':
+
+			output.write(`[httpOci] Attempting to authenticate via 'Bearer' auth.`, LogLevel.Trace);
+
+			const realmGroup = realmRegex.exec(wwwAuthenticate);
+			const serviceGroup = serviceRegex.exec(wwwAuthenticate);
+			const scopeGroup = scopeRegex.exec(wwwAuthenticate);
+
+			if (!realmGroup || !serviceGroup || !scopeGroup) {
+				output.write(`[httpOci] WWW-Authenticate header is not in expected format. Got:  ${wwwAuthenticate}`, LogLevel.Trace);
+				return;
+			}
+
+			const wwwAuthenticateData = {
+				realm: realmGroup[1],
+				service: serviceGroup[1],
+				operationScopes: scopeGroup[1],
+			};
+
+			const bearerToken = await fetchRegistryBearerToken(params, ociRef, wwwAuthenticateData);
+			if (!bearerToken) {
+				output.write(`[httpOci] ERR: Failed to fetch Bearer token from registry.`, LogLevel.Error);
+				return;
+			}
+
+			httpOptions.headers.authorization = `Bearer ${bearerToken}`;
+			break;
+
+		default:
+			output.write(`[httpOci] ERR: Unsupported authentication mode '${wwwAuthenticate.split(' ')[0]}'`, LogLevel.Error);
 			return;
-		}
-		return {
-			response: responseWithBasicAuth,
-			authHeader: `Basic ${basicAuthCredential}`, // Let caller cache token for use in future requests.
-		};
 	}
 
-	// Reauthenticating failed
-	output.write('Failed to send an authenticated request to registry.', LogLevel.Trace);
-	return;
+	// Retry the request with the updated authorization header.
+	const reattemptRes = await requestResolveHeaders(httpOptions, output);
+	output.write(`[httpOci] ${reattemptRes.statusCode} on reattempt after auth: ${httpOptions.url}`, LogLevel.Trace);
+	return {
+		response: reattemptRes,
+		authHeader: reattemptRes.statusCode !== 401 ? httpOptions.headers.authorization : undefined, // Let caller cache token for use in future requests.
+	};
 }
 
 // Attempts to get the Basic auth credentials for the provided registry.
 // These may be programatically crafted via environment variables (GITHUB_TOKEN),
 // parsed out of a special DEVCONTAINERS_OCI_AUTH environment variable,
-async function getBasicAuthCredential(params: CommonParams, realm: string, service: string): Promise<string | undefined> {
+async function getBasicAuthCredential(params: CommonParams, ociRef: OCIRef | OCICollectionRef): Promise<string | undefined> {
 	const { output, env } = params;
+	const { registry } = ociRef;
 
 	// TODO: Directly read out of the local docker config file/credential helper.
 
 	let userToken: string | undefined = undefined;
-	if (!!env['GITHUB_TOKEN'] && service === 'ghcr.io' && realm.startsWith('https://ghcr.io/')) {
-		output.write('Using environment GITHUB_TOKEN for auth', LogLevel.Trace);
+	if (!!env['GITHUB_TOKEN'] && registry === 'ghcr.io') {
+		output.write('[httpOci] Using environment GITHUB_TOKEN for auth', LogLevel.Trace);
 		userToken = `USERNAME:${env['GITHUB_TOKEN']}`;
 	} else if (!!env['DEVCONTAINERS_OCI_AUTH']) {
-		// eg: DEVCONTAINERS_OCI_AUTH=realm1|user1|token1,realm2|user2|token2
+		// eg: DEVCONTAINERS_OCI_AUTH=service1|user1|token1,service2|user2|token2
 		const authContexts = env['DEVCONTAINERS_OCI_AUTH'].split(',');
-		const authContext = authContexts.find(a => a.split('|')[0] === service);
+		const authContext = authContexts.find(a => a.split('|')[0] === registry);
 
 		if (authContext) {
-			output.write(`Using match from DEVCONTAINERS_OCI_AUTH for realm '${service}'`, LogLevel.Trace);
+			output.write(`[httpOci] Using match from DEVCONTAINERS_OCI_AUTH for registry '${registry}'`, LogLevel.Trace);
 			const split = authContext.split('|');
 			userToken = `${split[1]}:${split[2]}`;
 		}
@@ -112,14 +132,15 @@ async function getBasicAuthCredential(params: CommonParams, realm: string, servi
 	}
 
 	// Represents anonymous access.
-	output.write(`No authentication credentials found for realm '${realm}'.`, LogLevel.Trace);
+	output.write(`[httpOci] No authentication credentials found for registry='${registry}'.`, LogLevel.Trace);
 	return undefined;
 }
 
 // https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
-async function fetchRegistryBearerToken(params: CommonParams, ociRepoPath: string, wwwAuthenticateData: { realm: string; service: string; operationScopes: string }): Promise<string | undefined> {
+async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | OCICollectionRef, wwwAuthenticateData: { realm: string; service: string; operationScopes: string }): Promise<string | undefined> {
 	const { output } = params;
 	const { realm, service, operationScopes } = wwwAuthenticateData;
+	const { path } = ociRef;
 
 	// TODO: Remove this.
 	if (realm.includes('mcr.microsoft.com')) {
@@ -136,7 +157,7 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRepoPath: strin
 	// If an attempt to authenticate to the token server fails, the token server should return a 401 Unauthorized response 
 	// indicating that the provided credentials are invalid.
 	// > https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
-	const basicAuthTokenBase64 = await getBasicAuthCredential(params, realm, service);
+	const basicAuthTokenBase64 = await getBasicAuthCredential(params, ociRef);
 	if (basicAuthTokenBase64) {
 		headers['authorization'] = `Basic ${basicAuthTokenBase64}`;
 	}
@@ -146,8 +167,8 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRepoPath: strin
 	// scope="repository:samalba/my-app:pull,push"
 	// Example:
 	// https://auth.docker.io/token?service=registry.docker.io&scope=repository:samalba/my-app:pull,push
-	const url = `${realm}?service=${service}&scope=repository:${ociRepoPath}:${operationScopes}`;
-	output.write(`Attempting to fetch bearer token from:  ${url}`, LogLevel.Trace);
+	const url = `${realm}?service=${service}&scope=repository:${path}:${operationScopes}`;
+	output.write(`[httpOci] Attempting to fetch bearer token from:  ${url}`, LogLevel.Trace);
 
 	const options = {
 		type: 'GET',
@@ -160,12 +181,12 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRepoPath: strin
 		authReq = await request(options, output);
 	} catch (e: any) {
 		// This is ok if the registry is trying to speak Basic Auth with us.
-		output.write(`Could not fetch bearer token for '${service}': ${e}`, LogLevel.Error);
+		output.write(`[httpOci] Could not fetch bearer token for '${service}': ${e}`, LogLevel.Error);
 		return;
 	}
 
 	if (!authReq) {
-		output.write(`Did not receive bearer token for '${service}'`, LogLevel.Error);
+		output.write(`[httpOci] Did not receive bearer token for '${service}'`, LogLevel.Error);
 		return;
 	}
 
@@ -176,7 +197,7 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRepoPath: strin
 		// not JSON
 	}
 	if (!scopeToken) {
-		output.write(`Unexpected bearer token response format for '${service}'`, LogLevel.Error);
+		output.write(`[httpOci] Unexpected bearer token response format for '${service}'`, LogLevel.Error);
 		return;
 	}
 

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -1,5 +1,5 @@
 import { request, requestResolveHeaders } from '../spec-utils/httpRequest';
-import { Log, LogLevel } from '../spec-utils/log';
+import { LogLevel } from '../spec-utils/log';
 import { CommonParams } from './containerCollectionsOCI';
 
 export type HEADERS = { 'authorization'?: string; 'user-agent': string; 'content-type'?: string; 'accept'?: string; 'content-length'?: string };
@@ -43,6 +43,7 @@ export async function requestEnsureAuthenticated(params: CommonParams, registry:
 				const responseWithBearerToken = await requestResolveHeaders(httpOptions, output);
 				if (responseWithBearerToken.statusCode === 401) {
 					// Provided token was not valid.
+					output.write('401 while attempting to authenticate via WWW-Athenticate header.', LogLevel.Trace);
 					return;
 				}
 				return {
@@ -63,6 +64,7 @@ export async function requestEnsureAuthenticated(params: CommonParams, registry:
 		const responseWithBasicAuth = await requestResolveHeaders(httpOptions, output);
 		if (responseWithBasicAuth.statusCode === 401) {
 			// Provided token was not valid.
+			output.write('401 while attempting to with Basic Auth credentials.', LogLevel.Trace);
 			return;
 		}
 		return {
@@ -72,6 +74,7 @@ export async function requestEnsureAuthenticated(params: CommonParams, registry:
 	}
 
 	// Reauthenticating failed
+	output.write('Failed to send an authenticated request to registry.', LogLevel.Trace);
 	return;
 }
 

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -1,0 +1,163 @@
+import { request, requestResolveHeaders } from '../spec-utils/httpRequest';
+import { Log, LogLevel } from '../spec-utils/log';
+import { CommonParams } from './containerCollectionsOCI';
+
+export type HEADERS = { 'authorization'?: string; 'user-agent': string; 'content-type'?: string; 'accept'?: string; 'content-length'?: string };
+
+// https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate
+export async function requestEnsureAuthenticated(params: CommonParams, registry: string, ociRepoPath: string, httpOptions: { type: string; url: string; headers: HEADERS; data?: Buffer }, existingAuthHeader?: string) {
+	const { output } = params;
+
+	if (existingAuthHeader) {
+		httpOptions.headers.authorization = existingAuthHeader;
+	}
+
+	const responseAttempt = await requestResolveHeaders(httpOptions, output);
+
+	// Per the specification, on 401 retry the request after 
+	// fetching a Bearer token for the appropriate realm provided at the 'WWW-Authenticate' header.
+	if (responseAttempt.statusCode === 401) {
+		const wwwAuthenticate = responseAttempt.resHeaders['www-authenticate'];
+		if (wwwAuthenticate) {
+			// Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull,push"
+			const wwwAuthenticateParts = wwwAuthenticate.split(' ');
+			if (wwwAuthenticateParts[0] === 'Bearer') {
+				const realm = wwwAuthenticateParts[1].split('=')[1];
+				const service = wwwAuthenticateParts[2].split('=')[1];
+				const scope = wwwAuthenticateParts[3].split('=')[1];
+				const bearerToken = await fetchRegistryBearerToken(params, ociRepoPath, realm, service, scope);
+				if (bearerToken) {
+					httpOptions.headers.authorization = `Bearer ${bearerToken}`;
+					const responseWithBearerToken = await requestResolveHeaders(httpOptions, output);
+					if (responseWithBearerToken.statusCode === 401) {
+						// Provided token was not valid.
+						return;
+					}
+					return {
+						response: responseWithBearerToken,
+						authHeader: `Bearer ${bearerToken}`, // Cache token for use in future requests.
+					};
+				}
+			}
+		}
+		// Fall back attempting the request with Basic auth.
+		const basicAuthCredential = await getBasicAuthCredential(params, registry, ociRepoPath);
+		if (basicAuthCredential) {
+			httpOptions.headers.authorization = `Basic ${basicAuthCredential}`;
+			const responseWithBasicAuth = await requestResolveHeaders(httpOptions, output);
+			if (responseWithBasicAuth.statusCode === 401) {
+				// Provided token was not valid.
+				return;
+			}
+			return {
+				response: responseWithBasicAuth,
+				authHeader: `Basic ${basicAuthCredential}`, // Cache token for use in future requests.
+			};
+		}
+	} else {
+		// Return the original response.
+		return {
+			response: responseAttempt,
+			authHeader: existingAuthHeader, // Cache token for use in future requests.
+		};
+	}
+
+	// Failure to authenticate after a 401.
+	// Likely, the registry does not support WWW-Authenticate challenges.
+	return;
+}
+
+
+// Attempts to get the Basic auth credentials for the provided registry.
+// These may be programatically crafted via environment variables (GITHUB_TOKEN),
+// parsed out of a special DEVCONTAINERS_OCI_AUTH environment variable,
+// TODO: or directly read out of the local docker config file/credential helper.
+async function getBasicAuthCredential(params: CommonParams, realm: string, service: string): Promise<string | undefined> {
+	const { output, env } = params;
+
+	let userToken: string | undefined = undefined;
+	if (!!env['GITHUB_TOKEN'] && service === 'ghcr.io' && realm.startsWith('https://ghcr.io/')) {
+		output.write('Using environment GITHUB_TOKEN for auth', LogLevel.Trace);
+		userToken = `USERNAME:${env['GITHUB_TOKEN']}`;
+	} else if (!!env['DEVCONTAINERS_OCI_AUTH']) {
+		// eg: DEVCONTAINERS_OCI_AUTH=realm1|user1|token1,realm2|user2|token2
+		const authContexts = env['DEVCONTAINERS_OCI_AUTH'].split(',');
+		const authContext = authContexts.find(a => a.split('|')[0] === service);
+
+		if (authContext) {
+			output.write(`Using match from DEVCONTAINERS_OCI_AUTH for realm '${service}'`, LogLevel.Trace);
+			const split = authContext.split('|');
+			userToken = `${split[1]}:${split[2]}`;
+		}
+	}
+
+	if (userToken) {
+		return Buffer.from(userToken).toString('base64');
+	}
+
+	// Represents anonymous access.
+	output.write(`No authentication credentials found for realm '${realm}'.`, LogLevel.Warning);
+	return undefined;
+}
+
+// https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
+async function fetchRegistryBearerToken(params: CommonParams, ociRepoPath: string, realm: string, service: string, operationScopes: string): Promise<string | undefined> {
+	const { output } = params;
+
+	// TODO: Remove this.
+	if (realm.includes('mcr.microsoft.com')) {
+		return undefined;
+	}
+
+	const headers: HEADERS = {
+		'user-agent': 'devcontainer'
+	};
+
+	// The token server should first attempt to authenticate the client using any authentication credentials provided with the request.
+	// From Docker 1.11 the Docker engine supports both Basic Authentication and OAuth2 for getting tokens. 
+	// Docker 1.10 and before, the registry client in the Docker Engine only supports Basic Authentication. 
+	// If an attempt to authenticate to the token server fails, the token server should return a 401 Unauthorized response 
+	// indicating that the provided credentials are invalid.
+	// > https://docs.docker.com/registry/spec/auth/token/#requesting-a-token
+	const basicAuthTokenBase64 = await getBasicAuthCredential(params, realm, service);
+	if (basicAuthTokenBase64) {
+		headers['authorization'] = `Basic ${basicAuthTokenBase64}`;
+	}
+
+	// realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull,push"
+	// https://auth.docker.io/token?service=registry.docker.io&scope=repository:samalba/my-app:pull,push
+	const url = `${realm}?service=${service}&scope=repository:${ociRepoPath}:${operationScopes}`;
+	output.write(`Fetching scope token from: ${url}`, LogLevel.Trace);
+
+	const options = {
+		type: 'GET',
+		url: url,
+		headers: headers
+	};
+
+	let authReq: Buffer;
+	try {
+		authReq = await request(options, output);
+	} catch (e: any) {
+		// This is ok if the registry is trying to speak Basic Auth with us.
+		output.write(`Not used a scoped token for ${service}: ${e}`, LogLevel.Trace);
+		return;
+	}
+
+	if (!authReq) {
+		output.write('Failed to get registry auth token', LogLevel.Error);
+		return undefined;
+	}
+
+	let scopeToken: string | undefined;
+	try {
+		scopeToken = JSON.parse(authReq.toString())?.token;
+	} catch {
+		// not JSON
+	}
+	if (!scopeToken) {
+		output.write('Failed to parse registry auth token response', LogLevel.Error);
+		return undefined;
+	}
+	return scopeToken;
+}

--- a/src/spec-node/featuresCLI/infoManifest.ts
+++ b/src/spec-node/featuresCLI/infoManifest.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { fetchAuthorizationHeader, fetchOCIManifestIfExists, getRef } from '../../spec-configuration/containerCollectionsOCI';
+import { fetchOCIManifestIfExists, getRef } from '../../spec-configuration/containerCollectionsOCI';
 import { mapLogLevel } from '../../spec-utils/log';
 import { getPackageConfig } from '../../spec-utils/product';
 import { createLog } from '../devContainers';
@@ -44,8 +44,8 @@ async function featuresInfoManifest({
 	if (!featureRef) {
 		return undefined;
 	}
-	const authorization = await fetchAuthorizationHeader(params, featureRef.registry, featureRef.path, 'pull');
-	const manifest = await fetchOCIManifestIfExists(params, featureRef, undefined, authorization);
+
+	const manifest = await fetchOCIManifestIfExists(params, featureRef, undefined);
 
 	console.log(JSON.stringify(manifest, undefined, 4));
 	await dispose();

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -242,7 +242,7 @@ export async function inspectImageInRegistry(output: Log, name: string): Promise
 	if (!res) {
 		throw new Error(`Failed to fetch blob for ${resourceAndVersion}.`);
 	}
-	const blob = res.response.resBody.toString();
+	const blob = res.resBody.toString();
 	const obj = JSON.parse(blob);
 	return {
 		Id: manifest.config.digest,

--- a/src/test/container-features/configs/azure-container-registry/.devcontainer.json
+++ b/src/test/container-features/configs/azure-container-registry/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"devcontainercli.azurecr.io/features/color:1": {
+			"favorite": "pink"
+		}
+	}
+}

--- a/src/test/container-features/containerFeaturesOCIPush.test.ts
+++ b/src/test/container-features/containerFeaturesOCIPush.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { fetchAuthorizationHeader, DEVCONTAINER_TAR_LAYER_MEDIATYPE, getRef } from '../../spec-configuration/containerCollectionsOCI';
+import { DEVCONTAINER_TAR_LAYER_MEDIATYPE, getRef } from '../../spec-configuration/containerCollectionsOCI';
 import { fetchOCIFeatureManifestIfExistsFromUserIdentifier } from '../../spec-configuration/containerFeaturesOCI';
 import { calculateDataLayer, checkIfBlobExists, calculateManifestAndContentDigest } from '../../spec-configuration/containerCollectionsOCIPush';
 import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
@@ -346,19 +346,15 @@ describe('Test OCI Push Helper Functions', () => {
 		if (!ociFeatureRef) {
 			assert.fail('getRef() for the Feature should not be undefined');
 		}
-		const { registry, resource } = ociFeatureRef;
-		const sessionAuth = await fetchAuthorizationHeader({ output, env: process.env }, registry, resource, 'pull');
-		if (!sessionAuth) {
-			assert.fail('Could not get registry auth token');
-		}
 
-		const tarLayerBlobExists = await checkIfBlobExists(output, ociFeatureRef, 'sha256:b2006e7647191f7b47222ae48df049c6e21a4c5a04acfad0c4ef614d819de4c5', sessionAuth);
+
+		const tarLayerBlobExists = await checkIfBlobExists({ output, env: process.env }, ociFeatureRef, 'sha256:b2006e7647191f7b47222ae48df049c6e21a4c5a04acfad0c4ef614d819de4c5');
 		assert.isTrue(tarLayerBlobExists);
 
-		const configLayerBlobExists = await checkIfBlobExists(output, ociFeatureRef, 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', sessionAuth);
+		const configLayerBlobExists = await checkIfBlobExists({ output, env: process.env }, ociFeatureRef, 'sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
 		assert.isTrue(configLayerBlobExists);
 
-		const randomStringDoesNotExist = await checkIfBlobExists(output, ociFeatureRef, 'sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3', sessionAuth);
+		const randomStringDoesNotExist = await checkIfBlobExists({ output, env: process.env }, ociFeatureRef, 'sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3');
 		assert.isFalse(randomStringDoesNotExist);
 	});
 });

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -41,7 +41,6 @@ describe('Registry Compatibility', function () {
 
 		describe(`devcontainer features info manifest`, async () => {
 
-
 			it('fetches manifest anonymously from ACR', async () => {
 
 				let infoManifestResult: { stdout: string; stderr: string } | null = null;

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -21,6 +21,7 @@ describe('Registry Compatibility', function () {
 		await shellExec(`npm --prefix ${tmp} install devcontainers-cli-${pkg.version}.tgz`);
 	});
 
+	// TODO: Matrix this test against all tested registries)
 	describe('Azure Container Registry', () => {
 
 		describe(`'devcontainer up' with a Feature anonymously pulled from ACR`, () => {

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -21,7 +21,7 @@ describe('Registry Compatibility', function () {
 		await shellExec(`npm --prefix ${tmp} install devcontainers-cli-${pkg.version}.tgz`);
 	});
 
-	// TODO: Matrix this test against all tested registries)
+	// TODO: Matrix this test against all tested registries
 	describe('Azure Container Registry', () => {
 
 		describe(`'devcontainer up' with a Feature anonymously pulled from ACR`, () => {

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { assert } from 'chai';
+import * as path from 'path';
+import { devContainerDown, devContainerUp, shellExec } from '../testUtils';
+
+const pkg = require('../../../package.json');
+
+describe('Registry Compatibility', function () {
+	this.timeout('120s');
+
+	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
+	const cli = `npx --prefix ${tmp} devcontainer`;
+
+	before('Install', async () => {
+		await shellExec(`rm -rf ${tmp}/node_modules`);
+		await shellExec(`mkdir -p ${tmp}`);
+		await shellExec(`npm --prefix ${tmp} install devcontainers-cli-${pkg.version}.tgz`);
+	});
+
+	describe('Azure Container Registry', () => {
+
+		describe(`'devcontainer up' with a Feature anonymously pulled from ACR`, () => {
+			let containerId: string | null = null;
+			const testFolder = `${__dirname}/configs/azure-container-registry`;
+
+			before(async () => containerId = (await devContainerUp(cli, testFolder, { 'logLevel': 'trace' })).containerId);
+			after(async () => await devContainerDown({ containerId }));
+
+			it('should exec the color command', async () => {
+				const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} color`);
+				const response = JSON.parse(res.stdout);
+				console.log(res.stderr);
+				assert.equal(response.outcome, 'success');
+				assert.match(res.stderr, /my favorite color is pink/);
+			});
+		});
+
+		describe(`devcontainer features info manifest`, async () => {
+
+
+			it('fetches manifest anonymously from ACR', async () => {
+
+				let infoManifestResult: { stdout: string; stderr: string } | null = null;
+				let success = false;
+				try {
+					infoManifestResult = await shellExec(`${cli} features info manifest devcontainercli.azurecr.io/features/hello --log-level trace`);
+					success = true;
+				} catch (error) {
+					assert.fail('features info tags sub-command should not throw');
+				}
+
+				assert.isTrue(success);
+				assert.isDefined(infoManifestResult);
+				const manifest = infoManifestResult.stdout;
+				const regex = /application\/vnd\.devcontainers\.layer\.v1\+tar/;
+				assert.match(manifest, regex);
+			});
+		});
+	});
+
+});


### PR DESCRIPTION
ref: https://github.com/devcontainers/cli/issues/322

Implements the [Docker Registry v2 authentication via central service specification](https://docs.docker.com/registry/spec/auth/token/) to improve compatibility with registry services.  While not officially part of the distribution specification, this specification is widely used by various container registries.  This change has been tested with Azure Container Registry (acr) and GitHub Container Registry (ghcr). 

As outlined in the spec, requests will initially be made to a registry without any authentication.  If authentication is required by the server, a `401` response will be set and the `WWW-Authenticate` header will be set with information on how to exchange for a bearer token for the given resource, as well as which scopes to request.  


```
realm="https://ghcr.io/token",service="ghcr.io",scope="repository:devcontainers/features:pull,push"
```

Registries like GHCR and ACR require this token exchange even for anonymous access (pulling a public artifact).



This PR wraps all pulling and pushing HTTP operations in `requestEnsureAuthenticated(...)`, which will read the `WWW-Authenticate` header on `401` and attempt to negotiate a token with the server.  The last token to be successfully used will be cached and first attempted on subsequent requests.

This implementation supports exchanging for a Bearer token (as described in the linked specification from Docker), as well as setting the authentication header with Basic auth credentials (as expected by the `registry/registry` reference implementation

Additionally, this PR will now attempt to read the `$HOME/.docker/config.json` file on disk (if one exists) and will share these with the registry server to get a more privileged Bearer token.  By following [the 'Authenticate using token' steps on the Azure Container Registry Docs](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions#authenticate-using-token), one will be able to both publish and pull from an ACR that requires authentication. The existing `DEVCONTAINERS_OCI_AUTH` environment variable is still supported, and is preferred over reading the home folder config.json.  For `GHCR`, the environment's `GITHUB_TOKEN` is always preferred.

A test has been added to validate that anonymously pulling a Feature from ACR works end to end.  That Feature was pushed to ACR via the changes in this PR.

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/23246594/210026934-a3f63477-714d-4325-9b99-75bafaf194d8.png">
