### PR TITLE
[oci] Support querying registries that Accept `application/vnd.oci.image.index.v1+json`

### DIFF
--- a/src/spec-common/cliHost.ts
+++ b/src/spec-common/cliHost.ts
@@ -20,6 +20,7 @@ export type CLIHostType = 'local' | 'wsl' | 'container' | 'ssh';
 export interface CLIHost {
 	type: CLIHostType;
 	platform: NodeJS.Platform;
+	arch: NodeJS.Architecture;
 	exec: ExecFunction;
 	ptyExec: PtyExecFunction;
 	cwd: string;
@@ -63,6 +64,7 @@ function createLocalCLIHostFromExecFunctions(localCwd: string, exec: ExecFunctio
 	return {
 		type: 'local',
 		platform: process.platform,
+		arch: process.arch,
 		exec,
 		ptyExec,
 		cwd: localCwd,

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -75,7 +75,7 @@ interface OCIImageIndexEntry {
 	platform: {
 		architecture: string;
 		os: string;
-	}
+	};
 }
 
 // https://github.com/opencontainers/image-spec/blob/main/manifest.md#example-image-manifest
@@ -246,7 +246,7 @@ export async function getManifest(params: CommonParams, url: string, ref: OCIRef
 }
 
 // https://github.com/opencontainers/image-spec/blob/main/manifest.md
-export async function getImageIndexEntryForPlatform(params: CommonParams, url: string, ref: OCIRef | OCICollectionRef, platformInfo: { arch: NodeJS.Architecture, os: NodeJS.Platform }, mimeType?: string): Promise<OCIImageIndexEntry | undefined> {
+export async function getImageIndexEntryForPlatform(params: CommonParams, url: string, ref: OCIRef | OCICollectionRef, platformInfo: { arch: NodeJS.Architecture; os: NodeJS.Platform }, mimeType?: string): Promise<OCIImageIndexEntry | undefined> {
 	const imageIndex: OCIImageIndex = await getJsonWithMimeType(params, url, ref, mimeType || 'application/vnd.oci.image.index.v1+json');
 	if (!imageIndex || !imageIndex.manifests) {
 		return undefined;
@@ -276,7 +276,7 @@ async function getJsonWithMimeType(params: CommonParams, url: string, ref: OCIRe
 		};
 
 		const httpOptions = {
-			type: 'GET',	
+			type: 'GET',
 			url: url,
 			headers: headers
 		};

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -68,6 +68,23 @@ interface OCITagList {
 	tags: string[];
 }
 
+interface OCIImageIndexEntry {
+	mediaType: string;
+	size: number;
+	digest: string;
+	platform: {
+		architecture: string;
+		os: string;
+	}
+}
+
+// https://github.com/opencontainers/image-spec/blob/main/manifest.md#example-image-manifest
+interface OCIImageIndex {
+	schemaVersion: number;
+	mediaType: string;
+	manifests: OCIImageIndexEntry[];
+}
+
 // Following Spec:   https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
 // Alternative Spec: https://docs.docker.com/registry/spec/api/#overview
 //
@@ -77,6 +94,28 @@ const regexForPath = /^[a-z0-9]+([._-][a-z0-9]+)*(\/[a-z0-9]+([._-][a-z0-9]+)*)*
 // MUST be either (a) the digest of the manifest or (b) a tag
 // MUST be at most 128 characters in length and MUST match the following regular expression:
 const regexForReference = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/;
+
+// https://go.dev/doc/install/source#environment
+// Expected by OCI Spec as seen here: https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions
+export function mapNodeArchitectureToGOARCH(arch: NodeJS.Architecture): string {
+	switch (arch) {
+		case 'x64':
+			return 'amd64';
+		default:
+			return arch;
+	}
+}
+
+// https://go.dev/doc/install/source#environment
+// Expected by OCI Spec as seen here: https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions
+export function mapNodeOSToGOOS(os: NodeJS.Platform): string {
+	switch (os) {
+		case 'win32':
+			return 'windows';
+		default:
+			return os;
+	}
+}
 
 // https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
 // Attempts to parse the given string into an OCIRef
@@ -203,12 +242,37 @@ export async function fetchOCIManifestIfExists(params: CommonParams, ref: OCIRef
 }
 
 export async function getManifest(params: CommonParams, url: string, ref: OCIRef | OCICollectionRef, mimeType?: string): Promise<OCIManifest | undefined> {
+	return await getJsonWithMimeType(params, url, ref, mimeType || 'application/vnd.oci.image.manifest.v1+json');
+}
+
+// https://github.com/opencontainers/image-spec/blob/main/manifest.md
+export async function getImageIndexEntryForPlatform(params: CommonParams, url: string, ref: OCIRef | OCICollectionRef, platformInfo: { arch: NodeJS.Architecture, os: NodeJS.Platform }, mimeType?: string): Promise<OCIImageIndexEntry | undefined> {
+	const imageIndex: OCIImageIndex = await getJsonWithMimeType(params, url, ref, mimeType || 'application/vnd.oci.image.index.v1+json');
+	if (!imageIndex || !imageIndex.manifests) {
+		return undefined;
+	}
+
+	const ociFriendlyPlatformInfo = {
+		arch: mapNodeArchitectureToGOARCH(platformInfo.arch),
+		os: mapNodeOSToGOOS(platformInfo.os),
+	};
+
+	// Find a manifest for the current architecture and OS.
+	return imageIndex.manifests.find(m => {
+		if (m.platform?.architecture === ociFriendlyPlatformInfo.arch && m.platform?.os === ociFriendlyPlatformInfo.os) {
+			return m;
+		}
+		return undefined;
+	});
+}
+
+async function getJsonWithMimeType(params: CommonParams, url: string, ref: OCIRef | OCICollectionRef, mimeType: string): Promise<any | undefined> {
 	const { output } = params;
 	let body: string = '';
 	try {
 		const headers = {
 			'user-agent': 'devcontainer',
-			'accept': mimeType || 'application/vnd.oci.image.manifest.v1+json',
+			'accept': mimeType,
 		};
 
 		const httpOptions = {
@@ -228,13 +292,14 @@ export async function getManifest(params: CommonParams, url: string, ref: OCIRef
 
 		// NOTE: A 404 is expected here if the manifest does not exist on the remote.
 		if (statusCode > 299) {
-			output.write(`Did not fetch manifest: ${body}`, LogLevel.Trace);
+			output.write(`Did not fetch target with expected mimetype '${mimeType}': ${body}`, LogLevel.Trace);
 			return;
 		}
-
-		return JSON.parse(body);
+		const parsed = JSON.parse(body);
+		output.write(`Fetched: ${JSON.stringify(parsed, undefined, 4)}`, LogLevel.Trace);
+		return parsed;
 	} catch (e) {
-		output.write(`Failed to parse manifest: ${body}`, LogLevel.Error);
+		output.write(`Failed to parse JSON with mimeType '${mimeType}': ${body}`, LogLevel.Error);
 		return;
 	}
 }
@@ -247,7 +312,7 @@ export async function getPublishedVersions(params: CommonParams, ref: OCIRef, so
 		const url = `https://${ref.registry}/v2/${ref.namespace}/${ref.id}/tags/list`;
 
 		const headers = {
-			'accept': 'application/json',
+			'Accept': 'application/json',
 		};
 
 		const httpOptions = {
@@ -304,7 +369,7 @@ export async function getBlob(params: CommonParams, url: string, ociCacheDir: st
 		const tempTarballPath = path.join(ociCacheDir, 'blob.tar');
 
 		const headers = {
-			'accept': 'application/vnd.oci.image.manifest.v1+json',
+			'Accept': 'application/vnd.oci.image.manifest.v1+json',
 		};
 
 		const httpOptions = {

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -7,7 +7,7 @@ import { LogLevel } from '../spec-utils/log';
 import { isLocalFile, readLocalFile } from '../spec-utils/pfs';
 import { CommonParams, OCICollectionRef, OCIRef } from './containerCollectionsOCI';
 
-export type HEADERS = { 'authorization'?: string; 'user-agent'?: string; 'content-type'?: string; 'accept'?: string; 'content-length'?: string };
+export type HEADERS = { 'authorization'?: string; 'user-agent'?: string; 'content-type'?: string; 'Accept'?: string; 'content-length'?: string };
 
 interface DockerConfigFile {
 	auths: {

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -214,7 +214,7 @@ export async function inspectDockerImage(params: DockerResolverParameters | Dock
 	}
 }
 
-export async function inspectImageInRegistry(output: Log, platformInfo: { arch: NodeJS.Architecture, os: NodeJS.Platform }, name: string): Promise<ImageDetails> {
+export async function inspectImageInRegistry(output: Log, platformInfo: { arch: NodeJS.Architecture; os: NodeJS.Platform }, name: string): Promise<ImageDetails> {
 	const resourceAndVersion = qualifyImageName(name);
 	const params = { output, env: process.env };
 	const ref = getRef(output, resourceAndVersion);

--- a/src/test/dockerUtils.test.ts
+++ b/src/test/dockerUtils.test.ts
@@ -14,7 +14,7 @@ describe('Docker utils', function () {
 
 	it('inspect image in docker.io', async () => {
 		const imageName = 'docker.io/library/ubuntu:latest';
-		const config = await inspectImageInRegistry(output, imageName);
+		const config = await inspectImageInRegistry(output, { arch: 'x64', os: 'linux' }, imageName);
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);
@@ -22,7 +22,7 @@ describe('Docker utils', function () {
 
 	it('inspect image in mcr.microsoft.com', async () => {
 		const imageName = 'mcr.microsoft.com/devcontainers/rust:1';
-		const config = await inspectImageInRegistry(output, imageName);
+		const config = await inspectImageInRegistry(output, { arch: 'x64', os: 'linux' }, imageName);
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);
@@ -34,7 +34,7 @@ describe('Docker utils', function () {
 
 	it('inspect image in ghcr.io', async () => {
 		const imageName = 'ghcr.io/chrmarti/cache-from-test/images/test-cache:latest';
-		const config = await inspectImageInRegistry(output, imageName);
+		const config = await inspectImageInRegistry(output, { arch: 'x64', os: 'linux' }, imageName);
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);


### PR DESCRIPTION
This fixes two failing tests `inspect image in docker.io` and `inspect image in mcr.microsoft.com` that began failing on `main`.

The fix is to implement parsing the image index media type,
https://github.com/opencontainers/image-spec/blob/main/image-index.md.  Before this change, something had changed on the dockerhub/mcr side to reject the Accept header we had been sending and expecting as a response:

![image](https://user-images.githubusercontent.com/23246594/216206793-898ee97b-d385-480e-bb43-cd71331bb559.png)


Note that Features/Templates are uneffected since we have our own mediaTypes and expected format.