### PR TITLE
Fix #543: build with correct image names

### DIFF
--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -653,14 +653,8 @@ async function doBuild({
 			}
 
 			await inspectDockerImage(params, config.image, true);
-			const { updatedImageName } = await extendImage(params, configWithRaw, config.image, additionalFeatures, false);
-
-			if (imageNames) {
-				await Promise.all(imageNames.map(imageName => dockerPtyCLI(params, 'tag', updatedImageName[0], imageName)));
-				imageNameResult = imageNames;
-			} else {
-				imageNameResult = updatedImageName;
-			}
+			const { updatedImageName } = await extendImage(params, configWithRaw, config.image, imageNames, additionalFeatures, false);
+			imageNameResult = updatedImageName;
 		}
 
 		return {

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -120,7 +120,7 @@ export async function buildNamedImageAndExtend(params: DockerResolverParameters,
 		return await buildAndExtendImage(params, configWithRaw as SubstitutedConfig<DevContainerFromDockerfileConfig>, imageNames, params.buildNoCache ?? false, additionalFeatures);
 	}
 	// image-based dev container - extend
-	return await extendImage(params, configWithRaw, imageNames[0], additionalFeatures, canAddLabelsToContainer);
+	return await extendImage(params, configWithRaw, imageNames[0], imageNames.slice(1), additionalFeatures, canAddLabelsToContainer);
 }
 
 async function buildAndExtendImage(buildParams: DockerResolverParameters, configWithRaw: SubstitutedConfig<DevContainerFromDockerfileConfig>, baseImageNames: string[], noCache: boolean, additionalFeatures: Record<string, string | boolean | Record<string, string | boolean>>) {


### PR DESCRIPTION
Closes https://github.com/devcontainers/cli/issues/543

# Problem
- Method `extendImage` created image with the default name ignoring `--image-name` option.
- The image could not be tagged after building, because CLI exited with `ERROR: denied: requested access to the resource is denied` after pushing attempt.

# Solution
- Added image names from `--image-names` option at building stage.