### PR TITLE
automatic lookup for workspace folder

### DIFF
--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -463,7 +463,7 @@ function buildOptions(y: Argv) {
 		'user-data-folder': { type: 'string', description: 'Host path to a directory that is intended to be persisted and share state between sessions.' },
 		'docker-path': { type: 'string', description: 'Docker CLI path.' },
 		'docker-compose-path': { type: 'string', description: 'Docker Compose CLI path.' },
-		'workspace-folder': { type: 'string', required: true, description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', default: '.', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
 		'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
 		'log-format': { choices: ['text' as 'text', 'json' as 'json'], default: 'text' as 'text', description: 'Log format.' },
 		'no-cache': { type: 'boolean', default: false, description: 'Builds the image with `--no-cache`.' },
@@ -477,6 +477,14 @@ function buildOptions(y: Argv) {
 		'skip-feature-auto-mapping': { type: 'boolean', default: false, hidden: true, description: 'Temporary option for testing.' },
 		'experimental-image-metadata': { type: 'boolean', default: experimentalImageMetadataDefault, hidden: true, description: 'Temporary option for testing.' },
 		'skip-persisting-customizations-from-features': { type: 'boolean', default: false, hidden: true, description: 'Do not save customizations from referenced Features as image metadata' },
+	}).check(argv => {
+		if (argv['workspace-folder'] === '.') {
+			const workspaceFolder = findWorkspaceFolder();
+			if (!workspaceFolder) {
+				throw new Error('Unable to find Configuration File, provide workspace-folder argument');
+			}
+		}
+		return true;
 	});
 }
 
@@ -709,7 +717,7 @@ function runUserCommandsOptions(y: Argv) {
 		.check(argv => {
 			const idLabels = (argv['id-label'] && (Array.isArray(argv['id-label']) ? argv['id-label'] : [argv['id-label']])) as string[] | undefined;
 			const isWorkspaceFound = argv['workspace-folder'] || findWorkspaceFolder();
-			console.debug(isWorkspaceFound)
+			console.debug(isWorkspaceFound);
 			if (idLabels?.some(idLabel => !/.+=.+/.test(idLabel))) {
 				throw new Error('Unmatched argument format: id-label must match <name>=<value>');
 			}


### PR DESCRIPTION
Fixes #29 by checking if the current working directory contains a `.devcontainer` folder.

I added this check after seeing #332 

It looks like that the following two [`if`-statements](https://github.com/MunsMan/devcontainercli/blob/5c7077c67832614f0ec56bd5f3d76543e52c44f1/src/spec-node/devContainersSpecCLI.ts#L139-L144) are obsolete.
If they are obsolete, just let me know, then I will remove them as well.