### PR TITLE
fix: modify argument regex to only allow certain set of values

### DIFF
--- a/src/spec-node/dockerfileUtils.ts
+++ b/src/spec-node/dockerfileUtils.ts
@@ -17,7 +17,7 @@ const fromStatement = /^\s*FROM\s+(?<platform>--platform=\S+\s+)?"?(?<image>[^\s
 const argEnvUserStatements = /^\s*(?<instruction>ARG|ENV|USER)\s+(?<name>[^\s=]+)([ =]+("(?<value1>\S+)"|(?<value2>\S+)))?/gm;
 const directives = /^\s*#\s*(?<name>\S+)\s*=\s*(?<value>.+)/;
 
-const argumentExpression = /\$\{?(?<variable>[^:\}]+)(?<isVarExp>:(?<option>-|\+)(?<word>[^\}]+))?\}?/g;
+const argumentExpression = /\$\{?(?<variable>[a-zA-Z0-9_]+)(?<isVarExp>:(?<option>-|\+)(?<word>[^\}]+))?\}?/g;
 
 export interface Dockerfile {
 	preamble: {


### PR DESCRIPTION
fixes: #360 

- Modified the `argumentExpression` regex to only allow a certain set of values.