### PR TITLE
Surface buildkit policy errors more clearly

### DIFF
--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -6,7 +6,7 @@
 import * as yaml from 'js-yaml';
 import * as shellQuote from 'shell-quote';
 
-import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, DockerResolverParameters, inspectDockerImage, getEmptyContextFolder, getFolderImageName, SubstitutedConfig, checkDockerSupportForGPU } from './utils';
+import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, DockerResolverParameters, inspectDockerImage, getEmptyContextFolder, getFolderImageName, SubstitutedConfig, checkDockerSupportForGPU, isBuildKitImagePolicyError } from './utils';
 import { ContainerProperties, setupInContainer, ResolverProgress } from '../spec-common/injectHeadless';
 import { ContainerError } from '../spec-common/errors';
 import { Workspace } from '../spec-utils/workspaces';
@@ -274,6 +274,10 @@ ${cacheFromOverrideContent}
 				await dockerComposeCLI(infoParams, ...args);
 			}
 		} catch (err) {
+			if (isBuildKitImagePolicyError(err)) {
+				throw new ContainerError({ description: 'Could not resolve image due to policy.', originalError: err, data: { fileWithError: localComposeFiles[0] } });
+			}
+
 			throw err instanceof ContainerError ? err : new ContainerError({ description: 'An error occurred building the Docker Compose images.', originalError: err, data: { fileWithError: localComposeFiles[0] } });
 		}
 	}

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, getDockerfilePath, getDockerContextPath, DockerResolverParameters, isDockerFileConfig, uriToWSLFsPath, WorkspaceConfiguration, getFolderImageName, inspectDockerImage, logUMask, SubstitutedConfig, checkDockerSupportForGPU } from './utils';
+import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, getDockerfilePath, getDockerContextPath, DockerResolverParameters, isDockerFileConfig, uriToWSLFsPath, WorkspaceConfiguration, getFolderImageName, inspectDockerImage, logUMask, SubstitutedConfig, checkDockerSupportForGPU, isBuildKitImagePolicyError } from './utils';
 import { ContainerProperties, setupInContainer, ResolverProgress, ResolverParameters } from '../spec-common/injectHeadless';
 import { ContainerError, toErrorText } from '../spec-common/errors';
 import { ContainerDetails, listContainers, DockerCLIParameters, inspectContainers, dockerCLI, dockerPtyCLI, toPtyExecParameters, ImageDetails, toExecParameters } from '../spec-shutdown/dockerUtils';
@@ -248,6 +248,10 @@ async function buildAndExtendImage(buildParams: DockerResolverParameters, config
 			await dockerCLI(infoParams, ...args);
 		}
 	} catch (err) {
+		if (isBuildKitImagePolicyError(err)) {
+			throw new ContainerError({ description: 'Could not resolve image due to policy.', originalError: err, data: { fileWithError: dockerfilePath } });
+		}
+
 		throw new ContainerError({ description: 'An error occurred building the image.', originalError: err, data: { fileWithError: dockerfilePath } });
 	}
 

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -205,6 +205,12 @@ export async function checkDockerSupportForGPU(params: DockerCLIParameters | Doc
 	return runtimeFound;
 }
 
+export function isBuildKitImagePolicyError(err: any): boolean {
+	const imagePolicyErrorString = 'could not resolve image due to policy';
+	return (err?.cmdOutput && typeof err.cmdOutput === 'string' && err.cmdOutput.indexOf(imagePolicyErrorString) > -1) ||
+		(err?.stderr && typeof err.stderr === 'string' && err.stderr.indexOf(imagePolicyErrorString) > -1);
+}
+
 export async function inspectDockerImage(params: DockerResolverParameters | DockerCLIParameters, imageName: string, pullImageOnError: boolean) {
 	try {
 		return await inspectImage(params, imageName);


### PR DESCRIPTION
ref: https://github.com/github/codespaces/issues/15008

If a buildx build error occurs, detects if the root cause was due to a [buildx source policy](https://github.com/moby/buildkit/blob/master/docs/build-repro.md#reproducing-the-pinned-dependencies). If so, report a less generic error via the `description`.

Example with this change:

```

ERROR: failed to solve: mcr.microsoft.com/devcontainers/ruby: could not resolve image due to policy: source "docker-image://mcr.microsoft.com/devcontainers/ruby:latest" denied by policy: source denied by policy
2023-08-29 21:55:02.751Z: Stop: Run: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-root/container-features/0.51.1-jospicer01-1693346094254/Dockerfile-with-features -t vsc-rejected-image-ac758e141f596cab21ee70d2129d2b19fd366618d66e324971f146f6f4c05b4f --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label /var/lib/docker/codespacemount/workspace/rejected-image/.devcontainer
2023-08-29 21:55:02.753Z: Error: Command failed: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-root/container-features/0.51.1-jospicer01-1693346094254/Dockerfile-with-features -t vsc-rejected-image-ac758e141f596cab21ee70d2129d2b19fd366618d66e324971f146f6f4c05b4f --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label /var/lib/docker/codespacemount/workspace/rejected-image/.devcontainer
2023-08-29 21:55:02.754Z:     at BAA (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:463:1758)
2023-08-29 21:55:02.754Z:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2023-08-29 21:55:02.754Z:     at async Ww (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:462:1691)
2023-08-29 21:55:02.754Z:     at async SK (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:462:610)
2023-08-29 21:55:02.754Z:     at async SAA (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:479:3660)
2023-08-29 21:55:02.755Z:     at async GC (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:479:4775)
2023-08-29 21:55:02.756Z:     at async ZeA (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:611:12240)
2023-08-29 21:55:02.756Z:     at async VeA (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:611:11981)
2023-08-29 21:55:02.758Z: {
    "outcome": "error",
    "message": "Command failed: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-root/container-features/0.51.1-jospicer01-1693346094254/Dockerfile-with-features -t vsc-rejected-image-ac758e141f596cab21ee70d2129d2b19fd366618d66e324971f146f6f4c05b4f --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label /var/lib/docker/codespacemount/workspace/rejected-image/.devcontainer",
    "description": "Could not resolve image due to policy."
}
2023-08-29 21:55:02.767Z: devcontainer process exited with exit code 1
```