### PR TITLE
Pass secret values correcly to dotfile clone and install

### DIFF
--- a/src/test/configs/image-with-git-feature/.devcontainer.json
+++ b/src/test/configs/image-with-git-feature/.devcontainer.json
@@ -3,5 +3,8 @@
 	"features": {
 		"ghcr.io/devcontainers/features/git": {}
 	},
+	"remoteEnv": {
+		"TEST_REMOTE_ENV": "Value 1"
+	},
 	"remoteUser": "node"
 }


### PR DESCRIPTION
There was a bug, where we were not passing secrets correctly to the dotfiles clone and install command. This PR fixes it