### PR TITLE
Rework `mount` command string generation

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -95,7 +95,7 @@ export type FeatureOption = {
 };
 export interface Mount {
 	type: 'bind' | 'volume';
-	source: string;
+	source?: string;
 	target: string;
 	external?: boolean;
 }

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -710,6 +710,7 @@ function convertMountToVolume(mount: Mount): string {
  * Convert mount command' arguments to volume top-level element
  * @param mount 
  * @returns mount object representation as volumes top-level element
+ * @throws if `source` property is undefined
  */
 function convertMountToVolumeTopLevelElement(mount: Mount): string {
 	let volume: string = `

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -18,7 +18,7 @@ import { getExtendImageBuildInfo, updateRemoteUserUID } from './containerFeature
 import { Mount, parseMount } from '../spec-configuration/containerFeaturesConfiguration';
 import path from 'path';
 import { getDevcontainerMetadata, getImageBuildInfoFromDockerfile, getImageBuildInfoFromImage, getImageMetadataFromContainer, ImageBuildInfo, lifecycleCommandOriginMapFromMetadata, mergeConfiguration, MergedDevContainerConfig } from './imageMetadata';
-import { ensureDockerfileHasFinalStageName } from './dockerfileUtils';
+import { ensureDockerfileHasFinalStageName, convertMountToVolume } from './dockerfileUtils';
 
 const projectLabel = 'com.docker.compose.project';
 const serviceLabel = 'com.docker.compose.service';
@@ -543,7 +543,7 @@ while sleep 1 & wait $$!; do :; done", "-"${userEntrypoint.map(a => `, ${JSON.st
     labels:${additionalLabels.map(label => `
       - '${label.replace(/\$/g, '$$$$').replace(/'/g, '\'\'')}'`).join('')}` : ''}${mounts.length ? `
     volumes:${mounts.map(m => `
-      - ${m.source}:${m.target}`).join('')}` : ''}${gpuResources}${volumeMounts.length ? `
+      - ${convertMountToVolume(m)}`).join('')}` : ''}${gpuResources}${volumeMounts.length ? `
 volumes:${volumeMounts.map(m => `
   ${m.source}:${m.external ? '\n    external: true' : ''}`).join('')}` : ''}
 `;

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -500,7 +500,7 @@ async function generateFeaturesComposeOverrideContent(
 		...mergedConfig.mounts || [],
 		...additionalMounts,
 	].map(m => typeof m === 'string' ? parseMount(m) : m);
-	const volumeMounts = mounts.filter(m => m.type === 'volume');
+	const namedVolumeMounts = mounts.filter(m => m.type === 'volume' && m.source);
 	const customEntrypoints = mergedConfig.entrypoints || [];
 	const composeEntrypoint: string[] | undefined = typeof service.entrypoint === 'string' ? shellQuote.parse(service.entrypoint) : service.entrypoint;
 	const composeCommand: string[] | undefined = typeof service.command === 'string' ? shellQuote.parse(service.command) : service.command;
@@ -543,8 +543,8 @@ while sleep 1 & wait $$!; do :; done", "-"${userEntrypoint.map(a => `, ${JSON.st
     labels:${additionalLabels.map(label => `
       - '${label.replace(/\$/g, '$$$$').replace(/'/g, '\'\'')}'`).join('')}` : ''}${mounts.length ? `
     volumes:${mounts.map(m => `
-      - ${convertMountToVolume(m)}`).join('')}` : ''}${gpuResources}${volumeMounts.length ? `
-volumes:${volumeMounts.map(m => `
+      - ${convertMountToVolume(m)}`).join('')}` : ''}${gpuResources}${namedVolumeMounts.length ? `
+volumes:${namedVolumeMounts.map(m => `
   ${m.source}:${m.external ? '\n    external: true' : ''}`).join('')}` : ''}
 `;
 }

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -690,7 +690,7 @@ export function dockerComposeCLIConfig(params: Omit<PartialExecParameters, 'cmd'
 }
 
 /**
- * Convert mount command' arguments to Docker Compose volume
+ * Convert mount command arguments to Docker Compose volume
  * @param mount 
  * @returns mount command representation for Docker compose
  */
@@ -707,15 +707,13 @@ function convertMountToVolume(mount: Mount): string {
 }
 
 /**
- * Convert mount command' arguments to volume top-level element
+ * Convert mount command arguments to volume top-level element
  * @param mount 
  * @returns mount object representation as volumes top-level element
- * @throws if `source` property is undefined
  */
 function convertMountToVolumeTopLevelElement(mount: Mount): string {
 	let volume: string = `
-  ${mount.source}:
-`;
+  ${mount.source}:`;
 
 	if (mount.external) {
 		volume += '\n    external: true';

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -710,7 +710,6 @@ function convertMountToVolume(mount: Mount): string {
  * Convert mount command' arguments to volume top-level element
  * @param mount 
  * @returns mount object representation as volumes top-level element
- * @throws if `source` property is undefined
  */
 function convertMountToVolumeTopLevelElement(mount: Mount): string {
 	let volume: string = `

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -18,7 +18,7 @@ import { getExtendImageBuildInfo, updateRemoteUserUID } from './containerFeature
 import { Mount, parseMount } from '../spec-configuration/containerFeaturesConfiguration';
 import path from 'path';
 import { getDevcontainerMetadata, getImageBuildInfoFromDockerfile, getImageBuildInfoFromImage, getImageMetadataFromContainer, ImageBuildInfo, lifecycleCommandOriginMapFromMetadata, mergeConfiguration, MergedDevContainerConfig } from './imageMetadata';
-import { ensureDockerfileHasFinalStageName, convertMountToVolume } from './dockerfileUtils';
+import { ensureDockerfileHasFinalStageName } from './dockerfileUtils';
 
 const projectLabel = 'com.docker.compose.project';
 const serviceLabel = 'com.docker.compose.service';
@@ -687,4 +687,21 @@ export function dockerComposeCLIConfig(params: Omit<PartialExecParameters, 'cmd'
 			};
 		})());
 	};
+}
+
+/**
+ * Convert mount command' arguments to Docker Compose volume
+ * @param mount 
+ * @returns mount command representation for Docker compose
+ */
+function convertMountToVolume(mount: Mount): string {
+	let volume: string = '';
+
+	if (mount.source) {
+		volume = `${mount.source}:`;
+	}
+
+	volume += mount.target;
+
+	return volume;
 }

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -500,7 +500,7 @@ async function generateFeaturesComposeOverrideContent(
 		...mergedConfig.mounts || [],
 		...additionalMounts,
 	].map(m => typeof m === 'string' ? parseMount(m) : m);
-	const volumeMounts = mounts.filter(m => m.type === 'volume');
+	const namedVolumeMounts = mounts.filter(m => m.type === 'volume' && m.source);
 	const customEntrypoints = mergedConfig.entrypoints || [];
 	const composeEntrypoint: string[] | undefined = typeof service.entrypoint === 'string' ? shellQuote.parse(service.entrypoint) : service.entrypoint;
 	const composeCommand: string[] | undefined = typeof service.command === 'string' ? shellQuote.parse(service.command) : service.command;
@@ -543,9 +543,9 @@ while sleep 1 & wait $$!; do :; done", "-"${userEntrypoint.map(a => `, ${JSON.st
     labels:${additionalLabels.map(label => `
       - '${label.replace(/\$/g, '$$$$').replace(/'/g, '\'\'')}'`).join('')}` : ''}${mounts.length ? `
     volumes:${mounts.map(m => `
-      - ${convertMountToVolume(m)}`).join('')}` : ''}${gpuResources}${volumeMounts.length ? `
-volumes:${volumeMounts.map(m => `
-  ${m.source}:${m.external ? '\n    external: true' : ''}`).join('')}` : ''}
+      - ${convertMountToVolume(m)}`).join('')}` : ''}${gpuResources}${namedVolumeMounts.length ? `
+volumes:${namedVolumeMounts.map(m => `
+  ${convertMountToVolumeTopLevelElement(m)}`).join('')}` : ''}
 `;
 }
 
@@ -702,6 +702,24 @@ function convertMountToVolume(mount: Mount): string {
 	}
 
 	volume += mount.target;
+
+	return volume;
+}
+
+/**
+ * Convert mount command' arguments to volume top-level element
+ * @param mount 
+ * @returns mount object representation as volumes top-level element
+ * @throws if `source` property is undefined
+ */
+function convertMountToVolumeTopLevelElement(mount: Mount): string {
+	let volume: string = `
+  ${mount.source}
+`;
+
+	if (mount.external) {
+		volume += '\n    external: true';
+	}
 
 	return volume;
 }

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -545,7 +545,7 @@ while sleep 1 & wait $$!; do :; done", "-"${userEntrypoint.map(a => `, ${JSON.st
     volumes:${mounts.map(m => `
       - ${convertMountToVolume(m)}`).join('')}` : ''}${gpuResources}${namedVolumeMounts.length ? `
 volumes:${namedVolumeMounts.map(m => `
-  ${m.source}:${m.external ? '\n    external: true' : ''}`).join('')}` : ''}
+  ${convertMountToVolumeTopLevelElement(m)}`).join('')}` : ''}
 `;
 }
 
@@ -702,6 +702,24 @@ function convertMountToVolume(mount: Mount): string {
 	}
 
 	volume += mount.target;
+
+	return volume;
+}
+
+/**
+ * Convert mount command' arguments to volume top-level element
+ * @param mount 
+ * @returns mount object representation as volumes top-level element
+ * @throws if `source` property is undefined
+ */
+function convertMountToVolumeTopLevelElement(mount: Mount): string {
+	let volume: string = `
+  ${mount.source}:
+`;
+
+	if (mount.external) {
+		volume += '\n    external: true';
+	}
 
 	return volume;
 }

--- a/src/spec-node/dockerfileUtils.ts
+++ b/src/spec-node/dockerfileUtils.ts
@@ -292,20 +292,3 @@ export function generateMountCommand(mount: Mount | string): string[] {
 
 	return [command, args];
 }
-
-/**
- * Convert mount command' arguments to Docker Compose volume
- * @param mount 
- * @returns mount command representation for Docker compose
- */
-export function convertMountToVolume(mount: Mount): string {
-	let volume: string = '';
-
-	if (mount.source) {
-		volume = `${mount.source}:`;
-	}
-
-	volume += mount.target;
-
-	return volume;
-}

--- a/src/spec-node/dockerfileUtils.ts
+++ b/src/spec-node/dockerfileUtils.ts
@@ -273,9 +273,9 @@ export function supportsBuildContexts(dockerfile: Dockerfile) {
 }
 
 /**
- * Process the mount command arguments and return the command string 
+ * Convert mount command' arguments to string 
  * @param mount 
- * @returns command string 
+ * @returns mount command string 
  */
 export function generateMountCommand(mount: Mount | string): string[] {
 	const command: string = '--mount';
@@ -291,4 +291,21 @@ export function generateMountCommand(mount: Mount | string): string[] {
 	const args: string = `${type}${source}${destination}`;
 
 	return [command, args];
+}
+
+/**
+ * Convert mount command' arguments to Docker Compose volume
+ * @param mount 
+ * @returns mount command representation for Docker compose
+ */
+export function convertMountToVolume(mount: Mount): string {
+	let volume: string = '';
+
+	if (mount.source) {
+		volume = `${mount.source}:`;
+	}
+
+	volume += mount.target;
+
+	return volume;
 }

--- a/src/spec-node/dockerfileUtils.ts
+++ b/src/spec-node/dockerfileUtils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as semver from 'semver';
+import { Mount } from '../spec-configuration/containerFeaturesConfiguration';
 
 export { getConfigFilePath, getDockerfilePath, isDockerFileConfig, resolveConfigFilePath } from '../spec-configuration/configuration';
 export { uriToFsPath, parentURI } from '../spec-configuration/configurationCommonUtils';
@@ -269,4 +270,25 @@ export function supportsBuildContexts(dockerfile: Dockerfile) {
 		return true; // latest, labs or no tag.
 	}
 	return semver.intersects(numVersion, '>=1.4');
+}
+
+/**
+ * Process the mount command arguments and return the command string 
+ * @param mount 
+ * @returns command string 
+ */
+export function generateMountCommand(mount: Mount | string): string[] {
+	const command: string = '--mount';
+
+	if (typeof mount === 'string') {
+		return [command, mount];
+	}
+
+	const type: string = `type=${mount.type},`;
+	const source: string = mount.source ? `src=${mount.source},` : '';
+	const destination: string = `dst=${mount.target}`;
+
+	const args: string = `${type}${source}${destination}`;
+
+	return [command, args];
 }

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -12,7 +12,7 @@ import { DevContainerConfig, DevContainerFromDockerfileConfig, DevContainerFromI
 import { LogLevel, Log, makeLog } from '../spec-utils/log';
 import { extendImage, getExtendImageBuildInfo, updateRemoteUserUID } from './containerFeatures';
 import { getDevcontainerMetadata, getImageBuildInfoFromDockerfile, getImageMetadataFromContainer, ImageMetadataEntry, lifecycleCommandOriginMapFromMetadata, mergeConfiguration, MergedDevContainerConfig } from './imageMetadata';
-import { ensureDockerfileHasFinalStageName } from './dockerfileUtils';
+import { ensureDockerfileHasFinalStageName, generateMountCommand } from './dockerfileUtils';
 
 export const hostFolderLabel = 'devcontainer.local_folder'; // used to label containers created from a workspace/folder
 export const configFileLabel = 'devcontainer.config_file';
@@ -360,7 +360,7 @@ export async function spawnDevContainer(params: DockerResolverParameters, config
 		...[
 			...mergedConfig.mounts || [],
 			...params.additionalMounts,
-		].map(m => ['--mount', typeof m === 'string' ? m : `type=${m.type},src=${m.source},dst=${m.target}`])
+		].map(m => generateMountCommand(m))
 	);
 
 	const customEntrypoints = mergedConfig.entrypoints || [];

--- a/src/test/configs/compose-image-with-mounts/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-image-with-mounts/.devcontainer/devcontainer.json
@@ -1,5 +1,7 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/base:latest",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "test",
+	"workspaceFolder": "/",
 	"mounts": [
         {
             "target": "/home/test_devcontainer_config",

--- a/src/test/configs/compose-image-with-mounts/.devcontainer/docker-compose.yml
+++ b/src/test/configs/compose-image-with-mounts/.devcontainer/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  test:
+    image: mcr.microsoft.com/devcontainers/base:latest
+    command: sleep infinity
+    volumes:
+      - /home/test_docker_compose

--- a/src/test/configs/image-with-mounts/.devcontainer/devcontainer.json
+++ b/src/test/configs/image-with-mounts/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:latest",
+	"mounts": [
+        {
+            "target": "/home/vscode/.vscode-server",
+            "type": "volume",
+        }
+    ]
+}

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -202,6 +202,21 @@ describe('Image Metadata', function () {
 					await shellExec(`docker rm -f ${response.containerId}`);
 				});
 			});
+
+			['image-with-mounts'].forEach(testFolderName => {
+				it('docker volume should not be named undefined if the src argument is omitted in mount command', async () => {
+					const imageTestFolder = `${__dirname}/configs/${testFolderName}`;
+					const cliResult = await shellExec(`${cli} up --workspace-folder ${imageTestFolder}`);
+					const response = JSON.parse(cliResult.stdout);
+					assert.strictEqual(response.outcome, 'success');
+					const details = JSON.parse((await shellExec(`docker inspect ${response.containerId}`)).stdout)[0] as ContainerDetails;
+					const targetMount = details.Mounts.find(mount => mount.Destination === '/home/vscode/.vscode-server');
+
+					assert.notEqual(targetMount?.Name?.toLowerCase(), 'undefined');
+
+					await shellExec(`docker rm -f ${response.containerId}`);
+				});
+			});
 		});
 	});
 

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -203,14 +203,17 @@ describe('Image Metadata', function () {
 				});
 			});
 
-			['image-with-mounts'].forEach(testFolderName => {
+			[
+				'image-with-mounts',
+				'compose-image-with-mounts'
+			].forEach(testFolderName => {
 				it('docker volume should not be named undefined if the src argument is omitted in mount command', async () => {
 					const imageTestFolder = `${__dirname}/configs/${testFolderName}`;
 					const cliResult = await shellExec(`${cli} up --workspace-folder ${imageTestFolder}`);
 					const response = JSON.parse(cliResult.stdout);
 					assert.strictEqual(response.outcome, 'success');
 					const details = JSON.parse((await shellExec(`docker inspect ${response.containerId}`)).stdout)[0] as ContainerDetails;
-					const targetMount = details.Mounts.find(mount => mount.Destination === '/home/vscode/.vscode-server');
+					const targetMount = details.Mounts.find(mount => mount.Destination === '/home/test_devcontainer_config');
 
 					assert.notEqual(targetMount?.Name?.toLowerCase(), 'undefined');
 


### PR DESCRIPTION
**Description**:

This PR addresses the issue when the Docker volume is named as `undefined` if the `src` argument is not specified in the `mount` command.

The issue related to the following code:

https://github.com/devcontainers/cli/blob/7de4011ca1d21781730198f718ff449c1772ebe5/src/spec-node/singleContainer.ts#L359-L364

When the `mount` command string is generated, there is no check for the `src` argument. This results in the `src` attribute being set to `undefined` when cast to a string.

To fix this behavior, we need to apply null-check for the `src` argument and don't pass it to Docker. When the `src` arg is not passed, Docker generates a random name for the volume.

**Repro sample**:

```json
{
	"image": "mcr.microsoft.com/devcontainers/base:latest",
	"mounts": [
        {
            "target": "/home/vscode/.vscode-server",
            "type": "volume",
        }
    ]
}
```

**Examples**:
_Without fix_:

```console
node ➜ /workspaces/devcontainers-cli (main) $ docker inspect -f '{{json .Mounts }}' a85f6e52d478
```

```json
[
	{
		"Type": "bind",
		"Source": "/workspaces/devcontainers-cli",
		"Destination": "/workspaces/devcontainers-cli",
		"Mode": "",
		"RW": true,
		"Propagation": "rprivate"
	},
	{
		"Type": "volume",
		"Name": "undefined",
		"Source": "/var/lib/docker/volumes/undefined/_data",
		"Destination": "/home/vscode/.vscode-server",
		"Driver": "local",
		"Mode": "z",
		"RW": true,
		"Propagation": ""
	}
]
```

_With fix_:

```console
node ➜ /workspaces/devcontainers-cli (users/alexander-smolyakov/add_proper_handling_for_src_arg_in_mount_command) $ docker inspect -f '{{json .Mounts }}' 2e77ff5392dc
```

```json
[
	{
		"Type": "bind",
		"Source": "/workspaces/devcontainers-cli",
		"Destination": "/workspaces/devcontainers-cli",
		"Mode": "",
		"RW": true,
		"Propagation": "rprivate"
	},
	{
		"Type": "volume",
		"Name": "628f29020e5d6a9514614ce0ad90411d2400161b67e07bb8744f39a83a397922",
		"Source": "/var/lib/docker/volumes/628f29020e5d6a9514614ce0ad90411d2400161b67e07bb8744f39a83a397922/_data",
		"Destination": "/home/vscode/.vscode-server",
		"Driver": "local",
		"Mode": "z",
		"RW": true,
		"Propagation": ""
	}
]
```

**Attached related issue**:

- #478

**Changelog**:
- Move the `mount` command generation logic to a separate function;
- Add check if the `src` argument is undefined;
