### PR TITLE
Retry docker pull

### DIFF
--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -217,7 +217,7 @@ export async function inspectDockerImage(params: DockerResolverParameters | Dock
 			output.write(`Error fetching image details: ${err2?.message}`);
 		}
 		try {
-			await dockerPtyCLI(params, 'pull', imageName);
+			await retry(async () => dockerPtyCLI(params, 'pull', imageName), { maxRetries: 5, retryIntervalMilliseconds: 1000, output });
 		} catch (_err) {
 			if (err.stdout) {
 				output.write(err.stdout.toString());


### PR DESCRIPTION
Over the last ~month Codespaces has been seeing a non-negligible amount of creation failures due to timing out or 5XX errors when pulling from a registry.

Example log seen today:

```
[2023-03-01 22:16:05.063 StartEnvironment I] {"type":"text","level":2,"timestamp":1677708965063,"text":"Error fetching image details: No manifest found for mcr.microsoft.com/devcontainers/miniconda:0-3."}
[2023-03-01 22:16:05.063 StartEnvironment I] {"type":"start","level":2,"timestamp":1677708965063,"text":"Run: docker pull mcr.microsoft.com/devcontainers/miniconda:0-3"}
[2023-03-01 22:16:05.354 StartEnvironment I] {"type":"raw","level":2,"timestamp":1677708965354,"text":"0-3: Pulling from devcontainers/miniconda\r\n"}
[2023-03-01 22:16:07.877 StartEnvironment I] {"type":"raw","level":2,"timestamp":1677708967876,"text":"received unexpected HTTP status: 503 Service Unavailable\r\n"}
[2023-03-01 22:16:07.879 StartEnvironment I] {"type":"stop","level":2,"timestamp":1677708967879,"text":"Run: docker pull mcr.microsoft.com/devcontainers/miniconda:0-3","startTimestamp":1677708965063}
[2023-03-01 22:16:07.879 StartEnvironment I] {"type":"text","level":2,"timestamp":1677708967879,"text":"[]\n"}
[2023-03-01 22:16:07.879 StartEnvironment I] {"type":"text","level":2,"timestamp":1677708967879,"text":"\u001b[1m\u001b[31mError: No such image: mcr.microsoft.com/devcontainers/miniconda:0-3\u001b[39m\u001b[22m\r\n\u001b[1m\u001b[31m\u001b[39m\u001b[22m\r\n"}
[2023-03-01 22:16:07.880 StartEnvironment I] Error: Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/miniconda:0-3
[2023-03-01 22:16:07.880 StartEnvironment I]     at fie (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:1915:1355)
[2023-03-01 22:16:07.881 StartEnvironment I]     at P7 (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:1915:1291)
[2023-03-01 22:16:07.881 StartEnvironment I]     at processTicksAndRejections (internal/process/task_queues.js:95:5)
[2023-03-01 22:16:07.881 StartEnvironment I]     at async Fie (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:1921:2093)
[2023-03-01 22:16:07.881 StartEnvironment I]     at async $f (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:1921:3239)
[2023-03-01 22:16:07.881 StartEnvironment I]     at async eoe (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:2045:17247)
[2023-03-01 22:16:07.881 StartEnvironment I]     at async Qse (/usr/lib/node_modules/@microsoft/vscode-dev-containers-cli/dist/spec-node/devContainersSpecCLI.js:2045:16993)
[2023-03-01 22:16:07.882 StartEnvironment I] {"outcome":"error","message":"Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/miniconda:0-3","description":"An error occurred setting up the container."}
[2023-03-01 22:16:07.923 StartEnvironment I] devcontainer process exited with exit code 1 
```

From our telemetry we haven't seen any other place where these network failures are causing issues in the dev container CLI.  Additionally, this has been a small but persistent issue for the last ~month.

This change adds a generic retry function and wraps the `docker pull` in that function.