### PR TITLE
Capture output of docker-compose CLI

### DIFF
--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -561,7 +561,11 @@ export async function readDockerComposeConfig(params: DockerCLIParameters, compo
 		}
 		try {
 			const partial = toExecParameters(params, 'dockerComposeCLI' in params ? await params.dockerComposeCLI() : undefined);
-			const { stdout } = await dockerComposeCLI({ ...partial, print: 'onerror' }, ...composeGlobalArgs, 'config');
+			const { stdout } = await dockerComposeCLI({
+				...partial,
+				output: makeLog(params.output, LogLevel.Info),
+				print: 'onerror'
+			}, ...composeGlobalArgs, 'config');
 			const stdoutStr = stdout.toString();
 			params.output.write(stdoutStr);
 			return yaml.load(stdoutStr) || {} as any;


### PR DESCRIPTION
fixes https://github.com/devcontainers/cli/issues/535

Similar to the in the `catch` below this change, create a new `output` object to capture docker-compose CLI logging.

For major version '1' versions of docker-compose, this change surfaces a parsing error (as described in the attached issue).

<img width="1373" alt="image" src="https://github.com/devcontainers/cli/assets/23246594/7793839e-f9bf-4c9a-ab90-fb784d137406">
