### PR TITLE
RFC: Build as single executable application

### DIFF
--- a/build/single-executable.js
+++ b/build/single-executable.js
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+"use strict";
+
+const fs = require("fs");
+const cp = require("child_process");
+
+/**
+ * Create a single executable file for the devcontainer CLI.
+ * https://nodejs.org/api/single-executable-applications.html
+ */
+
+process.chdir("dist/spec-node");
+
+const name = "devcontainer";
+const binary = `${name}${process.platform === "win32" ? ".exe" : ""}`;
+
+fs.copyFileSync(process.execPath, binary);
+
+const config = {
+	main: "devContainersSpecCLI.js",
+	output: `prepared.blob`,
+};
+
+fs.writeFileSync("config.json", JSON.stringify(config));
+
+cp.spawnSync(process.execPath, ["--experimental-sea-config", "config.json"], {
+	stdio: "inherit",
+});
+
+cp.spawnSync(
+	"npx",
+	[
+		"--yes",
+		"postject",
+		binary,
+		"NODE_SEA_BLOB",
+		config.output,
+		"--sentinel-fuse",
+		"NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2",
+		...(process.platform === "darwin"
+			? ["--macho-segment-name", "NODE_SEA"]
+			: []),
+	],
+	{ stdio: "inherit" }
+);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"definitions-clean": "rimraf dist/node_modules/vscode-dev-containers",
 		"definitions-copy": "copyfiles \"node_modules/vscode-dev-containers/container-features/{devcontainer-features.json,feature-scripts.env,fish-debian.sh,homebrew-debian.sh,install.sh}\" dist",
 		"npm-pack": "npm pack",
+		"build-executable": "node build/single-executable.js",
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",
 		"clean-built": "rimraf built",


### PR DESCRIPTION
This commit adds a build script to package the `devcontainer` CLI as a single executable application using the new (and experimental) Node.js feature of the same name.
https://nodejs.org/api/single-executable-applications.html

Distributing the devcontainer CLI as a single executable application allows to use it on systems where Node.js is not installed. For example on immutable systems like Fedora Silverblue or openSUSE MicroOS.

I'm aware of another PR that also tries to package standalone binaries via `@vercel/pkg` here: https://github.com/devcontainers/cli/pull/343 but it seems that PR hasn't received updates in a while and I'm not sure if it is stale or not. Feel free to close my PR if the other approach is preferable.

TODOs:
- [ ] Code signing on Windows/MacOS (see point 5 https://nodejs.org/api/single-executable-applications.html)
- [ ] Update CLI tests to test against the executable
- [ ] Update GitHub workflows to build, test and publish the executable

Let me know what you think about either this PR or #343 and whether I should continue with the above outlined TODOs.