### PR TITLE
Add regression testing and reorganize auth precedence levels `httpOCIRegistry`

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -56,7 +56,6 @@ jobs:
           "src/test/cli.up.test.ts",
           "src/test/imageMetadata.test.ts",
           "src/test/container-features/containerFeaturesOCIPush.test.ts",
-          "src/test/container-features/registryCompatibilityOCI.test.ts",
           # Run all except the above:
           "--exclude src/test/container-features/registryCompatibilityOCI.test.ts --exclude src/test/container-features/containerFeaturesOCIPush.test.ts --exclude src/test/container-features/e2e.test.ts --exclude src/test/container-features/featuresCLICommands.test.ts --exclude src/test/container-features/containerFeaturesOrder.test.ts --exclude src/test/cli.build.test.ts --exclude src/test/cli.exec.buildKit.1.test.ts --exclude src/test/cli.exec.buildKit.2.test.ts --exclude src/test/cli.exec.nonBuildKit.1.test.ts --exclude src/test/cli.exec.nonBuildKit.2.test.ts --exclude src/test/cli.test.ts --exclude src/test/cli.up.test.ts --exclude src/test/imageMetadata.test.ts 'src/test/**/*.test.ts'",
         ]
@@ -79,10 +78,40 @@ jobs:
       run: yarn test-matrix --forbid-only ${{ matrix.mocha-args }}
       env:
         CI: true
+
+  features-registry-compatibility:
+    name: OCI Implementation Registry Compatibility
+    # TODO: This should be expanded to run on different platforms
+    #       Most notably to test platform-specific credential helper behavior
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '16.x'
+        registry-url: 'https://npm.pkg.github.com'
+        scope: '@microsoft'
+    - name: Install Dependencies
+      run: yarn install --frozen-lockfile
+    - name: Type-Check
+      run: yarn type-check
+    - name: Package
+      run: yarn package
+    - name: Run Tests
+      run: yarn test-matrix --forbid-only src/test/container-features/registryCompatibilityOCI.test.ts
+      env:
+        CI: true
+        # This variable should only be set in the parent `devcontainers/cli` repo.
         RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI: ${{ vars.RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI }}
+        # Scoped to read private packages in the `devcontainers` org (for testing purposes)
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
   tests:
     name: Tests
-    needs: tests-matrix
+    needs: [tests-matrix, features-registry-compatibility]
     runs-on: ubuntu-latest
     steps:
     - name: Done

--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -77,6 +77,9 @@ jobs:
       run: yarn package
     - name: Run Tests
       run: yarn test-matrix --forbid-only ${{ matrix.mocha-args }}
+      env:
+        CI: true
+        RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI: ${{ env.RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI }}
   tests:
     name: Tests
     needs: tests-matrix

--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -79,7 +79,7 @@ jobs:
       run: yarn test-matrix --forbid-only ${{ matrix.mocha-args }}
       env:
         CI: true
-        RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI: ${{ env.RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI }}
+        RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI: ${{ vars.RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI }}
   tests:
     name: Tests
     needs: tests-matrix

--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -107,6 +107,8 @@ jobs:
         RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI: ${{ vars.RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI }}
         # Scoped to read private packages in the `devcontainers` org (for testing purposes)
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Pull-only credential for a test Azure CR instance
+        FEATURES_TEST__AZURE_REGISTRY_SCOPED_CREDENTIAL: ${{ secrets.FEATURES_TEST__AZURE_REGISTRY_SCOPED_CREDENTIAL }}
 
 
   tests:

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -193,16 +193,12 @@ async function existsInPath(filename: string): Promise<boolean> {
 	if (!process.env.PATH) {
 		return false;
 	}
-	try {
-		const paths = process.env.PATH.split(':');
-		for (const path of paths) {
-			const fullPath = `${path}/${filename}`;
-			if (await isLocalFile(fullPath)) {
-				return true;
-			}
+	const paths = process.env.PATH.split(':');
+	for (const path of paths) {
+		const fullPath = `${path}/${filename}`;
+		if (await isLocalFile(fullPath)) {
+			return true;
 		}
-	} catch (err) {
-		return false;
 	}
 	return false;
 }

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -173,7 +173,7 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 		return credentialFromDockerConfig;
 	}
 
-	if (registry === 'ghcr.io' && githubToken && (!githubHost || githubHost === 'ghcr.io')) {
+	if (registry === 'ghcr.io' && githubToken && (!githubHost || githubHost === 'github.com')) {
 		output.write('[httpOci] Using environment GITHUB_TOKEN for auth', LogLevel.Trace);
 		const userToken = `USERNAME:${env['GITHUB_TOKEN']}`;
 		return {

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -148,9 +148,6 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 	const { output, env } = params;
 	const { registry } = ociRef;
 
-	const githubToken = env['GITHUB_TOKEN'];
-	const githubHost = env['GITHUB_HOST'];
-
 	if (!!env['DEVCONTAINERS_OCI_AUTH']) {
 		// eg: DEVCONTAINERS_OCI_AUTH=service1|user1|token1,service2|user2|token2
 		const authContexts = env['DEVCONTAINERS_OCI_AUTH'].split(',');
@@ -167,12 +164,17 @@ async function getCredential(params: CommonParams, ociRef: OCIRef | OCICollectio
 		}
 	}
 
-	// Attempt to use the docker config file or available credential helpers.
+	// Attempt to use the docker config file or available credential helper(s).
 	const credentialFromDockerConfig = await getCredentialFromDockerConfigOrCredentialHelper(params, registry);
 	if (credentialFromDockerConfig) {
 		return credentialFromDockerConfig;
 	}
 
+	const githubToken = env['GITHUB_TOKEN'];
+	const githubHost = env['GITHUB_HOST'];
+	if (githubHost) {
+		output.write(`[httpOci] Environment GITHUB_HOST is set to '${githubHost}'`, LogLevel.Trace);
+	}
 	if (registry === 'ghcr.io' && githubToken && (!githubHost || githubHost === 'github.com')) {
 		output.write('[httpOci] Using environment GITHUB_TOKEN for auth', LogLevel.Trace);
 		const userToken = `USERNAME:${env['GITHUB_TOKEN']}`;

--- a/src/test/container-features/configs/azure-container-registry/.devcontainer.json
+++ b/src/test/container-features/configs/azure-container-registry/.devcontainer.json
@@ -1,8 +1,0 @@
-{
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-	"features": {
-		"devcontainercli.azurecr.io/features/color:1": {
-			"favorite": "pink"
-		}
-	}
-}

--- a/src/test/container-features/configs/registry-compatibility/azure-anonymous/.devcontainer.json
+++ b/src/test/container-features/configs/registry-compatibility/azure-anonymous/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"devcontainercli.azurecr.io/features/color:1": {
+			"favorite": "pink"
+		}
+	}
+}

--- a/src/test/container-features/configs/registry-compatibility/azure-registry-scoped/.devcontainer.json
+++ b/src/test/container-features/configs/registry-compatibility/azure-registry-scoped/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"privatedevcontainercli.azurecr.io/features/rabbit:1": {}
+	}
+}

--- a/src/test/container-features/configs/registry-compatibility/github-anonymous/.devcontainer.json
+++ b/src/test/container-features/configs/registry-compatibility/github-anonymous/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/feature-starter/color:1": {
+			"favorite": "pink"
+		}
+	}
+}

--- a/src/test/container-features/configs/registry-compatibility/github-private/.devcontainer.json
+++ b/src/test/container-features/configs/registry-compatibility/github-private/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/private-feature-set-for-tests/color:1": {
+			"favorite": "pink"
+		}
+	}
+}

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -7,7 +7,6 @@ export const output = makeLog(createPlainLog(text => process.stdout.write(text),
 describe('getCollectionRef()', async function () {
     this.timeout('240s');
 
-
     it('valid getCollectionRef()', async () => {
         const collectionRef = getCollectionRef(output, 'ghcr.io', 'devcontainers/templates');
         if (!collectionRef) {
@@ -166,8 +165,10 @@ describe('getRef()', async function () {
 
 });
 
-describe('Test OCI Pull', () => {
-    it('Parse OCI identifier', async () => {
+describe('Test OCI Pull', async function () {
+    this.timeout('10s');
+
+    it('Parse OCI identifier', async function () {
         const feat = getRef(output, 'ghcr.io/codspace/features/ruby:1');
         if (!feat) {
             assert.fail('featureRef should not be undefined');

--- a/src/test/container-features/generateFeaturesConfig.test.ts
+++ b/src/test/container-features/generateFeaturesConfig.test.ts
@@ -156,7 +156,7 @@ RUN chmod -R 0755 /tmp/dev-container-features/hello_4 \\
     });
 
     it('should correctly return featuresConfig with customizations', async function () {
-        this.timeout('10s');
+        this.timeout('20s');
         const version = 'unittest';
         const tmpFolder: string = path.join(await getLocalCacheFolder(), 'container-features', `${version}-${Date.now()}`);
         await mkdirpLocal(tmpFolder);

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -9,9 +9,34 @@ import { devContainerDown, devContainerUp, shellExec } from '../testUtils';
 
 const pkg = require('../../../package.json');
 
-describe('Registry Compatibility', function () {
-	this.timeout('120s');
+interface TestPlan {
+	name: string;
+	configName: string;
+	testFeatureId: string;
+	testCommand?: string;
+	testCommandResult?: RegExp;
+}
 
+const defaultTestPlan = {
+	testCommand: 'color',
+	testCommandResult: /my favorite color is pink/,
+};
+
+const registryCompatibilityTestPlan: TestPlan[] = [
+	{
+		name: 'Anonymous access of Azure Container Registry',
+		configName: 'azure-anonymous',
+		testFeatureId: 'devcontainercli.azurecr.io/features/color',
+	},
+	{
+		name: 'Anonymous access of GHCR',
+		configName: 'github-anonymous',
+		testFeatureId: 'ghcr.io/devcontainers/feature-starter/color',
+	}
+];
+
+describe('Registry Compatibility', function () {
+	this.timeout('1200s');
 	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
 	const cli = `npx --prefix ${tmp} devcontainer`;
 
@@ -21,41 +46,43 @@ describe('Registry Compatibility', function () {
 		await shellExec(`npm --prefix ${tmp} install devcontainers-cli-${pkg.version}.tgz`);
 	});
 
-	// TODO: Matrix this test against all tested registries
-	describe('Azure Container Registry', () => {
+	registryCompatibilityTestPlan.forEach(({ name, configName, testFeatureId, testCommand, testCommandResult }) => {
+		this.timeout('120s');
+		describe(name, () => {
+			describe('devcontainer up', () => {
+				let containerId: string | null = null;
+				const testFolder = `${__dirname}/configs/registry-compatibility/${configName}`;
 
-		describe(`'devcontainer up' with a Feature anonymously pulled from ACR`, () => {
-			let containerId: string | null = null;
-			const testFolder = `${__dirname}/configs/azure-container-registry`;
+				before(async () => containerId = (await devContainerUp(cli, testFolder, { 'logLevel': 'trace' })).containerId);
+				after(async () => await devContainerDown({ containerId }));
 
-			before(async () => containerId = (await devContainerUp(cli, testFolder, { 'logLevel': 'trace' })).containerId);
-			after(async () => await devContainerDown({ containerId }));
+				const cmd = testCommand ?? defaultTestPlan.testCommand;
+				const expected = testCommandResult ?? defaultTestPlan.testCommandResult;
 
-			it('should exec the color command', async () => {
-				const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} color`);
-				assert.strictEqual(res.error, null);
-				assert.match(res.stdout, /my favorite color is pink/);
+				it(`should exec the ${cmd} command`, async () => {
+					const res = await shellExec(`${cli} exec --workspace-folder ${testFolder} ${cmd} `);
+					assert.strictEqual(res.error, null);
+					assert.match(res.stdout, expected);
+				});
 			});
-		});
 
-		describe(`devcontainer features info manifest`, async () => {
+			describe(`devcontainer features info manifest`, async () => {
+				it('fetches manifest', async () => {
+					let infoManifestResult: { stdout: string; stderr: string } | null = null;
+					let success = false;
+					try {
+						infoManifestResult = await shellExec(`${cli} features info manifest ${testFeatureId} --log-level trace`);
+						success = true;
+					} catch (error) {
+						assert.fail('features info tags sub-command should not throw');
+					}
 
-			it('fetches manifest anonymously from ACR', async () => {
-
-				let infoManifestResult: { stdout: string; stderr: string } | null = null;
-				let success = false;
-				try {
-					infoManifestResult = await shellExec(`${cli} features info manifest devcontainercli.azurecr.io/features/hello --log-level trace`);
-					success = true;
-				} catch (error) {
-					assert.fail('features info tags sub-command should not throw');
-				}
-
-				assert.isTrue(success);
-				assert.isDefined(infoManifestResult);
-				const manifest = infoManifestResult.stdout;
-				const regex = /application\/vnd\.devcontainers\.layer\.v1\+tar/;
-				assert.match(manifest, regex);
+					assert.isTrue(success);
+					assert.isDefined(infoManifestResult);
+					const manifest = infoManifestResult.stdout;
+					const regex = /application\/vnd\.devcontainers\.layer\.v1\+tar/;
+					assert.match(manifest, regex);
+				});
 			});
 		});
 	});

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -123,12 +123,13 @@ describe('Registry Compatibility', function () {
 			((authStrategyKey && !envVariableExists(authStrategyKey)) ? describe.skip : describe)('devcontainer up', async function () {
 
 				const authFolder = constructAuthFromStrategy(tmp, useAuthStrategy ?? AuthStrategy.Anonymous, authStrategyKey) || '/fake-path';
+				const gitHubToken = (useAuthStrategy === AuthStrategy.GitHubToken) ? (process.env.GITHUB_TOKEN ?? '') : '';
 
 				let containerId: string | null = null;
 				const testFolder = `${__dirname}/configs/registry-compatibility/${configName}`;
 
 				before(async () => containerId = (await devContainerUp(cli, testFolder, {
-					'logLevel': 'trace', prefix: `DOCKER_CONFIG=${authFolder}`
+					'logLevel': 'trace', prefix: `DOCKER_CONFIG=${authFolder} GITHUB_TOKEN=${gitHubToken}`
 				})).containerId);
 				after(async () => await devContainerDown({ containerId }));
 
@@ -145,12 +146,14 @@ describe('Registry Compatibility', function () {
 			((authStrategyKey && !envVariableExists(authStrategyKey)) ? describe.skip : describe)(`devcontainer features info manifest`, async function () {
 
 				const authFolder = constructAuthFromStrategy(tmp, useAuthStrategy ?? AuthStrategy.Anonymous, authStrategyKey) || '/fake-path';
+				const gitHubToken = (useAuthStrategy === AuthStrategy.GitHubToken) ? (process.env.GITHUB_TOKEN ?? '') : '';
 
 				it('fetches manifest', async function () {
 					let infoManifestResult: { stdout: string; stderr: string } | null = null;
 					let success = false;
 					try {
-						infoManifestResult = await shellExec(`DOCKER_CONFIG=${authFolder} ${cli} features info manifest ${testFeatureId} --log-level trace`);
+						infoManifestResult =
+							await shellExec(`DOCKER_CONFIG=${authFolder} GITHUB_TOKEN=${gitHubToken} ${cli} features info manifest ${testFeatureId} --log-level trace`);
 						success = true;
 					} catch (error) {
 						assert.fail('features info tags sub-command should not throw');

--- a/src/test/container-features/registryCompatibilityOCI.test.ts
+++ b/src/test/container-features/registryCompatibilityOCI.test.ts
@@ -67,6 +67,10 @@ const registryCompatibilityTestPlan: TestPlan[] = [
 	}
 ];
 
+function envVariableExists(key: string): boolean {
+	return !!process.env[key] && process.env[key] !== '';
+}
+
 function constructAuthFromStrategy(tmpFolder: string, authStrategy: AuthStrategy, authStrategyKey?: string): string | undefined {
 	const generateAuthFolder = () => {
 		const randomChars = Math.random().toString(36).substring(2, 6);
@@ -116,7 +120,7 @@ describe('Registry Compatibility', function () {
 	registryCompatibilityTestPlan.forEach(({ name, configName, testFeatureId, testCommand, testCommandResult, useAuthStrategy, authStrategyKey }) => {
 		this.timeout('120s');
 		describe(name, async function () {
-			((authStrategyKey && !process.env[authStrategyKey]) ? describe.skip : describe)('devcontainer up', async function () {
+			((authStrategyKey && !envVariableExists(authStrategyKey)) ? describe.skip : describe)('devcontainer up', async function () {
 
 				const authFolder = constructAuthFromStrategy(tmp, useAuthStrategy ?? AuthStrategy.Anonymous, authStrategyKey) || '/fake-path';
 
@@ -138,7 +142,7 @@ describe('Registry Compatibility', function () {
 				});
 			});
 
-			((authStrategyKey && !process.env[authStrategyKey]) ? describe.skip : describe)(`devcontainer features info manifest`, async function () {
+			((authStrategyKey && !envVariableExists(authStrategyKey)) ? describe.skip : describe)(`devcontainer features info manifest`, async function () {
 
 				const authFolder = constructAuthFromStrategy(tmp, useAuthStrategy ?? AuthStrategy.Anonymous, authStrategyKey) || '/fake-path';
 

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -81,13 +81,14 @@ export async function shellPtyExec(command: string, options: { stdin?: string } 
     }).then(res => ({ code: 0, ...res }), error => error);
 }
 
-export async function devContainerUp(cli: string, workspaceFolder: string, options?: { cwd?: string; useBuildKit?: boolean; userDataFolder?: string; logLevel?: string; extraArgs?: string }): Promise<UpResult> {
+export async function devContainerUp(cli: string, workspaceFolder: string, options?: { cwd?: string; useBuildKit?: boolean; userDataFolder?: string; logLevel?: string; extraArgs?: string; prefix?: string }): Promise<UpResult> {
     const buildkitOption = (options?.useBuildKit ?? false) ? '' : ' --buildkit=never';
     const userDataFolderOption = (options?.userDataFolder ?? false) ? ` --user-data-folder=${options?.userDataFolder}` : '';
     const logLevelOption = (options?.logLevel ?? false) ? ` --log-level ${options?.logLevel}` : '';
     const extraArgs = (options?.extraArgs ?? false) ? ` ${options?.extraArgs}` : '';
+    const prefix = (options?.prefix ?? false) ? `${options?.prefix} ` : '';
     const shellExecOptions = { cwd: options?.cwd };
-    const res = await shellExec(`${cli} up --workspace-folder ${workspaceFolder}${buildkitOption}${userDataFolderOption}${extraArgs} ${logLevelOption}`, shellExecOptions);
+    const res = await shellExec(`${prefix}${cli} up --workspace-folder ${workspaceFolder}${buildkitOption}${userDataFolderOption}${extraArgs} ${logLevelOption}`, shellExecOptions);
     const response = JSON.parse(res.stdout);
     assert.equal(response.outcome, 'success');
     const { outcome, containerId, composeProjectName } = response as UpResult;


### PR DESCRIPTION
related: https://github.com/devcontainers/cli/issues/473, #468 

Changes here are primarily around re-structuring the different auth strategies to rely more on the standard docker auth strategies (docker config file and docker credential helper), and less on the registry-specific strategies that previously held higher precedence.

The precedence order is now (encoded in [`getCredential(...)`](https://github.com/devcontainers/cli/blob/4fde394ac16df1061b731d2d2f226850277cbce2/src/spec-configuration/httpOCIRegistry.ts#L147):

   - parsed out of a special `DEVCONTAINERS_OCI_AUTH` environment variable
   - Read from a docker credential helper indicated in config
   - Read from a docker cred store indicated in config (https://docs.docker.com/engine/reference/commandline/login/#credentials-store)
   - Read from a docker config file (flat file with base64 encoded credentials)
   - Read from the platform's default credential helper
   - Crafted from the GITHUB_TOKEN environment variable

Two new minor changes have also been added:

-  If `GITHUB_HOST` is set to something other than `github.com`, `GITHUB_TOKEN` is not used for ghcr.io (useful for GitHub Enterprise instances, among other cases). Reported in #473 
- Aligning with the docker cli, `DOCKER_CONFIG` can be set to change the path that the docker config file is looked for (https://docs.docker.com/engine/reference/commandline/cli/#change-the-docker-directory).  (This is immediately useful in the tests outlined below).

---

This change also introduces significant changes to the `registryCompatibilityOCI.test.ts` test, introducing a way to quickly add "testPlans" (new registries) with different forms of provided auth.  This PR introduces four "testPlans", testing both AzureCR and GHCR both anonymous and with some form of auth.

Since we want folks to be able to fork this repo and run all the tests without failure, the tests will automatically skip if there is a set `useAuthStrategy` and no accompanying `authStrategyKey` (environment variable, containing a credential if needed for the test and parsed account according to the `useAuthStrategy` enum).  This lets us add in the necessary secrets to our GitHub Action CI tests without introducing flakey tests to other contributors who may have forks of this repo.  Mocha has a way to mark tests as "skipped", which is what we use here.

```ts
const registryCompatibilityTestPlan: TestPlan[] = [
	{
		name: 'Anonymous access of Azure Container Registry',
		configName: 'azure-anonymous',
		testFeatureId: 'devcontainercli.azurecr.io/features/color',
	},
	{
		name: 'Anonymous access of GHCR',
		configName: 'github-anonymous',
		testFeatureId: 'ghcr.io/devcontainers/feature-starter/color',
	},
	// https://learn.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions
	{
		name: 'Authenticated access of Azure Container Registry with registry scoped token',
		configName: 'azure-registry-scoped',
		testFeatureId: 'privatedevcontainercli.azurecr.io/features/rabbit',
		useAuthStrategy: AuthStrategy.DockerConfigAuthFile,
		authStrategyKey: 'FEATURES_TEST__AZURE_REGISTRY_SCOPED_CREDENTIAL',
		testCommand: 'rabbit',
		testCommandResult: /rabbit-is-the-best-animal/,
	},
	// Via GHCR visibility settings, this repo's GitHub Actions CI should be able to access this Feature via its GITHUB_TOKEN.
	{
		name: 'Private access of GHCR via an environment GITHUB_TOKEN',
		configName: 'github-private',
		testFeatureId: 'ghcr.io/devcontainers/private-feature-set-for-tests/color',
		useAuthStrategy: AuthStrategy.GitHubToken,
		authStrategyKey: 'RUNNING_IN_DEVCONTAINERS_CLI_REPO_CI'
	}
];
```

In CI on this repository the above `authStrategyKey` variables are set, so no tests should be skipped (as seen [here](https://github.com/devcontainers/cli/actions/runs/4660764835/jobs/8249229694?pr=482#step:7:1786))
