### PR TITLE
Doc: add shell highlighting to markdown

### DIFF
--- a/docs/features/test.md
+++ b/docs/features/test.md
@@ -78,7 +78,7 @@ The following `scenarios.json` defines a single test scenario named `install_dot
 The test command will build a container with the config above, and then look for a `.sh` test file with the same name.  The test will pass if the container builds successfully and the `install_dotnet_and_oryx.sh` shell script exits will a successful exit code (0).
 
 ##### test/install_dotnet_and_oryx.sh
-```
+```shell
 #!/bin/bash
 
 set -e


### PR DESCRIPTION
Just added a single word 'shell' to markdown to enable syntax highlighting. For comparison...

With ("shell" in markdown):
```shell
#!/bin/bash

set -e

# Import test library for `check` command
source dev-container-features-test-lib

check "Oryx version" oryx --version
check "Dotnet is not removed if it is not installed by the Oryx Feature" dotnet --version
...
```

Without:
```
#!/bin/bash

set -e

# Import test library for `check` command
source dev-container-features-test-lib

check "Oryx version" oryx --version
check "Dotnet is not removed if it is not installed by the Oryx Feature" dotnet --version
...
```

Note: If you're not noticing the difference, it's more apparent on dark themes