### PR TITLE
HttpOci: Retry fetching bearer token anonymously if credentials appear expired

### DIFF
--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as jsonc from 'jsonc-parser';
 
 import { runCommandNoPty, plainExec } from '../spec-common/commonUtils';
-import { request, requestResolveHeaders } from '../spec-utils/httpRequest';
+import { requestResolveHeaders } from '../spec-utils/httpRequest';
 import { LogLevel } from '../spec-utils/log';
 import { isLocalFile, readLocalFile } from '../spec-utils/pfs';
 import { CommonParams, OCICollectionRef, OCIRef } from './containerCollectionsOCI';

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -410,7 +410,7 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 	}
 
 	if (!res || res.statusCode > 299 || !res.resBody) {
-		output.write(`[httpOci] Failed to fetch bearer token for '${service}': ${res.resBody.toString()}`, LogLevel.Error);
+		output.write(`[httpOci] ${res.statusCode}: Failed to fetch bearer token for '${service}': ${res.resBody.toString()}`, LogLevel.Error);
 		return;
 	}
 

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -398,8 +398,11 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 
 	let res = await requestResolveHeaders(httpOptions, output);
 	if (res && res.statusCode === 401 || res.statusCode === 403) {
-		output.write(`[httpOci] Credentials for '${service}' may be expired. Attempting request anonymously.`, LogLevel.Info);
-		output.write(`[httpOci] ${res.resBody.toString()}.`, LogLevel.Trace);
+		output.write(`[httpOci] ${res.statusCode}: Credentials for '${service}' may be expired. Attempting request anonymously.`, LogLevel.Info);
+		const body = res.resBody?.toString();
+		if (body) {
+			output.write(`${res.resBody.toString()}.`, LogLevel.Info);
+		}
 
 		// Try again without user credentials. If we're here, their creds are likely expired.
 		delete headers['authorization'];

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -397,8 +397,8 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 	}
 
 	let res = await requestResolveHeaders(httpOptions, output);
-	if (res.statusCode === 401 || res.statusCode === 403) {
-		output.write(`[httpOci] Credentials for '${service}' may be expired: ${res.resBody.toString()?.trimEnd()}`, LogLevel.Warning);
+	if (res && res.statusCode === 401 || res.statusCode === 403) {
+		output.write(`[httpOci] Credentials for '${service}' may be expired: ${res.resBody?.toString()?.trimEnd()}`, LogLevel.Info);
 
 		// Try again without user credentials. If we're here, their creds are likely expired.
 		output.write(`[httpOci] Removing user credentials for '${service}' and attempting to fetch credentials anonymously.`, LogLevel.Trace);
@@ -419,8 +419,7 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 		// not JSON
 	}
 	if (!scopeToken) {
-		output.write(`[httpOci] Unexpected bearer token response format for '${service}'`, LogLevel.Error);
-		output.write(`httpOci] Response: ${res.resBody.toString()}`, LogLevel.Trace);
+		output.write(`[httpOci] Unexpected bearer token response format for '${service}: ${res.resBody.toString()}'`, LogLevel.Error);
 		return;
 	}
 

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -398,10 +398,10 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 
 	let res = await requestResolveHeaders(httpOptions, output);
 	if (res && res.statusCode === 401 || res.statusCode === 403) {
-		output.write(`[httpOci] Credentials for '${service}' may be expired: ${res.resBody?.toString()?.trimEnd()}`, LogLevel.Info);
+		output.write(`[httpOci] Credentials for '${service}' may be expired. Attempting request anonymously.`, LogLevel.Info);
+		output.write(`[httpOci] ${res.resBody.toString()}.`, LogLevel.Trace);
 
 		// Try again without user credentials. If we're here, their creds are likely expired.
-		output.write(`[httpOci] Removing user credentials for '${service}' and attempting to fetch credentials anonymously.`, LogLevel.Trace);
 		delete headers['authorization'];
 		res = await requestResolveHeaders(httpOptions, output);
 	}


### PR DESCRIPTION
ref: https://github.com/microsoft/vscode-remote-release/issues/8449

When trying to resolve a bearer token, we first attempt with the user credentials available to us for that service.  If the returned response is 401 or 403 (ghcr appears to return 403), then we attempt one more time after clearing the `Authorization` header.

In this example, I set a GitHub PAT via `docker login` and then revoked the PAT.
<img width="1110" alt="image" src="https://github.com/devcontainers/cli/assets/23246594/38c55967-f21f-45ba-b809-483e28f5b915">
