### PR TITLE
Fix: Launch bundled CLI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch CLI - up",
-            "program": "${workspaceFolder}/src/spec-node/devContainersSpecCLI.ts",
+            "program": "${workspaceFolder}/dist/spec-node/devContainersSpecCLI.js",
             "cwd": "${workspaceFolder}",
             // "envFile": "${workspaceFolder}/.env",  // Create .env file in the workspace folder to pass environment variables to the CLI.
             "args": [


### PR DESCRIPTION
Recent versions of Chalk come as ESM module which doesn't load with our current configuration. (Briefly looked into switching to Node.js' ESM support, but that seems to require some updates to our code.)