### PR TITLE
Ability to skip storing remoteEnv from devcontainer config on container metadata label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes.
 ### [0.33.0]
 
 - Connect stdin to executed process. (https://github.com/devcontainers/cli/issues/59)
+- Better support for private Features published to Azure Container Registry (https://github.com/devcontainers/cli/pull/444)
 
 ### [0.32.0]
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"definitions": "npm-run-all definitions-clean definitions-copy",
 		"lint": "eslint -c .eslintrc.js --rulesdir ./build/eslint --max-warnings 0 --ext .ts ./src",
 		"definitions-clean": "rimraf dist/node_modules/vscode-dev-containers",
-		"definitions-copy": "copyfiles --all \"node_modules/vscode-dev-containers/**/*\" dist",
+		"definitions-copy": "copyfiles \"node_modules/vscode-dev-containers/container-features/{devcontainer-features.json,feature-scripts.env,fish-debian.sh,gradle-debian.sh,homebrew-debian.sh,install.sh,jupyterlab-debian.sh,maven-debian.sh}\" dist",
 		"npm-pack": "npm pack",
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",

--- a/src/spec-common/injectHeadless.ts
+++ b/src/spec-common/injectHeadless.ts
@@ -65,6 +65,7 @@ export interface ResolverParameters {
 	experimentalImageMetadata: boolean;
 	containerSessionDataFolder?: string;
 	skipPersistingCustomizationsFromFeatures: boolean;
+	skipPersistingRemoteEnvFromConfig: boolean;
 }
 
 export interface LifecycleHook {

--- a/src/spec-common/injectHeadless.ts
+++ b/src/spec-common/injectHeadless.ts
@@ -65,7 +65,7 @@ export interface ResolverParameters {
 	experimentalImageMetadata: boolean;
 	containerSessionDataFolder?: string;
 	skipPersistingCustomizationsFromFeatures: boolean;
-	skipPersistingRemoteEnvFromConfig?: boolean;
+	omitConfigRemotEnvFromMetadata?: boolean;
 }
 
 export interface LifecycleHook {

--- a/src/spec-common/injectHeadless.ts
+++ b/src/spec-common/injectHeadless.ts
@@ -65,7 +65,7 @@ export interface ResolverParameters {
 	experimentalImageMetadata: boolean;
 	containerSessionDataFolder?: string;
 	skipPersistingCustomizationsFromFeatures: boolean;
-	skipPersistingRemoteEnvFromConfig: boolean;
+	skipPersistingRemoteEnvFromConfig?: boolean;
 }
 
 export interface LifecycleHook {

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -131,7 +131,7 @@ export async function getExtendImageBuildInfo(params: DockerResolverParameters, 
 		if (canAddLabelsToContainer && !imageBuildInfo.dockerfile) {
 			return {
 				labels: {
-					[imageMetadataLabel]: JSON.stringify(getDevcontainerMetadata(imageBuildInfo.metadata, config, undefined, [], getOmitDevcontainerPropertyOverride(params.common.skipPersistingRemoteEnvFromConfig)).raw),
+					[imageMetadataLabel]: JSON.stringify(getDevcontainerMetadata(imageBuildInfo.metadata, config, undefined, [], getOmitDevcontainerPropertyOverride(params.common)).raw),
 				}
 			};
 		}
@@ -224,7 +224,7 @@ function getImageBuildOptions(params: DockerResolverParameters, config: Substitu
 		dstFolder,
 		dockerfileContent: `
 FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage
-${getDevcontainerMetadataLabel(getDevcontainerMetadata(imageBuildInfo.metadata, config, { featureSets: [] }, [], getOmitDevcontainerPropertyOverride(params.common.skipPersistingRemoteEnvFromConfig)), params.common.experimentalImageMetadata)}
+${getDevcontainerMetadataLabel(getDevcontainerMetadata(imageBuildInfo.metadata, config, { featureSets: [] }, [], getOmitDevcontainerPropertyOverride(params.common)), params.common.experimentalImageMetadata)}
 `,
 		overrideTarget: 'dev_containers_target_stage',
 		dockerfilePrefixContent: `${syntax ? `# syntax=${syntax}` : ''}
@@ -237,8 +237,8 @@ ${getDevcontainerMetadataLabel(getDevcontainerMetadata(imageBuildInfo.metadata, 
 	};
 }
 
-function getOmitDevcontainerPropertyOverride(shouldOmit: boolean | undefined): (keyof DevContainerConfig & keyof ImageMetadataEntry)[] {
-	if (shouldOmit) {
+function getOmitDevcontainerPropertyOverride(resolverParams: { omitConfigRemotEnvFromMetadata?: boolean }): (keyof DevContainerConfig & keyof ImageMetadataEntry)[] {
+	if (resolverParams.omitConfigRemotEnvFromMetadata) {
 		return ['remoteEnv'];
 	}
 
@@ -281,7 +281,7 @@ async function getFeaturesBuildOptions(params: DockerResolverParameters, devCont
 	const buildContentImageName = 'dev_container_feature_content_temp';
 
 	const omitPropertyOverride = params.common.skipPersistingCustomizationsFromFeatures ? ['customizations'] : [];
-	const imageMetadata = getDevcontainerMetadata(imageBuildInfo.metadata, devContainerConfig, featuresConfig, omitPropertyOverride, getOmitDevcontainerPropertyOverride(params.common.skipPersistingRemoteEnvFromConfig));
+	const imageMetadata = getDevcontainerMetadata(imageBuildInfo.metadata, devContainerConfig, featuresConfig, omitPropertyOverride, getOmitDevcontainerPropertyOverride(params.common));
 	const { containerUser, remoteUser } = findContainerUsers(imageMetadata, composeServiceUser, imageBuildInfo.user);
 	const builtinVariables = [
 		`_CONTAINER_USER=${containerUser}`,

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -129,9 +129,10 @@ export async function getExtendImageBuildInfo(params: DockerResolverParameters, 
 	const featuresConfig = await generateFeaturesConfig({ ...params.common, platform }, dstFolder, config.config, getContainerFeaturesFolder, additionalFeatures);
 	if (!featuresConfig) {
 		if (canAddLabelsToContainer && !imageBuildInfo.dockerfile) {
+			const omitDevcontainerPropertyOverride: (keyof DevContainerConfig & keyof ImageMetadataEntry)[] = params.common.skipPersistingRemoteEnvFromConfig ? ['remoteEnv'] : [];
 			return {
 				labels: {
-					[imageMetadataLabel]: JSON.stringify(getDevcontainerMetadata(imageBuildInfo.metadata, config, undefined).raw),
+					[imageMetadataLabel]: JSON.stringify(getDevcontainerMetadata(imageBuildInfo.metadata, config, undefined, [], omitDevcontainerPropertyOverride).raw),
 				}
 			};
 		}

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -59,7 +59,7 @@ export interface ProvisionOptions {
 	experimentalImageMetadata: boolean;
 	containerSessionDataFolder?: string;
 	skipPersistingCustomizationsFromFeatures: boolean;
-	skipPersistingRemoteEnvFromConfig: boolean;
+	skipPersistingRemoteEnvFromConfig?: boolean;
 	dotfiles: {
 		repository?: string;
 		installCommand?: string;

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -59,6 +59,7 @@ export interface ProvisionOptions {
 	experimentalImageMetadata: boolean;
 	containerSessionDataFolder?: string;
 	skipPersistingCustomizationsFromFeatures: boolean;
+	skipPersistingRemoteEnvFromConfig: boolean;
 	dotfiles: {
 		repository?: string;
 		installCommand?: string;
@@ -140,6 +141,7 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		experimentalImageMetadata: options.experimentalImageMetadata,
 		containerSessionDataFolder: options.containerSessionDataFolder,
 		skipPersistingCustomizationsFromFeatures: options.skipPersistingCustomizationsFromFeatures,
+		skipPersistingRemoteEnvFromConfig: options.skipPersistingRemoteEnvFromConfig,
 		dotfilesConfiguration: {
 			repository: options.dotfiles.repository,
 			installCommand: options.dotfiles.installCommand,

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -59,7 +59,7 @@ export interface ProvisionOptions {
 	experimentalImageMetadata: boolean;
 	containerSessionDataFolder?: string;
 	skipPersistingCustomizationsFromFeatures: boolean;
-	skipPersistingRemoteEnvFromConfig?: boolean;
+	omitConfigRemotEnvFromMetadata?: boolean;
 	dotfiles: {
 		repository?: string;
 		installCommand?: string;
@@ -141,7 +141,7 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		experimentalImageMetadata: options.experimentalImageMetadata,
 		containerSessionDataFolder: options.containerSessionDataFolder,
 		skipPersistingCustomizationsFromFeatures: options.skipPersistingCustomizationsFromFeatures,
-		skipPersistingRemoteEnvFromConfig: options.skipPersistingRemoteEnvFromConfig,
+		omitConfigRemotEnvFromMetadata: options.omitConfigRemotEnvFromMetadata,
 		dotfilesConfiguration: {
 			repository: options.dotfiles.repository,
 			installCommand: options.dotfiles.installCommand,

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -122,7 +122,7 @@ function provisionOptions(y: Argv) {
 		'dotfiles-install-command': { type: 'string', description: 'The command to run after cloning the dotfiles repository. Defaults to run the first file of `install.sh`, `install`, `bootstrap.sh`, `bootstrap`, `setup.sh` and `setup` found in the dotfiles repository`s root folder.' },
 		'dotfiles-target-path': { type: 'string', default: '~/dotfiles', description: 'The path to clone the dotfiles repository to. Defaults to `~/dotfiles`.' },
 		'container-session-data-folder': { type: 'string', description: 'Folder to cache CLI data, for example userEnvProbe results' },
-		'skip-persisting-remote-env-from-config': { type: 'boolean', default: false, description: 'Do not persist remoteEnv from devcontainer.json in container metadata label' },
+		'omit-config-remote-env-from-metadata': { type: 'boolean', default: false, hidden: true, description: 'Omit remoteEnv from devcontainer.json for container metadata label' },
 	})
 		.check(argv => {
 			const idLabels = (argv['id-label'] && (Array.isArray(argv['id-label']) ? argv['id-label'] : [argv['id-label']])) as string[] | undefined;
@@ -189,7 +189,7 @@ async function provision({
 	'dotfiles-install-command': dotfilesInstallCommand,
 	'dotfiles-target-path': dotfilesTargetPath,
 	'container-session-data-folder': containerSessionDataFolder,
-	'skip-persisting-remote-env-from-config': skipPersistingRemoteEnvFromConfig,
+	'omit-config-remote-env-from-metadata': omitConfigRemotEnvFromMetadata,
 }: ProvisionArgs) {
 
 	const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
@@ -246,7 +246,7 @@ async function provision({
 		experimentalImageMetadata,
 		containerSessionDataFolder,
 		skipPersistingCustomizationsFromFeatures: false,
-		skipPersistingRemoteEnvFromConfig,
+		omitConfigRemotEnvFromMetadata: omitConfigRemotEnvFromMetadata,
 	};
 
 	const result = await doProvision(options, providedIdLabels);

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -396,7 +396,6 @@ async function doSetUp({
 			skipPostAttach: false,
 			experimentalImageMetadata: true,
 			skipPersistingCustomizationsFromFeatures: false,
-			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {
 				repository: dotfilesRepository,
 				installCommand: dotfilesInstallCommand,
@@ -549,7 +548,6 @@ async function doBuild({
 			skipPostAttach: true,
 			experimentalImageMetadata,
 			skipPersistingCustomizationsFromFeatures: skipPersistingCustomizationsFromFeatures,
-			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {}
 		}, disposables);
 
@@ -801,7 +799,6 @@ async function doRunUserCommands({
 			skipPostAttach,
 			experimentalImageMetadata,
 			skipPersistingCustomizationsFromFeatures: false,
-			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {
 				repository: dotfilesRepository,
 				installCommand: dotfilesInstallCommand,
@@ -1158,7 +1155,6 @@ export async function doExec({
 			skipPostAttach: false,
 			experimentalImageMetadata,
 			skipPersistingCustomizationsFromFeatures: false,
-			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {}
 		}, disposables);
 

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -122,6 +122,7 @@ function provisionOptions(y: Argv) {
 		'dotfiles-install-command': { type: 'string', description: 'The command to run after cloning the dotfiles repository. Defaults to run the first file of `install.sh`, `install`, `bootstrap.sh`, `bootstrap`, `setup.sh` and `setup` found in the dotfiles repository`s root folder.' },
 		'dotfiles-target-path': { type: 'string', default: '~/dotfiles', description: 'The path to clone the dotfiles repository to. Defaults to `~/dotfiles`.' },
 		'container-session-data-folder': { type: 'string', description: 'Folder to cache CLI data, for example userEnvProbe results' },
+		'skip-persisting-remote-env-from-config': { type: 'boolean', default: false, description: 'Do not persist remoteEnv from devcontainer.json in container metatdata label' },
 	})
 		.check(argv => {
 			const idLabels = (argv['id-label'] && (Array.isArray(argv['id-label']) ? argv['id-label'] : [argv['id-label']])) as string[] | undefined;
@@ -188,6 +189,7 @@ async function provision({
 	'dotfiles-install-command': dotfilesInstallCommand,
 	'dotfiles-target-path': dotfilesTargetPath,
 	'container-session-data-folder': containerSessionDataFolder,
+	'skip-persisting-remote-env-from-config': skipPersistingRemoteEnvFromConfig,
 }: ProvisionArgs) {
 
 	const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
@@ -244,6 +246,7 @@ async function provision({
 		experimentalImageMetadata,
 		containerSessionDataFolder,
 		skipPersistingCustomizationsFromFeatures: false,
+		skipPersistingRemoteEnvFromConfig,
 	};
 
 	const result = await doProvision(options, providedIdLabels);
@@ -393,6 +396,7 @@ async function doSetUp({
 			skipPostAttach: false,
 			experimentalImageMetadata: true,
 			skipPersistingCustomizationsFromFeatures: false,
+			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {
 				repository: dotfilesRepository,
 				installCommand: dotfilesInstallCommand,
@@ -545,6 +549,7 @@ async function doBuild({
 			skipPostAttach: true,
 			experimentalImageMetadata,
 			skipPersistingCustomizationsFromFeatures: skipPersistingCustomizationsFromFeatures,
+			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {}
 		}, disposables);
 
@@ -796,6 +801,7 @@ async function doRunUserCommands({
 			skipPostAttach,
 			experimentalImageMetadata,
 			skipPersistingCustomizationsFromFeatures: false,
+			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {
 				repository: dotfilesRepository,
 				installCommand: dotfilesInstallCommand,
@@ -1152,6 +1158,7 @@ export async function doExec({
 			skipPostAttach: false,
 			experimentalImageMetadata,
 			skipPersistingCustomizationsFromFeatures: false,
+			skipPersistingRemoteEnvFromConfig: false,
 			dotfiles: {}
 		}, disposables);
 

--- a/src/spec-node/featuresCLI/testCommandImpl.ts
+++ b/src/spec-node/featuresCLI/testCommandImpl.ts
@@ -399,6 +399,7 @@ async function launchProject(params: DockerResolverParameters, args: FeaturesTes
 		skipFeatureAutoMapping: common.skipFeatureAutoMapping,
 		experimentalImageMetadata: !args.skipImageMetadata,
 		skipPersistingCustomizationsFromFeatures: common.skipPersistingCustomizationsFromFeatures,
+		skipPersistingRemoteEnvFromConfig: common.skipPersistingRemoteEnvFromConfig,
 		log: text => quiet ? null : process.stderr.write(text),
 		dotfiles: {}
 	};
@@ -495,6 +496,7 @@ async function generateDockerParams(workspaceFolder: string, args: FeaturesTestC
 		skipFeatureAutoMapping: false,
 		skipPostAttach: false,
 		skipPersistingCustomizationsFromFeatures: false,
+		skipPersistingRemoteEnvFromConfig: false,
 		experimentalImageMetadata: !args.skipImageMetadata,
 		dotfiles: {}
 	}, disposables);

--- a/src/spec-node/featuresCLI/testCommandImpl.ts
+++ b/src/spec-node/featuresCLI/testCommandImpl.ts
@@ -496,7 +496,6 @@ async function generateDockerParams(workspaceFolder: string, args: FeaturesTestC
 		skipFeatureAutoMapping: false,
 		skipPostAttach: false,
 		skipPersistingCustomizationsFromFeatures: false,
-		skipPersistingRemoteEnvFromConfig: false,
 		experimentalImageMetadata: !args.skipImageMetadata,
 		dotfiles: {}
 	}, disposables);

--- a/src/spec-node/featuresCLI/testCommandImpl.ts
+++ b/src/spec-node/featuresCLI/testCommandImpl.ts
@@ -399,7 +399,7 @@ async function launchProject(params: DockerResolverParameters, args: FeaturesTes
 		skipFeatureAutoMapping: common.skipFeatureAutoMapping,
 		experimentalImageMetadata: !args.skipImageMetadata,
 		skipPersistingCustomizationsFromFeatures: common.skipPersistingCustomizationsFromFeatures,
-		skipPersistingRemoteEnvFromConfig: common.skipPersistingRemoteEnvFromConfig,
+		omitConfigRemotEnvFromMetadata: common.omitConfigRemotEnvFromMetadata,
 		log: text => quiet ? null : process.stderr.write(text),
 		dotfiles: {}
 	};

--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -307,7 +307,7 @@ export function getDevcontainerMetadata(baseImageMetadata: SubstitutedConfig<Ima
 		config: [
 			...baseImageMetadata.config,
 			...featureRaw.map(devContainerConfig.substitute),
-			pick(devContainerConfig.config, pickConfigProperties),
+			pick(devContainerConfig.config, effectivePickDevcontainerProperties),
 		].filter(config => Object.keys(config).length),
 		raw,
 		substitute: devContainerConfig.substitute,

--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -287,8 +287,9 @@ function collectOrUndefined<T, K extends keyof T>(entries: T[], property: K): No
 	return values.length ? values : undefined;
 }
 
-export function getDevcontainerMetadata(baseImageMetadata: SubstitutedConfig<ImageMetadataEntry[]>, devContainerConfig: SubstitutedConfig<DevContainerConfig>, featuresConfig: FeaturesConfig | undefined, omitPropertyOverride: string[] = []): SubstitutedConfig<ImageMetadataEntry[]> {
+export function getDevcontainerMetadata(baseImageMetadata: SubstitutedConfig<ImageMetadataEntry[]>, devContainerConfig: SubstitutedConfig<DevContainerConfig>, featuresConfig: FeaturesConfig | undefined, omitPropertyOverride: string[] = [], omitDevcontainerPropertyOverride: (keyof DevContainerConfig & keyof ImageMetadataEntry)[] = []): SubstitutedConfig<ImageMetadataEntry[]> {
 	const effectivePickFeatureProperties = pickFeatureProperties.filter(property => !omitPropertyOverride.includes(property));
+	const effectivePickDevcontainerProperties = pickConfigProperties.filter(property => !omitDevcontainerPropertyOverride.includes(property));
 
 	const featureRaw = featuresConfig?.featureSets.map(featureSet =>
 		featureSet.features.map(feature => ({
@@ -299,7 +300,7 @@ export function getDevcontainerMetadata(baseImageMetadata: SubstitutedConfig<Ima
 	const raw = [
 		...baseImageMetadata.raw,
 		...featureRaw,
-		pick(devContainerConfig.raw, pickConfigProperties),
+		pick(devContainerConfig.raw, effectivePickDevcontainerProperties),
 	].filter(config => Object.keys(config).length);
 
 	return {

--- a/src/test/configs/compose-Dockerfile-with-features/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-Dockerfile-with-features/.devcontainer/devcontainer.json
@@ -24,5 +24,10 @@
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}
+	},
+	"postCreateCommand": "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt",
+	"remoteEnv": {
+		"TEST": "ENV",
+		"TEST_ESCAPING": "{\n  \"fo$o\": \"ba'r\"\n}"
 	}
 }

--- a/src/test/configs/compose-Dockerfile-without-features/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-Dockerfile-without-features/.devcontainer/devcontainer.json
@@ -18,5 +18,10 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+	"remoteUser": "node",
+	"postCreateCommand": "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt",
+	"remoteEnv": {
+		"TEST": "ENV",
+		"TEST_ESCAPING": "{\n  \"fo$o\": \"ba'r\"\n}"
+	}
 }

--- a/src/test/configs/compose-image-with-features/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-image-with-features/.devcontainer/devcontainer.json
@@ -24,5 +24,10 @@
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}
+	},
+	"postCreateCommand": "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt",
+	"remoteEnv": {
+		"TEST": "ENV",
+		"TEST_ESCAPING": "{\n  \"fo$o\": \"ba'r\"\n}"
 	}
 }

--- a/src/test/configs/compose-image-without-features-minimal/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-image-without-features-minimal/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
-	"postCreateCommand": "touch /postCreateCommand.txt",
+	"postCreateCommand": "echo \"Val: $TEST\" > /postCreateCommand.txt",
 	"remoteEnv": {
 		"TEST": "ENV",
 		"TEST_ESCAPING": "{\n  \"fo$o\": \"ba'r\"\n}"

--- a/src/test/configs/dockerfile-without-features/.devcontainer.json
+++ b/src/test/configs/dockerfile-without-features/.devcontainer.json
@@ -5,13 +5,6 @@
 			"VARIANT": "16-bullseye"
 		}
 	},
-	// "postCreateCommand": [
-	// 	// "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt"
-	// 	"sudo",
-	// 	"sh",
-	// 	"-c",
-	// 	"echo \"Val: $TEST\" > /postCreateCommand.txt"
-	// ],
 	"postCreateCommand": "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt",
 	"remoteEnv": {
 		"TEST": "ENV",

--- a/src/test/configs/dockerfile-without-features/.devcontainer.json
+++ b/src/test/configs/dockerfile-without-features/.devcontainer.json
@@ -1,16 +1,17 @@
 {
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { 
+		"args": {
 			"VARIANT": "16-bullseye"
 		}
 	},
-	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/devcontainers/feature-starter/hello:1": {
-			"greeting": "howdy"
-		}
-	},
+	// "postCreateCommand": [
+	// 	// "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt"
+	// 	"sudo",
+	// 	"sh",
+	// 	"-c",
+	// 	"echo \"Val: $TEST\" > /postCreateCommand.txt"
+	// ],
 	"postCreateCommand": "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt",
 	"remoteEnv": {
 		"TEST": "ENV",

--- a/src/test/configs/dockerfile-without-features/Dockerfile
+++ b/src/test/configs/dockerfile-without-features/Dockerfile
@@ -1,0 +1,4 @@
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License. See License.txt in the project root for license information.
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/src/test/configs/image-with-features/.devcontainer.json
+++ b/src/test/configs/image-with-features/.devcontainer.json
@@ -5,5 +5,10 @@
 		"ghcr.io/devcontainers/feature-starter/hello:1": {
 			"greeting": "howdy"
 		}
+	},
+	"postCreateCommand": "echo \"Val: $TEST\" | sudo tee /postCreateCommand.txt",
+	"remoteEnv": {
+		"TEST": "ENV",
+		"TEST_ESCAPING": "{\n  \"fo$o\": \"ba'r\"\n}"
 	}
 }

--- a/src/test/configs/image/.devcontainer.json
+++ b/src/test/configs/image/.devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"image": "ubuntu:latest",
-	"postCreateCommand": "touch /postCreateCommand.txt",
+	"postCreateCommand": "echo \"Val: $TEST\" > /postCreateCommand.txt",
 	"remoteEnv": {
 		"TEST": "ENV",
 		"TEST_ESCAPING": "{\n  \"fo$o\": \"ba'r\"\n}",

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -175,6 +175,19 @@ describe('Image Metadata', function () {
 					await shellExec(`docker exec ${response.containerId} test -f /postCreateCommand.txt`);
 					await shellExec(`docker rm -f ${response.containerId}`);
 				});
+			});
+
+			[
+				'image-with-features',
+				'image',
+				'compose-image-with-features',
+				'compose-image-without-features-minimal',
+				'compose-Dockerfile-with-features',
+				'compose-Dockerfile-without-features',
+				'dockerfile-with-features',
+				'dockerfile-without-features',
+			].forEach(testFolderName => {
+				const imageTestFolder = `${__dirname}/configs/${testFolderName}`;
 
 				it(`up should should avoid storing remoteEnv in metadata label with --skip-persisting-remote-env-from-config [${testFolderName}, ${text}]`, async () => {
 					if (!experimentalImageMetadataDefault) {
@@ -186,8 +199,7 @@ describe('Image Metadata', function () {
 					assert.strictEqual(response.outcome, 'success');
 					const details = JSON.parse((await shellExec(`docker inspect ${response.containerId}`)).stdout)[0] as ContainerDetails;
 					const metadata = internalGetImageMetadata0(details, true, nullLog);
-					assert.strictEqual(metadata.length, 1);
-					assert.ok(!metadata[0].remoteEnv); // remoteEnv is not stored on container metadata label
+					assert.ok(!metadata[metadata.length - 1].remoteEnv); // remoteEnv from devcontainer config is not stored on container metadata label
 					const result = await shellExec(`docker exec ${response.containerId} cat /postCreateCommand.txt`);
 					assert.strictEqual(result.stdout, 'Val: ENV\n'); // remoteEnv is available to lifecycle hooks
 

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -189,12 +189,12 @@ describe('Image Metadata', function () {
 			].forEach(testFolderName => {
 				const imageTestFolder = `${__dirname}/configs/${testFolderName}`;
 
-				it(`up should should avoid storing remoteEnv in metadata label with --skip-persisting-remote-env-from-config [${testFolderName}, ${text}]`, async () => {
+				it(`up should should avoid storing remoteEnv in metadata label with --omit-config-remote-env-from-metadata [${testFolderName}, ${text}]`, async () => {
 					if (!experimentalImageMetadataDefault) {
 						return;
 					}
 					const buildKitOption = (options?.useBuildKit ?? false) ? '' : ' --buildkit=never';
-					const res = await shellExec(`${cli} up --workspace-folder ${imageTestFolder} --skip-persisting-remote-env-from-config --remove-existing-container${buildKitOption}`);
+					const res = await shellExec(`${cli} up --workspace-folder ${imageTestFolder} --omit-config-remote-env-from-metadata --remove-existing-container${buildKitOption}`);
 					const response = JSON.parse(res.stdout);
 					assert.strictEqual(response.outcome, 'success');
 					const details = JSON.parse((await shellExec(`docker inspect ${response.containerId}`)).stdout)[0] as ContainerDetails;
@@ -243,7 +243,7 @@ describe('Image Metadata', function () {
 			assert.strictEqual(raw[1].remoteUser, 'testUser');
 		});
 
-		it('should omit specified props from devcontainer.json for raw', () => {
+		it('should omit specified props from devcontainer.json', () => {
 			const omitDevcontainerPropertyOverride: (keyof DevContainerConfig & keyof ImageMetadataEntry)[] = ['remoteEnv'];
 			const { config: metadata, raw } = getDevcontainerMetadata(configWithRaw([]), configWithRaw({
 				configFilePath: URI.parse('file:///devcontainer.json'),
@@ -258,7 +258,7 @@ describe('Image Metadata', function () {
 				omitDevcontainerPropertyOverride);
 			assert.strictEqual(metadata.length, 1);
 			assert.strictEqual(metadata[0].remoteUser, 'testUser');
-			assert.strictEqual(metadata[0].remoteEnv?.DEVCONTENV, 'value');
+			assert.ok(!metadata[0].remoteEnv);
 			assert.strictEqual(raw.length, 1);
 			assert.strictEqual(raw[0].remoteUser, 'testUser');
 			assert.ok(!raw[0].remoteEnv);

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -38,7 +38,7 @@ describe('Image Metadata', function () {
 		await shellExec(`npm --prefix ${tmp} install devcontainers-cli-${pkg.version}.tgz`);
 		await shellExec(`docker build -t image-metadata-test-base ${testFolder}/base-image`);
 	});
-	
+
 	describe('CLI', () => {
 
 		buildKitOptions.forEach(({ text, options }) => {
@@ -139,7 +139,7 @@ describe('Image Metadata', function () {
 				'compose-image-without-features-minimal',
 			].forEach(testFolderName => {
 				const imageTestFolder = `${__dirname}/configs/${testFolderName}`;
-			
+
 				it(`build should collect metadata on image label [${testFolderName}, ${text}]`, async () => {
 					if (!experimentalImageMetadataDefault) {
 						return;
@@ -156,7 +156,7 @@ describe('Image Metadata', function () {
 					assert.strictEqual(metadata.length, 1);
 					assert.ok(metadata[0].remoteEnv);
 				});
-	
+
 				it(`up should avoid new image when possible [${testFolderName}, ${text}]`, async () => {
 					if (!experimentalImageMetadataDefault) {
 						return;
@@ -173,6 +173,36 @@ describe('Image Metadata', function () {
 					assert.strictEqual(metadata[0].remoteEnv.TEST, 'ENV');
 					assert.strictEqual(metadata[0].remoteEnv.TEST_ESCAPING, '{\n  "fo$o": "ba\'r"\n}');
 					await shellExec(`docker exec ${response.containerId} test -f /postCreateCommand.txt`);
+					await shellExec(`docker rm -f ${response.containerId}`);
+				});
+
+				it(`up should should avoid storing remoteEnv in metadata label with --skip-persisting-remote-env-from-config [${testFolderName}, ${text}]`, async () => {
+					if (!experimentalImageMetadataDefault) {
+						return;
+					}
+					const buildKitOption = (options?.useBuildKit ?? false) ? '' : ' --buildkit=never';
+					const res = await shellExec(`${cli} up --workspace-folder ${imageTestFolder} --skip-persisting-remote-env-from-config --remove-existing-container${buildKitOption}`);
+					const response = JSON.parse(res.stdout);
+					assert.strictEqual(response.outcome, 'success');
+					const details = JSON.parse((await shellExec(`docker inspect ${response.containerId}`)).stdout)[0] as ContainerDetails;
+					const metadata = internalGetImageMetadata0(details, true, nullLog);
+					assert.strictEqual(metadata.length, 1);
+					assert.ok(!metadata[0].remoteEnv); // remoteEnv is not stored on container metadata label
+					const result = await shellExec(`docker exec ${response.containerId} cat /postCreateCommand.txt`);
+					assert.strictEqual(result.stdout, 'Val: ENV\n'); // remoteEnv is available to lifecycle hooks
+
+					const readConfigRes = await shellExec(`${cli} read-configuration --container-id ${response.containerId} --workspace-folder ${imageTestFolder} --include-merged-configuration`);
+					const readConfig = JSON.parse(readConfigRes.stdout);
+					assert.strictEqual(readConfig.mergedConfiguration.postCreateCommands.length, 1);
+					const configRemoteEnv = readConfig.configuration.remoteEnv;
+					assert.ok(configRemoteEnv);
+					assert.strictEqual(configRemoteEnv.TEST, 'ENV');
+					assert.strictEqual(configRemoteEnv.TEST_ESCAPING, '{\n  "fo$o": "ba\'r"\n}');
+					const mergedConfigRemoteEnv = readConfig.mergedConfiguration.remoteEnv;
+					assert.ok(mergedConfigRemoteEnv);
+					assert.strictEqual(mergedConfigRemoteEnv.TEST, 'ENV');
+					assert.strictEqual(mergedConfigRemoteEnv.TEST_ESCAPING, '{\n  "fo$o": "ba\'r"\n}');
+
 					await shellExec(`docker rm -f ${response.containerId}`);
 				});
 			});
@@ -201,6 +231,27 @@ describe('Image Metadata', function () {
 			assert.strictEqual(raw[1].remoteUser, 'testUser');
 		});
 
+		it('should omit specified props from devcontainer.json for raw', () => {
+			const omitDevcontainerPropertyOverride: (keyof DevContainerConfig & keyof ImageMetadataEntry)[] = ['remoteEnv'];
+			const { config: metadata, raw } = getDevcontainerMetadata(configWithRaw([]), configWithRaw({
+				configFilePath: URI.parse('file:///devcontainer.json'),
+				image: 'image',
+				remoteUser: 'testUser',
+				remoteEnv: {
+					DEVCONTENV: 'value',
+				}
+			}),
+				undefined,
+				[],
+				omitDevcontainerPropertyOverride);
+			assert.strictEqual(metadata.length, 1);
+			assert.strictEqual(metadata[0].remoteUser, 'testUser');
+			assert.strictEqual(metadata[0].remoteEnv?.DEVCONTENV, 'value');
+			assert.strictEqual(raw.length, 1);
+			assert.strictEqual(raw[0].remoteUser, 'testUser');
+			assert.ok(!raw[0].remoteEnv);
+		});
+
 		const testContainerDetails: ContainerDetails = {
 			Id: 'testId',
 			Created: '2022-10-11T08:31:30.10478055Z',
@@ -222,7 +273,7 @@ describe('Image Metadata', function () {
 			},
 			Ports: [],
 		};
-	
+
 		it('should read metadata from existing container', () => {
 			const { config: metadata, raw } = getImageMetadataFromContainer({
 				...testContainerDetails,
@@ -251,7 +302,7 @@ describe('Image Metadata', function () {
 			assert.strictEqual(raw[0].remoteUser, 'testMetadataUser');
 			assert.strictEqual(raw[1].remoteUser, 'testConfigUser');
 		});
-	
+
 		it('should add config for existing container without id labels', () => {
 			const { config: metadata, raw } = getImageMetadataFromContainer({
 				...testContainerDetails,
@@ -279,7 +330,7 @@ describe('Image Metadata', function () {
 			assert.strictEqual(raw[0].remoteUser, 'testMetadataUser');
 			assert.strictEqual(raw[1].remoteUser, 'testConfigUser');
 		});
-	
+
 		it('should update config for existing container', () => {
 			const { config: metadata, raw } = getImageMetadataFromContainer({
 				...testContainerDetails,


### PR DESCRIPTION
Ability to skip storing remoteEnv from devcontainer config on container metadata label, by using the new option `skip-persisting-remote-env-from-config` for the `up` command.

This will help users to avoid putting sensitive variables/secrets on the image label.