### PR TITLE
add pre-commit formatting hook

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,7 @@
 		// Keep command history across instances
 		"source=dev-containers-cli-bashhistory,target=/home/node/commandhistory"
 	],
-
-	"postCreateCommand": "yarn install",
+	"updateContentCommand": "yarn && yarn husky:setup",
 
 	"remoteUser": "node",
 	

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 		// Keep command history across instances
 		"source=dev-containers-cli-bashhistory,target=/home/node/commandhistory"
 	],
-	"updateContentCommand": "yarn && yarn husky:setup",
+	"updateContentCommand": "yarn && yarn husky-setup",
 
 	"remoteUser": "node",
 	

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint --fix

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 		"event-stream": "^4.0.1",
 		"gulp-eslint": "^6.0.0",
 		"gulp-filter": "^7.0.0",
+		"husky": "^8.0.3",
 		"mocha": "^10.1.0",
 		"npm-run-all": "^4.1.5",
 		"p-all": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"compile": "npm-run-all clean-dist definitions compile-dev",
 		"watch": "npm-run-all clean-dist definitions compile-watch",
 		"package": "npm-run-all clean-dist definitions compile-prod store-packagejson patch-packagejson npm-pack restore-packagejson",
+		"husky-setup": "husky install",
 		"store-packagejson": "copyfiles package.json build-tmp/",
 		"patch-packagejson": "node build/patch-packagejson.js",
 		"restore-packagejson": "copyfiles --up 1 build-tmp/package.json .",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1768,6 +1768,11 @@ https-proxy-agent@5, https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+husky@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Adds a `pre-commit` hook with `husky` to enforce code style/linting.

When create a commit, the `.husky/pre-commit` script will run in `--fix` mode.  If something cannot be auto-fixed, the commit will fail.

<img width="424" alt="image" src="https://user-images.githubusercontent.com/23246594/218208544-ef70f36d-6ff4-48e1-855f-317cbe2b8410.png">

Since `yarn lint` is required to pass by CI, no commit should ever be pushed without passing this check.