### PR TITLE
Update supported node engines to ^16.13.0 || >=18.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"license": "SEE LICENSE IN LICENSE.txt",
 	"engines": {
-		"node": ">=14.17.0"
+		"node": "^16.13.0 || >=18.0.0"
 	},
 	"scripts": {
 		"compile": "npm-run-all clean-dist definitions compile-dev",


### PR DESCRIPTION
With the upgrade to ES 2021 the CLI no longer support older node versions