### PR TITLE
Add object notation support for `initializeCommand`

### DIFF
--- a/src/test/cli.exec.base.ts
+++ b/src/test/cli.exec.base.ts
@@ -104,7 +104,27 @@ export function describeTests1({ text, options }: BuildKitOption) {
 					assert.match(res.stdout, /howdy, node/);
 				});
 			});
-
+			describe(`with valid (image) config and parallel initializeCommand [${text}]`, () => {
+				let containerId: string | null = null;
+				const testFolder = `${__dirname}/configs/image-with-parallel-initialize-command`;
+				beforeEach(async () => containerId = (await devContainerUp(cli, testFolder, options)).containerId);
+				afterEach(async () => {
+					await devContainerDown({ containerId });
+					await shellExec(`rm -f ${testFolder}/*.testMarker`);
+				});
+				it('should create testMarker files', async () => {
+					{
+						const res = await shellExec(`cat ${testFolder}/initializeCommand.1.testMarker`);
+						assert.strictEqual(res.error, null);
+						assert.strictEqual(res.stderr, '');
+					}
+					{
+						const res = await shellExec(`cat ${testFolder}/initializeCommand.2.testMarker`);
+						assert.strictEqual(res.error, null);
+						assert.strictEqual(res.stderr, '');
+					}
+				});
+			});
 			describe(`with valid (Dockerfile) config with target [${text}]`, () => {
 				let containerId: string | null = null;
 				const testFolder = `${__dirname}/configs/dockerfile-with-target`;

--- a/src/test/configs/image-with-parallel-initialize-command/.devcontainer.json
+++ b/src/test/configs/image-with-parallel-initialize-command/.devcontainer.json
@@ -2,16 +2,6 @@
 	"image": "mcr.microsoft.com/devcontainers/base:alpine",
 	"initializeCommand": {
 		"touch-test1": "touch ${localWorkspaceFolder}/initializeCommand.1.testMarker",
-		"touch-test2": "touch ${localWorkspaceFolder}/initializeCommand.2.testMarker",
-		"count-to-5-slowly": [
-			"bash",
-			"-c",
-			"for i in {1..5}; do echo a-$i; sleep 1; done"
-		],
-		"count-to-5-even-slower": [
-			"bash",
-			"-c",
-			"for i in {1..5}; do echo b-$i; sleep 2; done"
-		]
+		"touch-test2": "touch ${localWorkspaceFolder}/initializeCommand.2.testMarker"
 	}
 }

--- a/src/test/configs/image-with-parallel-initialize-command/.devcontainer.json
+++ b/src/test/configs/image-with-parallel-initialize-command/.devcontainer.json
@@ -1,0 +1,17 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:alpine",
+	"initializeCommand": {
+		"touch-test1": "touch ${localWorkspaceFolder}/initializeCommand.1.testMarker",
+		"touch-test2": "touch ${localWorkspaceFolder}/initializeCommand.2.testMarker",
+		"count-to-5-slowly": [
+			"bash",
+			"-c",
+			"for i in {1..5}; do echo a-$i; sleep 1; done"
+		],
+		"count-to-5-even-slower": [
+			"bash",
+			"-c",
+			"for i in {1..5}; do echo b-$i; sleep 2; done"
+		]
+	}
+}


### PR DESCRIPTION
refs: https://github.com/microsoft/vscode-remote-release/issues/7765, https://github.com/devcontainers/spec/issues/168, https://github.slack.com/archives/C0431R35H37/p1683554998695899

Aligns the `initializeCommand` lifecycle hook with the other hooks, allow for the 'object notation', running each provided (and named) command in parallel with one another.

For logging, the behavior is mirrored for the other lifecycle hooks, _not_ continuously streaming the output from each parallel hook, but instead holding the output until the end (otherwise, output will be interleaved and hard to follow).  See the demo below for an illustration of this.

https://user-images.githubusercontent.com/23246594/236972162-860377bb-0337-487b-9dd9-67440ebacefb.mov

