### PR TITLE
increase test timeouts

### DIFF
--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -12,7 +12,7 @@ import { buildKitOptions, shellExec } from './testUtils';
 const pkg = require('../../package.json');
 
 describe('Dev Containers CLI', function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -12,7 +12,7 @@ import { buildKitOptions, shellExec } from './testUtils';
 const pkg = require('../../package.json');
 
 describe('Dev Containers CLI', function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/cli.exec.base.ts
+++ b/src/test/cli.exec.base.ts
@@ -148,7 +148,7 @@ export function describeTests1({ text, options }: BuildKitOption) {
 export function describeTests2({ text, options }: BuildKitOption) {
 
 	describe('Dev Containers CLI', function () {
-		this.timeout('150s');
+		this.timeout('240s');
 
 		const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 		const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/cli.exec.base.ts
+++ b/src/test/cli.exec.base.ts
@@ -148,7 +148,7 @@ export function describeTests1({ text, options }: BuildKitOption) {
 export function describeTests2({ text, options }: BuildKitOption) {
 
 	describe('Dev Containers CLI', function () {
-		this.timeout('240s');
+		this.timeout('150s');
 
 		const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 		const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -10,7 +10,7 @@ import { devContainerDown, devContainerUp, shellExec } from './testUtils';
 const pkg = require('../../package.json');
 
 describe('Dev Containers CLI', function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -10,7 +10,7 @@ import { devContainerDown, devContainerUp, shellExec } from './testUtils';
 const pkg = require('../../package.json');
 
 describe('Dev Containers CLI', function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/cli.up.test.ts
+++ b/src/test/cli.up.test.ts
@@ -12,7 +12,7 @@ import { devContainerDown, devContainerUp, shellExec, UpResult } from './testUti
 const pkg = require('../../package.json');
 
 describe('Dev Containers CLI', function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/cli.up.test.ts
+++ b/src/test/cli.up.test.ts
@@ -12,7 +12,7 @@ import { devContainerDown, devContainerUp, shellExec, UpResult } from './testUti
 const pkg = require('../../package.json');
 
 describe('Dev Containers CLI', function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -5,7 +5,7 @@ import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
 
 describe('getCollectionRef()', async function () {
-    this.timeout('150s');
+    this.timeout('240s');
 
 
     it('valid getCollectionRef()', async () => {

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -57,7 +57,7 @@ describe('getCollectionRef()', async function () {
 });
 
 describe('getRef()', async function () {
-    this.timeout('120s');
+    this.timeout('240s');
 
     it('valid getRef() with a tag', async () => {
         const feat = getRef(output, 'ghcr.io/devcontainers/templates/docker-from-docker:latest');

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -5,7 +5,7 @@ import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
 
 describe('getCollectionRef()', async function () {
-    this.timeout('240s');
+    this.timeout('150s');
 
 
     it('valid getCollectionRef()', async () => {
@@ -57,7 +57,7 @@ describe('getCollectionRef()', async function () {
 });
 
 describe('getRef()', async function () {
-    this.timeout('240s');
+    this.timeout('150s');
 
     it('valid getRef() with a tag', async () => {
         const feat = getRef(output, 'ghcr.io/devcontainers/templates/docker-from-docker:latest');

--- a/src/test/container-features/containerFeaturesOCIPush.test.ts
+++ b/src/test/container-features/containerFeaturesOCIPush.test.ts
@@ -22,7 +22,7 @@ interface PublishResult {
 }
 
 describe('Test OCI Push against reference registry', async function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp', Date.now().toString()));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/container-features/e2e.test.ts
+++ b/src/test/container-features/e2e.test.ts
@@ -11,7 +11,7 @@ import { devContainerDown, devContainerUp, shellExec } from '../testUtils';
 const pkg = require('../../../package.json');
 
 describe('Dev Container Features E2E (remote)', function () {
-    this.timeout('240s');
+    this.timeout('150s');
 
     const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
     const cli = `npx --prefix ${tmp} devcontainer`;
@@ -114,7 +114,7 @@ describe('Dev Container Features E2E (remote)', function () {
 });
 
 describe('Dev Container Features E2E - local cache/short-hand notation', function () {
-    this.timeout('240s');
+    this.timeout('150s');
 
     const tmp = path.resolve(process.cwd(), path.join(__dirname, 'tmp3'));
     const cli = `npx --prefix ${tmp} devcontainer`;
@@ -143,7 +143,7 @@ describe('Dev Container Features E2E - local cache/short-hand notation', functio
 
 
 describe('Dev Container Features E2E (local-path)', function () {
-    this.timeout('240s');
+    this.timeout('150s');
 
     const tmp = path.resolve(process.cwd(), path.join(__dirname, 'tmp1'));
     const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/container-features/e2e.test.ts
+++ b/src/test/container-features/e2e.test.ts
@@ -11,7 +11,7 @@ import { devContainerDown, devContainerUp, shellExec } from '../testUtils';
 const pkg = require('../../../package.json');
 
 describe('Dev Container Features E2E (remote)', function () {
-    this.timeout('120s');
+    this.timeout('240s');
 
     const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
     const cli = `npx --prefix ${tmp} devcontainer`;
@@ -143,7 +143,7 @@ describe('Dev Container Features E2E - local cache/short-hand notation', functio
 
 
 describe('Dev Container Features E2E (local-path)', function () {
-    this.timeout('120s');
+    this.timeout('240s');
 
     const tmp = path.resolve(process.cwd(), path.join(__dirname, 'tmp1'));
     const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/container-features/featuresCLICommands.test.ts
+++ b/src/test/container-features/featuresCLICommands.test.ts
@@ -10,7 +10,7 @@ export const output = makeLog(createPlainLog(text => process.stdout.write(text),
 const pkg = require('../../../package.json');
 
 describe('CLI features subcommands', async function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp2'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -10,7 +10,7 @@ import { devContainerDown, devContainerUp, shellExec } from '../testUtils';
 const pkg = require('../../../package.json');
 
 describe('Registry Compatibility', function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -10,7 +10,7 @@ import { devContainerDown, devContainerUp, shellExec } from '../testUtils';
 const pkg = require('../../../package.json');
 
 describe('Registry Compatibility', function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/container-templates/containerTemplatesOCI.test.ts
+++ b/src/test/container-templates/containerTemplatesOCI.test.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { readLocalFile } from '../../spec-utils/pfs';
 
 describe('fetchTemplate', async function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	it('template apply docker-from-docker without features and with user options', async () => {
 

--- a/src/test/container-templates/containerTemplatesOCI.test.ts
+++ b/src/test/container-templates/containerTemplatesOCI.test.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { readLocalFile } from '../../spec-utils/pfs';
 
 describe('fetchTemplate', async function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	it('template apply docker-from-docker without features and with user options', async () => {
 

--- a/src/test/container-templates/templatesCLICommands.test.ts
+++ b/src/test/container-templates/templatesCLICommands.test.ts
@@ -14,7 +14,7 @@ export const output = makeLog(createPlainLog(text => process.stderr.write(text),
 const pkg = require('../../../package.json');
 
 describe('tests apply command', async function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp4'));
 	const cli = `npx --prefix ${tmp} devcontainer`;
@@ -64,7 +64,7 @@ describe('tests apply command', async function () {
 });
 
 describe('tests packageTemplates()', async function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp3'));
 

--- a/src/test/container-templates/templatesCLICommands.test.ts
+++ b/src/test/container-templates/templatesCLICommands.test.ts
@@ -14,7 +14,7 @@ export const output = makeLog(createPlainLog(text => process.stderr.write(text),
 const pkg = require('../../../package.json');
 
 describe('tests apply command', async function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp4'));
 	const cli = `npx --prefix ${tmp} devcontainer`;
@@ -64,7 +64,7 @@ describe('tests apply command', async function () {
 });
 
 describe('tests packageTemplates()', async function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp3'));
 

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -26,7 +26,7 @@ function configWithRaw<T extends DevContainerConfig | ImageMetadataEntry[]>(raw:
 }
 
 describe('Image Metadata', function () {
-	this.timeout('240s');
+	this.timeout('150s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -26,7 +26,7 @@ function configWithRaw<T extends DevContainerConfig | ImageMetadataEntry[]>(raw:
 }
 
 describe('Image Metadata', function () {
-	this.timeout('120s');
+	this.timeout('240s');
 
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;


### PR DESCRIPTION
We're seeing more transient timeouts in the unit tests recently, ~~likely due to https://github.com/devcontainers/cli/commit/0583b9cad9089e779104ec3b766f7a3f0fb41cb0, which needs to make additional HTTPs calls to fetch authorization from a remote OCI server.~~

I've compared the runtime with and without https://github.com/devcontainers/cli/commit/0583b9cad9089e779104ec3b766f7a3f0fb41cb0, and do not notice any notable difference in performance: https://drive.google.com/file/d/1JWOVdBz0QzwmFQbUurnusPvEgWqF62Cl/view?usp=sharing