### PR TITLE
Upgrade target to ES2021

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
 		"composite": true,
 		"rootDir": "./src",
 		"outDir": "./built",
-		"target": "es2019",
+		"target": "es2021",
 		"module": "commonjs",
 		"esModuleInterop": true,
 		"strict": true,


### PR DESCRIPTION
Upgrade to ES2021 

Motivation
 - Leverage new language features such as string.replaceAll
 - ES2021 is supported on Node 15+. Node versions prior to that are already EOL.