### PR TITLE
fix: environment variables with spaces are not supported

### DIFF
--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -496,7 +496,7 @@ export function getContainerEnvMetadata(containerEnv: Record<string, string> | u
 		return '';
 	}
 
-	const keys = Object.keys(containerEnv);
-	const concatenatedEnv = keys.map(k => `ENV ${k}=${containerEnv![k]}`).join('\n');
-	return concatenatedEnv;
+	return Object.entries(containerEnv)
+		.map(([k, v]) => `ENV ${k}=${v.replace(/ /g, '\\ ')}`)
+		.join('\n');
 }

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -232,8 +232,14 @@ describe('Dev Containers CLI', function () {
 			const containerId: string = resRun.stdout.split('\n')[0];
 			assert.ok(containerId, 'Container id not found.');
 
-			const result = await shellExec(`docker exec ${containerId} bash -c 'echo $JAVA_HOME'`);
-			assert.equal('/usr/lib/jvm/msopenjdk-current\n', result.stdout);
+			const javaHome = await shellExec(`docker exec ${containerId} bash -c 'echo -n $JAVA_HOME'`);
+			assert.equal('/usr/lib/jvm/msopenjdk-current', javaHome.stdout);
+
+			const envWithSpaces = await shellExec(`docker exec ${containerId} bash -c 'echo -n $ENV_WITH_SPACES'`);
+			assert.equal('Environment variable with spaces', envWithSpaces.stdout);
+
+			const evalEnvWithCommand = await shellExec(`docker exec ${containerId} bash -c 'eval $ENV_WITH_COMMAND'`);
+			assert.equal('Hello, World!', evalEnvWithCommand.stdout);
 
 			await shellExec(`docker rm -f ${containerId}`);
 		});

--- a/src/test/cli.up.test.ts
+++ b/src/test/cli.up.test.ts
@@ -173,8 +173,14 @@ describe('Dev Containers CLI', function () {
 			const containerId: string = response.containerId;
 			assert.ok(containerId, 'Container id not found.');
 
-			const result = await shellExec(`docker exec ${containerId} bash -c 'echo $JAVA_HOME'`);
-			assert.equal('/usr/lib/jvm/msopenjdk-current\n', result.stdout);
+			const javaHome = await shellExec(`docker exec ${containerId} bash -c 'echo -n $JAVA_HOME'`);
+			assert.equal('/usr/lib/jvm/msopenjdk-current', javaHome.stdout);
+
+			const envWithSpaces = await shellExec(`docker exec ${containerId} bash -c 'echo -n $ENV_WITH_SPACES'`);
+			assert.equal('Environment variable with spaces', envWithSpaces.stdout);
+
+			const evalEnvWithCommand = await shellExec(`docker exec ${containerId} bash -c 'eval $ENV_WITH_COMMAND'`);
+			assert.equal('Hello, World!', evalEnvWithCommand.stdout);
 
 			await shellExec(`docker rm -f ${containerId}`);
 		});

--- a/src/test/configs/image-metadata-containerEnv/.devcontainer/devcontainer.json
+++ b/src/test/configs/image-metadata-containerEnv/.devcontainer/devcontainer.json
@@ -6,6 +6,8 @@
         }
     },
     "containerEnv": {
-        "JAVA_HOME": "/usr/lib/jvm/msopenjdk-current"
+        "JAVA_HOME": "/usr/lib/jvm/msopenjdk-current",
+        "ENV_WITH_SPACES": "Environment variable with spaces",
+        "ENV_WITH_COMMAND": "bash -c 'echo -n \"Hello, World!\"'"
     }
 }


### PR DESCRIPTION
When using environment variables with spaces in `containerEnv`, the rendered Dockerfile will not be valid, because the spaces are not escaped.

i.e. using
```json
    "containerEnv": {
        "ENV_WITH_SPACES": "Environment variable with spaces"
    }
```

fails with:
```
Syntax error - can't find = in "variable". Must be of the form: name=value
```

because the following is inserted in the Dockerfile:
```Dockerfile
ENV ENV_WITH_SPACES=Environment variable with spaces
```

but it should be:
```Dockerfile
ENV ENV_WITH_SPACES=Environment\ variable\ with\ spaces
```
