### PR TITLE
Add support for Docker credential helpers

### DIFF
--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -1,5 +1,4 @@
 import * as os from 'os';
-import * as fs from 'fs';
 import * as path from 'path';
 import * as jsonc from 'jsonc-parser';
 
@@ -221,7 +220,7 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 			let defaultCredHelper = '';
 			// Try platform-specific default credential helper
 			if (process.platform === 'linux') {
-				if (existsInPath('pass')) {
+				if (await existsInPath('pass')) {
 					defaultCredHelper = 'pass';
 				} else {
 					defaultCredHelper = 'secret';
@@ -246,14 +245,14 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 	return;
 }
 
-function existsInPath(filename: string): boolean {
+async function existsInPath(filename: string): Promise<boolean> {
 	if (!process.env.PATH) {
 		return false;
 	}
 	const paths = process.env.PATH.split(':');
 	for (const path of paths) {
 		const fullPath = `${path}/${filename}`;
-		if (fs.existsSync(fullPath)) {
+		if (await isLocalFile(fullPath)) {
 			return true;
 		}
 	}

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -232,7 +232,7 @@ async function getCredentialFromHelper(params: CommonParams, registry: string, c
 			stdin: Buffer.from(registry, 'utf-8'),
 			output,
 		});
-		helperOutput = stdout
+		helperOutput = stdout;
 	} catch (err) {
 		output.write(`[httpOci] Failed to execute credential helper ${credHelperName}"`, LogLevel.Error);
 		return undefined;

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -18,7 +18,7 @@ interface DockerConfigFile {
 		};
 	};
 	credHelpers: {
-		[registry: string]: string
+		[registry: string]: string;
 	};
 	credsStore: string;
 }
@@ -177,7 +177,7 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 					const dockerConfig: DockerConfigFile = jsonc.parse((await readLocalFile(dockerConfigPath)).toString());
 
 					if (dockerConfig.auths && dockerConfig.auths[registry]) {
-						output.write(`[httpOci] Found auths entry in config.json for registry '${registry}'`, LogLevel.Trace);
+						output.write(`[httpOci] Found auths entry in '${dockerConfigPath}' for registry '${registry}'`, LogLevel.Trace);
 						const auth = dockerConfig.auths[registry].auth;
 						const identityToken = dockerConfig.auths[registry].identitytoken; // Refresh token, seen when running: 'az acr login -n <registry>'
 
@@ -196,7 +196,7 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 					}
 					if (dockerConfig.credHelpers && dockerConfig.credHelpers[registry]) {
 						const credHelper = dockerConfig.credHelpers[registry];
-						output.write(`[httpOci] Found credential helper '${credHelper}' in config.json for registry '${registry}'`, LogLevel.Trace);
+						output.write(`[httpOci] Found credential helper '${credHelper}' in '${dockerConfigPath}' registry '${registry}'`, LogLevel.Trace);
 						const auth = await getCredentialFromHelper(params, registry, credHelper);
 						if (auth) {
 							return auth;
@@ -241,7 +241,7 @@ async function getCredentialFromHelper(params: CommonParams, registry: string, c
 			base64EncodedCredential: undefined,
 		};
 	}
-	const userToken = creds.Username+':'+creds.Secret
+	const userToken = `${creds.Username}:${creds.Secret}`;
 	return {
 		base64EncodedCredential: Buffer.from(userToken).toString('base64'),
 		refreshToken: undefined,

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -248,7 +248,7 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 
 function existsInPath(filename: string): boolean {
 	if (!process.env.PATH) {
-		return false
+		return false;
 	}
 	const paths = process.env.PATH.split(':');
 	for (const path of paths) {

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -234,7 +234,13 @@ async function getCredentialFromHelper(params: CommonParams, registry: string, c
 		return undefined;
 	}
 
-	const creds:CredentialHelperResult = jsonc.parse(stdout.toString());
+	let errors: jsonc.ParseError[] = [];
+	const creds:CredentialHelperResult = jsonc.parse(stdout.toString(), errors);
+	if (errors.length !== 0) {
+		output.write(`[httpOci] Credential helper ${credHelperName} returned non-JSON response "${stdout.toString()}" for registry ${registry}`, LogLevel.Warning);
+		return undefined;
+	}
+
 	if (creds.Username === '<token>') {
 		return {
 			refreshToken: creds.Secret,


### PR DESCRIPTION
This adds the ability to retrieve registry credentials from a credential helper specified in `credHelpers` or `credsStore` inside ~/.docker/config.json.