### PR TITLE
Incrementally copy features near the layer they're installed

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -319,6 +319,7 @@ function escapeQuotesForShell(input: string) {
 
 export function getFeatureLayers(featuresConfig: FeaturesConfig, containerUser: string, remoteUser: string, useBuildKitBuildContexts = false, contentSourceRootPath = '/tmp/build-features/') {
 	let result = `RUN \\
+mkdir -p /tmp/build-features && \\
 echo "_CONTAINER_USER_HOME=$(getent passwd ${containerUser} | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env && \\
 echo "_REMOTE_USER_HOME=$(getent passwd ${remoteUser} | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -224,7 +224,7 @@ export function getContainerFeaturesBaseDockerFile(useBuildKitBuildContexts = fa
 
 #{nonBuildKitFeatureContentFallback}
 ${(() => {
-	return useBuildKitBuildContexts ? '' : `
+	return useBuildKitBuildContexts ? `` : `
 FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_feature_content_normalize
 USER root
 COPY --from=dev_containers_feature_content_source {contentSourceRootPath} /tmp/build-features/
@@ -239,6 +239,7 @@ USER root
 ${(() => {
 	return useBuildKitBuildContexts ? `
 COPY --from=dev_containers_feature_content_source {contentSourceRootPath}/devcontainer-features.builtin.env /tmp/build-features/
+RUN chmod -R 0700 /tmp/build-features
 ` : `
 COPY --from=dev_containers_feature_content_normalize /tmp/build-features /tmp/build-features
 `;
@@ -330,7 +331,7 @@ echo "_REMOTE_USER_HOME=$(getent passwd ${remoteUser} | cut -d: -f6)" >> /tmp/bu
 	const folders = (featuresConfig.featureSets || []).filter(y => y.internalVersion !== '2').map(x => x.features[0].consecutiveId);
 	folders.forEach(folder => {
 		if (!useBuildKitBuildContexts) {
-		result += `RUN cd /tmp/build-features/${folder} \\
+			result += `RUN cd /tmp/build-features/${folder} \\
 && chmod +x ./install.sh \\
 && ./install.sh
 
@@ -338,8 +339,7 @@ echo "_REMOTE_USER_HOME=$(getent passwd ${remoteUser} | cut -d: -f6)" >> /tmp/bu
 		} else {
 			const source = path.posix.join(contentSourceRootPath, folder!);
 			result += `RUN --mount=type=bind,from=dev_containers_feature_content_source,source=${source},target=/tmp/build-features-src/${folder} \\
-    mkdir -p /tmp/build-feat \\
- && cp -ar /tmp/build-features-src/${folder} /tmp/build-features/ \\
+    cp -ar /tmp/build-features-src/${folder} /tmp/build-features/ \\
  && cd /tmp/build-features/${folder} \\
  && chmod +x ./install.sh \\
  && ./install.sh \\
@@ -357,18 +357,18 @@ echo "_REMOTE_USER_HOME=$(getent passwd ${remoteUser} | cut -d: -f6)" >> /tmp/bu
 RUN cd /tmp/build-features/${feature.consecutiveId} \\
 && chmod +x ./devcontainer-features-install.sh \\
 && ./devcontainer-features-install.sh
+
 `;
 			} else {
 				const source = path.posix.join(contentSourceRootPath, feature.consecutiveId!);
 				result += `
 RUN --mount=type=bind,from=dev_containers_feature_content_source,source=${source},target=/tmp/build-features-src/${feature.consecutiveId} \\
-    mkdir -p /tmp/build-features \\
- && cp -ar /tmp/build-features-src/${feature.consecutiveId} /tmp/build-features/ \\
- && chmod -R 0700 /tmp/build-features \\
+    cp -ar /tmp/build-features-src/${feature.consecutiveId} /tmp/build-features/ \\
  && cd /tmp/build-features/${feature.consecutiveId} \\
  && chmod +x ./devcontainer-features-install.sh \\
  && ./devcontainer-features-install.sh \\
  && rm -rf /tmp/build-features/${feature.consecutiveId}
+
 `;
 			}
 		});

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -237,7 +237,9 @@ FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage
 USER root
 
 ${(() => {
-	return useBuildKitBuildContexts ? '' : `
+	return useBuildKitBuildContexts ? `
+COPY --from=dev_containers_feature_content_source {contentSourceRootPath}/devcontainer-features.builtin.env /tmp/build-features/
+` : `
 COPY --from=dev_containers_feature_content_normalize /tmp/build-features /tmp/build-features
 `;
 })()}
@@ -319,7 +321,6 @@ function escapeQuotesForShell(input: string) {
 
 export function getFeatureLayers(featuresConfig: FeaturesConfig, containerUser: string, remoteUser: string, useBuildKitBuildContexts = false, contentSourceRootPath = '/tmp/build-features/') {
 	let result = `RUN \\
-mkdir -p /tmp/build-features && \\
 echo "_CONTAINER_USER_HOME=$(getent passwd ${containerUser} | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env && \\
 echo "_REMOTE_USER_HOME=$(getent passwd ${remoteUser} | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -285,7 +285,7 @@ async function getFeaturesBuildOptions(params: DockerResolverParameters, devCont
 	// When copying via buildkit, the content is accessed via '.' (i.e. in the context root)
 	// When copying via temp image, the content is in '/tmp/build-features'
 	const contentSourceRootPath = useBuildKitBuildContexts ? '.' : '/tmp/build-features/';
-	const dockerfile = getContainerFeaturesBaseDockerFile(useBuildKitBuildContexts)
+	const dockerfile = getContainerFeaturesBaseDockerFile()
 		.replace('#{nonBuildKitFeatureContentFallback}', useBuildKitBuildContexts ? '' : `FROM ${buildContentImageName} as dev_containers_feature_content_source`)
 		.replace('{contentSourceRootPath}', contentSourceRootPath)
 		.replace('#{featureBuildStages}', getFeatureBuildStages(featuresConfig, buildStageScripts, contentSourceRootPath))

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -285,11 +285,11 @@ async function getFeaturesBuildOptions(params: DockerResolverParameters, devCont
 	// When copying via buildkit, the content is accessed via '.' (i.e. in the context root)
 	// When copying via temp image, the content is in '/tmp/build-features'
 	const contentSourceRootPath = useBuildKitBuildContexts ? '.' : '/tmp/build-features/';
-	const dockerfile = getContainerFeaturesBaseDockerFile()
+	const dockerfile = getContainerFeaturesBaseDockerFile(useBuildKitBuildContexts)
 		.replace('#{nonBuildKitFeatureContentFallback}', useBuildKitBuildContexts ? '' : `FROM ${buildContentImageName} as dev_containers_feature_content_source`)
 		.replace('{contentSourceRootPath}', contentSourceRootPath)
 		.replace('#{featureBuildStages}', getFeatureBuildStages(featuresConfig, buildStageScripts, contentSourceRootPath))
-		.replace('#{featureLayer}', getFeatureLayers(featuresConfig, containerUser, remoteUser))
+		.replace('#{featureLayer}', getFeatureLayers(featuresConfig, containerUser, remoteUser, useBuildKitBuildContexts, contentSourceRootPath))
 		.replace('#{containerEnv}', generateContainerEnvs(featuresConfig))
 		.replace('#{copyFeatureBuildStages}', getCopyFeatureBuildStages(featuresConfig, buildStageScripts))
 		.replace('#{devcontainerMetadata}', getDevcontainerMetadataLabel(imageMetadata, common.experimentalImageMetadata))

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -72,6 +72,7 @@ describe('validate generateFeaturesConfig()', function () {
         // getFeatureLayers
         const actualLayers = getFeatureLayers(featuresConfig, 'testContainerUser', 'testRemoteUser');
         const expectedLayers = `RUN \\
+mkdir -p /tmp/build-features && \\
 echo "_CONTAINER_USER_HOME=$(getent passwd testContainerUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env && \\
 echo "_REMOTE_USER_HOME=$(getent passwd testRemoteUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -72,7 +72,6 @@ describe('validate generateFeaturesConfig()', function () {
         // getFeatureLayers
         const actualLayers = getFeatureLayers(featuresConfig, 'testContainerUser', 'testRemoteUser');
         const expectedLayers = `RUN \\
-mkdir -p /tmp/build-features && \\
 echo "_CONTAINER_USER_HOME=$(getent passwd testContainerUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env && \\
 echo "_REMOTE_USER_HOME=$(getent passwd testRemoteUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 
@@ -131,7 +130,6 @@ RUN cd /tmp/build-features/second_2 \\
         // getFeatureLayers
         const actualLayers = getFeatureLayers(featuresConfig, 'testContainerUser', 'testRemoteUser');
         const expectedLayers = `RUN \\
-mkdir -p /tmp/build-features && \\
 echo "_CONTAINER_USER_HOME=$(getent passwd testContainerUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env && \\
 echo "_REMOTE_USER_HOME=$(getent passwd testRemoteUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -131,6 +131,7 @@ RUN cd /tmp/build-features/second_2 \\
         // getFeatureLayers
         const actualLayers = getFeatureLayers(featuresConfig, 'testContainerUser', 'testRemoteUser');
         const expectedLayers = `RUN \\
+mkdir -p /tmp/build-features && \\
 echo "_CONTAINER_USER_HOME=$(getent passwd testContainerUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env && \\
 echo "_REMOTE_USER_HOME=$(getent passwd testRemoteUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -75,11 +75,15 @@ describe('validate generateFeaturesConfig()', function () {
 echo "_CONTAINER_USER_HOME=$(getent passwd testContainerUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env && \\
 echo "_REMOTE_USER_HOME=$(getent passwd testRemoteUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 
-RUN cd /tmp/build-features/first_1 \\
+COPY --chown=root:root --from=dev_containers_feature_content_source /tmp/build-features/first_1 /tmp/build-features/first_1
+RUN chmod -R 0700 /tmp/build-features/first_1 \\
+&& cd /tmp/build-features/first_1 \\
 && chmod +x ./install.sh \\
 && ./install.sh
 
-RUN cd /tmp/build-features/second_2 \\
+COPY --chown=root:root --from=dev_containers_feature_content_source /tmp/build-features/second_2 /tmp/build-features/second_2
+RUN chmod -R 0700 /tmp/build-features/second_2 \\
+&& cd /tmp/build-features/second_2 \\
 && chmod +x ./install.sh \\
 && ./install.sh
 
@@ -134,12 +138,16 @@ echo "_CONTAINER_USER_HOME=$(getent passwd testContainerUser | cut -d: -f6)" >> 
 echo "_REMOTE_USER_HOME=$(getent passwd testRemoteUser | cut -d: -f6)" >> /tmp/build-features/devcontainer-features.builtin.env
 
 
-RUN cd /tmp/build-features/color_3 \\
+COPY --chown=root:root --from=dev_containers_feature_content_source /tmp/build-features/color_3 /tmp/build-features/color_3
+RUN chmod -R 0700 /tmp/build-features/color_3 \\
+&& cd /tmp/build-features/color_3 \\
 && chmod +x ./devcontainer-features-install.sh \\
 && ./devcontainer-features-install.sh
 
 
-RUN cd /tmp/build-features/hello_4 \\
+COPY --chown=root:root --from=dev_containers_feature_content_source /tmp/build-features/hello_4 /tmp/build-features/hello_4
+RUN chmod -R 0700 /tmp/build-features/hello_4 \\
+&& cd /tmp/build-features/hello_4 \\
 && chmod +x ./devcontainer-features-install.sh \\
 && ./devcontainer-features-install.sh
 


### PR DESCRIPTION
This PR incrementally copies each feature's contents near the layer they're installed, so rebuilds of a devcontainer take full advantage of the build cache.

To illustrate the behavior I built a devcontainer, edited the source of the last feature in the image, then rebuilt it again. With the public `devcontainer` CLI, the image rebuilds all features even though only the last one changed. With this PR, the second build used the layer cache and started from the layer of the changed feature.

* [build-1-old.log](https://gist.github.com/trxcllnt/8b2ff12f29a434e4d4ff2b45cb2fa823#file-build-1-old-log) (`1m31.803s`)
* [build-2-old.log](https://gist.github.com/trxcllnt/8b2ff12f29a434e4d4ff2b45cb2fa823#file-build-2-old-log) (`1m29.621s`)
* [build-1-new.log](https://gist.github.com/trxcllnt/8b2ff12f29a434e4d4ff2b45cb2fa823#file-build-1-new-log) (`1m27.219s`)
* [build-2-new.log](https://gist.github.com/trxcllnt/8b2ff12f29a434e4d4ff2b45cb2fa823#file-build-2-new-log) (`0m32.794s` :fire: :rocket: :fire: :rocket: :fire: :rocket:)

Fixes https://github.com/devcontainers/cli/issues/291 and https://github.com/devcontainers/cli/issues/313