### PR TITLE
Install dependency modules via common js in the dev container.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 		"source=dev-containers-cli-bashhistory,target=/home/node/commandhistory"
 	],
 
-	"postCreateCommand": "yarn install",
+	"postCreateCommand": "yarn install --frozen-lockfile",
 
 	"remoteUser": "node",
 	


### PR DESCRIPTION
Ensure chalk installation in devcontainer to an earlier version, since it now uses es modules.