### PR TITLE
Fetch Features/Templates by digest

### DIFF
--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -20,6 +20,7 @@ export interface CommonParams {
 
 // Represents the unique OCI identifier for a Feature or Template.
 // eg:  ghcr.io/devcontainers/features/go:1.0.0
+// eg:  ghcr.io/devcontainers/features/go@sha256:fe73f123927bd9ed1abda190d3009c4d51d0e17499154423c5913cf344af15a3
 // Constructed by 'getRef()'
 export interface OCIRef {
 	registry: string; 		// 'ghcr.io'
@@ -28,7 +29,10 @@ export interface OCIRef {
 	path: string;			// 'devcontainers/features/go'
 	resource: string;		// 'ghcr.io/devcontainers/features/go'
 	id: string;				// 'go'
-	version?: string;		// '1.0.0'
+
+	version: string;		// (Either the contents of 'tag' or 'digest')
+	tag?: string;			// '1.0.0'
+	digest?: string; 		// 'sha256:fe73f123927bd9ed1abda190d3009c4d51d0e17499154423c5913cf344af15a3'
 }
 
 // Represents the unique OCI identifier for a Collection's Metadata artifact.
@@ -38,6 +42,7 @@ export interface OCICollectionRef {
 	registry: string;		// 'ghcr.io'
 	path: string;			// 'devcontainers/features'
 	resource: string;		// 'ghcr.io/devcontainers/features'
+	tag: 'latest';			// 'latest' (always)
 	version: 'latest';		// 'latest' (always)
 }
 
@@ -88,12 +93,14 @@ interface OCIImageIndex {
 // Following Spec:   https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests
 // Alternative Spec: https://docs.docker.com/registry/spec/api/#overview
 //
-// Entire path ('namespace' in spec terminology) for the given repository 
+// The path:
+// 'namespace' in spec terminology for the given repository
 // (eg: devcontainers/features/go)
 const regexForPath = /^[a-z0-9]+([._-][a-z0-9]+)*(\/[a-z0-9]+([._-][a-z0-9]+)*)*$/;
+// The reference:
 // MUST be either (a) the digest of the manifest or (b) a tag
 // MUST be at most 128 characters in length and MUST match the following regular expression:
-const regexForReference = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/;
+const regexForVersionOrDigest = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/;
 
 // https://go.dev/doc/install/source#environment
 // Expected by OCI Spec as seen here: https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions
@@ -124,20 +131,49 @@ export function getRef(output: Log, input: string): OCIRef | undefined {
 	input = input.toLowerCase();
 
 	const indexOfLastColon = input.lastIndexOf(':');
+	const indexOfLastAtCharacter = input.lastIndexOf('@');
 
 	let resource = '';
-	let version = ''; // TODO: Support parsing out manifest digest (...@sha256:...)
+	let tag: string | undefined = undefined;
+	let digest: string | undefined = undefined;
 
-	// 'If' condition is true in the following cases:
-	//  1. The final colon is before the first slash (a port) :  eg:   ghcr.io:8081/codspace/features/ruby
-	//  2. There is no version :      				   			 eg:   ghcr.io/codspace/features/ruby
-	// In both cases, assume 'latest' tag.
-	if (indexOfLastColon === -1 || indexOfLastColon < input.indexOf('/')) {
-		resource = input;
-		version = 'latest';
+	if (indexOfLastAtCharacter !== -1) {
+		// The version is specified by digest
+		// eg: ghcr.io/codspace/features/ruby@sha256:abcdefgh
+		resource = input.substring(0, indexOfLastAtCharacter);
+		const digestWithHashingAlgorithm = input.substring(indexOfLastAtCharacter + 1);
+		const splitOnColon = digestWithHashingAlgorithm.split(':');
+		if (splitOnColon.length !== 2) {
+			output.write(`Failed to parse digest '${digestWithHashingAlgorithm}'.   Expected format: 'sha256:abcdefghijk'`, LogLevel.Error);
+			return undefined;
+		}
+
+		if (splitOnColon[0] !== 'sha256') {
+			output.write(`Digest algorithm for input '${input}' failed validation.  Expected hashing algorithm to be 'sha256'.`, LogLevel.Error);
+			return undefined;
+		}
+
+		if (!regexForVersionOrDigest.test(splitOnColon[1])) {
+			output.write(`Digest for input '${input}' failed validation.  Expected digest to match regex '${regexForVersionOrDigest}'.`, LogLevel.Error);
+		}
+
+		digest = digestWithHashingAlgorithm;
 	} else {
-		resource = input.substring(0, indexOfLastColon);
-		version = input.substring(indexOfLastColon + 1);
+		// In both cases, assume 'latest' tag.
+		if (indexOfLastColon === -1 || indexOfLastColon < input.indexOf('/')) {
+			//  1. The final colon is before the first slash (a port)
+			//     eg:   ghcr.io:8081/codspace/features/ruby
+			//  2. There is no tag at all
+			//     eg:   ghcr.io/codspace/features/ruby
+			// In both cases, assume the 'latest' tag
+			resource = input;
+			tag = 'latest';
+		} else {
+			// The version is specified by tag
+			// eg: ghcr.io/codspace/features/ruby:1.0.0
+			resource = input.substring(0, indexOfLastColon);
+			tag = input.substring(indexOfLastColon + 1);
+		}
 	}
 
 	const splitOnSlash = resource.split('/');
@@ -149,36 +185,48 @@ export function getRef(output: Log, input: string): OCIRef | undefined {
 
 	const path = `${namespace}/${id}`;
 
+	const version = digest || tag || 'latest'; // The most specific version.
+
 	output.write(`> input: ${input}`, LogLevel.Trace);
 	output.write(`>`, LogLevel.Trace);
 	output.write(`> resource: ${resource}`, LogLevel.Trace);
 	output.write(`> id: ${id}`, LogLevel.Trace);
-	output.write(`> version: ${version}`, LogLevel.Trace);
 	output.write(`> owner: ${owner}`, LogLevel.Trace);
 	output.write(`> namespace: ${namespace}`, LogLevel.Trace); // TODO: We assume 'namespace' includes at least one slash (eg: 'devcontainers/features')
 	output.write(`> registry: ${registry}`, LogLevel.Trace);
 	output.write(`> path: ${path}`, LogLevel.Trace);
+	output.write(`>`, LogLevel.Trace);
+	output.write(`> version: ${version}`, LogLevel.Trace);
+	output.write(`> tag?: ${tag}`, LogLevel.Trace);
+	output.write(`> digest?: ${digest}`, LogLevel.Trace);
 
-	// Validate results of parse.
+	// -- Validate results of parse.
 
 	if (!regexForPath.exec(path)) {
-		output.write(`Parsed path '${path}' for input '${input}' failed validation.`, LogLevel.Error);
+		output.write(`Path '${path}' for input '${input}' failed validation.  Expected path to match regex '${regexForPath}'.`, LogLevel.Error);
 		return undefined;
 	}
 
-	if (!regexForReference.test(version)) {
-		output.write(`Parsed version '${version}' for input '${input}' failed validation.`, LogLevel.Error);
+	if (digest && tag) {
+		output.write(`Parsed both a digest ('${digest}') and a tag ('${tag}') for input '${input}'. Resource can only have one.`, LogLevel.Error);
+		return undefined;
+	}
+
+	if (tag && !regexForVersionOrDigest.test(tag)) {
+		output.write(`Tag '${tag}' for input '${input}' failed validation.  Expected digest to match regex '${regexForVersionOrDigest}'.`, LogLevel.Error);
 		return undefined;
 	}
 
 	return {
 		id,
-		version,
 		owner,
 		namespace,
 		registry,
 		resource,
 		path,
+		version,
+		tag,
+		digest,
 	};
 }
 
@@ -203,7 +251,8 @@ export function getCollectionRef(output: Log, registry: string, namespace: strin
 		registry,
 		path,
 		resource,
-		version: 'latest'
+		version: 'latest',
+		tag: 'latest',
 	};
 }
 

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -724,18 +724,14 @@ export async function getFeatureIdType(params: CommonParams, userFeatureId: stri
 		return { type: 'file-path', manifest: undefined };
 	}
 
-	// version identifier for a github release feature.
-	// DEPRECATED: This is a legacy feature-set ID
-	if (userFeatureId.includes('@')) {
-		return { type: 'github-repo', manifest: undefined };
-	}
-
 	const manifest = await fetchOCIFeatureManifestIfExistsFromUserIdentifier(params, userFeatureId);
 	if (manifest) {
 		return { type: 'oci', manifest: manifest };
 	} else {
+		output.write(`Could not resolve Feature manifest for '${userFeatureId}'.  If necessary, provide registry credentials with 'docker login <registry>'.`, LogLevel.Warning);
+		output.write(`Falling back to legacy GitHub Releases mode to acquire Feature.`, LogLevel.Trace);
+
 		// DEPRECATED: This is a legacy feature-set ID
-		output.write('(!) WARNING: Falling back to deprecated GitHub Release syntax. See https://github.com/devcontainers/spec/blob/main/proposals/devcontainer-features.md#referencing-a-feature for updated specification.', LogLevel.Warning);
 		return { type: 'github-repo', manifest: undefined };
 	}
 }

--- a/src/test/container-features/configs/dockerfile-with-v2-oci-features/.devcontainer.json
+++ b/src/test/container-features/configs/dockerfile-with-v2-oci-features/.devcontainer.json
@@ -7,7 +7,7 @@
 	},
 	"features": {
 		"terraform": "latest",
-		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker@sha256:e32e8937c87345ff7a937d22cacb7f395d41deffde9943291ef3cc0ac91a8ac6": {},
 		"node": "16"
 	}
 }

--- a/src/test/container-features/containerFeaturesOrder.test.ts
+++ b/src/test/container-features/containerFeaturesOrder.test.ts
@@ -152,6 +152,7 @@ describe('Container features install order', function () {
                     registry: spiltOnSlash[0],
                     resource: splitOnColon[0],
                     tag: splitOnColon[1],
+                    version: splitOnColon[1],
                     path: `${spiltOnSlash[1]}/${spiltOnSlash[2]}/spiltOnSlash[3]`
                 },
                 manifest: {

--- a/src/test/container-features/containerFeaturesOrder.test.ts
+++ b/src/test/container-features/containerFeaturesOrder.test.ts
@@ -151,7 +151,7 @@ describe('Container features install order', function () {
                     owner: spiltOnSlash[1],
                     registry: spiltOnSlash[0],
                     resource: splitOnColon[0],
-                    version: splitOnColon[1],
+                    tag: splitOnColon[1],
                     path: `${spiltOnSlash[1]}/${spiltOnSlash[2]}/spiltOnSlash[3]`
                 },
                 manifest: {

--- a/src/test/container-features/featureHelpers.test.ts
+++ b/src/test/container-features/featureHelpers.test.ts
@@ -207,9 +207,46 @@ describe('validate processFeatureIdentifier', async function () {
 				namespace: 'codspace/features',
 				registry: 'ghcr.io',
 				tag: 'latest',
+				digest: undefined,
 				version: 'latest',
 				resource: 'ghcr.io/codspace/features/ruby',
 				path: 'codspace/features/ruby',
+			};
+
+			if (featureSet.sourceInformation.type === 'oci') {
+				assert.ok(featureSet.sourceInformation.type === 'oci');
+				assert.deepEqual(featureSet.sourceInformation.featureRef, expectedFeatureRef);
+			} else {
+				assert.fail('sourceInformation.type is not oci');
+			}
+		});
+
+		it('should process oci registry (with a digest)', async function () {
+			const userFeature: DevContainerFeature = {
+				id: 'ghcr.io/devcontainers/features/ruby@sha256:4ef08c9c3b708f3c2faecc5a898b39736423dd639f09f2a9f8bf9b0b9252ef0a',
+				options: {},
+			};
+
+			const featureSet = await processFeatureIdentifier(params, defaultConfigPath, workspaceRoot, userFeature);
+			if (!featureSet) {
+				assert.fail('processFeatureIdentifier returned null');
+			}
+			const featureId = featureSet.features[0].id;
+			assertFeatureIdInvariant(featureId);
+			assert.strictEqual(featureSet?.features[0].id, 'ruby');
+
+			assert.exists(featureSet);
+
+			const expectedFeatureRef: OCIRef = {
+				id: 'ruby',
+				owner: 'devcontainers',
+				namespace: 'devcontainers/features',
+				registry: 'ghcr.io',
+				tag: undefined,
+				digest: 'sha256:4ef08c9c3b708f3c2faecc5a898b39736423dd639f09f2a9f8bf9b0b9252ef0a',
+				version: 'sha256:4ef08c9c3b708f3c2faecc5a898b39736423dd639f09f2a9f8bf9b0b9252ef0a',
+				resource: 'ghcr.io/devcontainers/features/ruby',
+				path: 'devcontainers/features/ruby',
 			};
 
 			if (featureSet.sourceInformation.type === 'oci') {
@@ -242,6 +279,7 @@ describe('validate processFeatureIdentifier', async function () {
 				namespace: 'codspace/features',
 				registry: 'ghcr.io',
 				tag: '1.0.13',
+				digest: undefined,
 				version: '1.0.13',
 				resource: 'ghcr.io/codspace/features/ruby',
 				path: 'codspace/features/ruby',

--- a/src/test/container-features/featureHelpers.test.ts
+++ b/src/test/container-features/featureHelpers.test.ts
@@ -206,6 +206,7 @@ describe('validate processFeatureIdentifier', async function () {
 				owner: 'codspace',
 				namespace: 'codspace/features',
 				registry: 'ghcr.io',
+				tag: 'latest',
 				version: 'latest',
 				resource: 'ghcr.io/codspace/features/ruby',
 				path: 'codspace/features/ruby',
@@ -240,6 +241,7 @@ describe('validate processFeatureIdentifier', async function () {
 				owner: 'codspace',
 				namespace: 'codspace/features',
 				registry: 'ghcr.io',
+				tag: '1.0.13',
 				version: '1.0.13',
 				resource: 'ghcr.io/codspace/features/ruby',
 				path: 'codspace/features/ruby',
@@ -582,6 +584,7 @@ chmod +x ./install.sh
 					path: 'my-org/my-repo/test',
 					resource: 'ghcr.io/my-org/my-repo/test',
 					id: 'test',
+					tag: '1.2.3',
 					version: '1.2.3',
 				},
 				manifest: {
@@ -664,6 +667,7 @@ chmod +x ./install.sh
 					path: 'my-org/my-repo/test',
 					resource: 'ghcr.io/my-org/my-repo/test',
 					id: 'test',
+					tag: '1.2.3',
 					version: '1.2.3',
 				},
 				manifest: {
@@ -749,6 +753,7 @@ chmod +x ./install.sh
 					path: 'my-org/my-repo/test',
 					resource: 'ghcr.io/my-org/my-repo/test',
 					id: 'test',
+					tag: '1.2.3',
 					version: '1.2.3',
 				},
 				manifest: {

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -540,6 +540,7 @@ function getFeaturesConfig(features: Feature[]): FeaturesConfig {
 					resource: 'ghcr.io/my-org/my-repo/test',
 					id: 'test',
 					tag: '1.2.3',
+					version: '1.2.3',
 				},
 				manifest: {
 					schemaVersion: 1,

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -539,7 +539,7 @@ function getFeaturesConfig(features: Feature[]): FeaturesConfig {
 					path: 'my-org/my-repo/test',
 					resource: 'ghcr.io/my-org/my-repo/test',
 					id: 'test',
-					version: '1.2.3',
+					tag: '1.2.3',
 				},
 				manifest: {
 					schemaVersion: 1,


### PR DESCRIPTION
ref: https://github.com/devcontainers/cli/issues/479

Previously, all Features and Templates resolved a digest and associated manifest by tag.  This change also allow resolving the Feature or Template by sha256 digest directly. 

Eg: 
```json
{
  "features": {
    "ghcr.io/devcontainers/features/git-lfs@sha256:9e0b6df853ec932203945b76b9cfa7470ebd1f8bd765484027608581f9cf8a77": {}
  }
}
```