### PR TITLE
[tests] Pin image to major version 0

### DIFF
--- a/src/test/container-features/configs/image-with-v2-tarball/.devcontainer.json
+++ b/src/test/container-features/configs/image-with-v2-tarball/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:16",
+	"image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-16",
 	"features": {
 		"https://github.com/codspace/features/releases/download/tarball02/devcontainer-feature-docker-in-docker.tgz": {}
 	}


### PR DESCRIPTION
With the release of Debian bookworm, several of the images we maintain had a major version bump from 0 to 1.  This test involving a tgz Feature tries to download via `apt` that doesn't exist in the bookworm feed.

https://github.com/devcontainers/images/commit/5366f3b9b99bf81f612bfc4c59c3030aa79a2e14

The actual issue that arises during the build is:

```
bookworm InRelease\n[2023-06-16T16:06:37.964Z] Err:5 https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm Release\n  404  Not Found [IP: 40.118.250.56 443]\n[2023-06-16T16:06:38.148Z] Reading package lists...\n[2023-06-16T16:06:38.758Z] \n[2023-06-16T16:06:38.772Z] E: The repository 'https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm Release' does not have a Release file.\n[2023-06-16T16:06:38.773Z] ERROR: Feature \"Docker (Docker-in-Docker)\" (Unknown) failed to install!\n[2023-06-16T16:06:38.956Z] The command '/bin/sh -c chmod -R 0755 /tmp/dev-container-features/docker-in-docker_0 && cd /tmp/dev-container-features/docker-in-docker_0 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh' returned a non-zero code: 100\r\n\n[2023-06-16T16:06:38.957Z] Stop (58933 ms): Run: docker build --build-arg 
```