### PR TITLE
Consistent usage of digest

### DIFF
--- a/src/spec-configuration/containerCollectionsOCIPush.ts
+++ b/src/spec-configuration/containerCollectionsOCIPush.ts
@@ -313,12 +313,14 @@ async function generateCompleteManifestForCollectionFile(output: Log, dataBytes:
 export async function calculateDataLayer(output: Log, data: Buffer, basename: string, mediaType: string): Promise<OCILayer | undefined> {
 	output.write(`Creating manifest from data`, LogLevel.Trace);
 
-	const tarSha256 = crypto.createHash('sha256').update(data).digest('hex');
-	output.write(`sha256:${tarSha256} (size: ${data.byteLength})`, LogLevel.Info);
+	const algorithm = 'sha256';
+	const tarSha256 = crypto.createHash(algorithm).update(data).digest('hex');
+	const digest = `${algorithm}:${tarSha256}`;
+	output.write(`Data layer digest: ${digest} (archive size: ${data.byteLength})`, LogLevel.Info);
 
 	return {
 		mediaType,
-		digest: `sha256:${tarSha256}`,
+		digest,
 		size: data.byteLength,
 		annotations: {
 			'org.opencontainers.image.title': basename,
@@ -339,7 +341,7 @@ export async function checkIfBlobExists(params: CommonParams, ociRef: OCIRef | O
 	}
 
 	const statusCode = res.statusCode;
-	output.write(`${url}: ${statusCode}`, LogLevel.Trace);
+	output.write(`checkIfBlobExists: ${url}: ${statusCode}`, LogLevel.Trace);
 	return statusCode === 200;
 }
 
@@ -401,13 +403,15 @@ export async function calculateManifestAndContentDigest(output: Log, ociRef: OCI
 	}
 
 	const manifestBuffer = Buffer.from(JSON.stringify(manifest));
-	const manifestHash = crypto.createHash('sha256').update(manifestBuffer).digest('hex');
-	output.write(`Computed Content-Digest ->  sha256:${manifestHash} (size: ${manifestHash.length})`, LogLevel.Info);
+	const algorithm = 'sha256';
+	const manifestHash = crypto.createHash(algorithm).update(manifestBuffer).digest('hex');
+	const contentDigest = `${algorithm}:${manifestHash}`;
+	output.write(`Computed content digest from manifest: ${contentDigest}`, LogLevel.Info);
 
 	return {
 		manifestBuffer,
 		manifestObj: manifest,
-		contentDigest: manifestHash,
+		contentDigest,
 		canonicalId: `${ociRef.resource}@sha256:${manifestHash}`
 	};
 }

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -302,7 +302,7 @@ async function getCredentialFromHelper(params: CommonParams, registry: string, c
 		});
 		helperOutput = stdout;
 	} catch (err) {
-		output.write(`[httpOci] Failed to execute credential helper ${credHelperName}`, LogLevel.Error);
+		output.write(`[httpOci] Failed to query for '${registry}' credential from 'docker-credential-${credHelperName}': ${err}`, LogLevel.Trace);
 		return undefined;
 	}
 	if (helperOutput.length === 0) {
@@ -312,7 +312,7 @@ async function getCredentialFromHelper(params: CommonParams, registry: string, c
 	let errors: jsonc.ParseError[] = [];
 	const creds: CredentialHelperResult = jsonc.parse(helperOutput.toString(), errors);
 	if (errors.length !== 0) {
-		output.write(`[httpOci] Credential helper ${credHelperName} returned non-JSON response "${helperOutput.toString()}" for registry ${registry}`, LogLevel.Warning);
+		output.write(`[httpOci] Credential helper ${credHelperName} returned non-JSON response "${helperOutput.toString()}" for registry '${registry}'`, LogLevel.Warning);
 		return undefined;
 	}
 

--- a/src/test/container-features/containerFeaturesOCIPush.test.ts
+++ b/src/test/container-features/containerFeaturesOCIPush.test.ts
@@ -344,7 +344,7 @@ describe('Test OCI Push Helper Functions', function () {
 		assert.strictEqual('{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.devcontainers","digest":"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","size":0},"layers":[{"mediaType":"application/vnd.devcontainers.layer.v1+tar","digest":"sha256:b2006e7647191f7b47222ae48df049c6e21a4c5a04acfad0c4ef614d819de4c5","size":15872,"annotations":{"org.opencontainers.image.title":"go.tgz"}}]}', manifestBuffer.toString());
 
 		// This is the canonical digest of the manifest
-		assert.strictEqual('9726054859c13377c4c3c3c73d15065de59d0c25d61d5652576c0125f2ea8ed3', contentDigest);
+		assert.strictEqual('sha256:9726054859c13377c4c3c3c73d15065de59d0c25d61d5652576c0125f2ea8ed3', contentDigest);
 	});
 
 	it('Can fetch an artifact from a digest reference', async () => {


### PR DESCRIPTION
This change updates the output of the `devcontainer features publish` command to include the hashing algorithm (`sha256:`) at the beginning of the digest in the command output.  This simply makes it more consistent with how a user would pin to digest.