### PR TITLE
Fix -`devcontainer feature test` cmd should fail with non-zero exit code if Feature's sub-folder does not exist

### DIFF
--- a/src/spec-node/featuresCLI/testCommandImpl.ts
+++ b/src/spec-node/featuresCLI/testCommandImpl.ts
@@ -9,7 +9,7 @@ import { LaunchResult, staticExecParams, staticProvisionParams, testLibraryScrip
 import { DockerResolverParameters } from '../utils';
 import { DevContainerConfig } from '../../spec-configuration/configuration';
 import { FeaturesTestCommandInput } from './test';
-import { cpDirectoryLocal } from '../../spec-utils/pfs';
+import { cpDirectoryLocal, rmLocal } from '../../spec-utils/pfs';
 import { nullLog } from '../../spec-utils/log';
 
 const TEST_LIBRARY_SCRIPT_NAME = 'dev-container-features-test-lib';
@@ -310,6 +310,12 @@ async function generateDefaultProjectFromFeatures(
 	for (const featureId of featuresToTest) {
 		// Copy the feature source code to the temp folder
 		const pathToFeatureSource = `${collectionsDirectory}/src/${featureId}`;
+
+		if (! await cliHost.isFolder(pathToFeatureSource)) {
+			await rmLocal(tmpFolder, { recursive: true, force: true });
+			fail(`Folder '${pathToFeatureSource}' does not exist for the '${featureId}' Feature.`);
+		}
+
 		await cpDirectoryLocal(pathToFeatureSource, `${tmpFolder}/.devcontainer/${featureId}`);
 	}
 


### PR DESCRIPTION
Addresses - https://github.com/devcontainers/cli/issues/413

![image](https://user-images.githubusercontent.com/24955913/219815484-4f49e60b-563a-4e39-aa2b-3036def676c1.png)