### PR TITLE
Fix: Only allocate tty for `docker exec` when stdin is a tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes.
 
 ## July 2023
 
+### [0.50.2]
+- Fix: Only allocate tty for `docker exec` when stdin is a tty (https://github.com/devcontainers/cli/issues/606)
+
 ### [0.50.1]
 - Fix: Allocate pty for `docker exec` (https://github.com/devcontainers/cli/issues/556)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@devcontainers/cli",
 	"description": "Dev Containers CLI",
-	"version": "0.50.1",
+	"version": "0.50.2",
 	"bin": {
 		"devcontainer": "devcontainer.js"
 	},


### PR DESCRIPTION
Fix #606