### PR TITLE
updateUID: remove redundant `SHELL` instruction

### DIFF
--- a/scripts/updateUID.Dockerfile
+++ b/scripts/updateUID.Dockerfile
@@ -8,7 +8,6 @@ USER root
 ARG REMOTE_USER
 ARG NEW_UID
 ARG NEW_GID
-SHELL ["/bin/sh", "-c"]
 RUN eval $(sed -n "s/${REMOTE_USER}:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/OLD_UID=\1;OLD_GID=\2;HOME_FOLDER=\3/p" /etc/passwd); \
 	eval $(sed -n "s/\([^:]*\):[^:]*:${NEW_UID}:.*/EXISTING_USER=\1/p" /etc/passwd); \
 	eval $(sed -n "s/\([^:]*\):[^:]*:${NEW_GID}:.*/EXISTING_GROUP=\1/p" /etc/group); \


### PR DESCRIPTION
Docker already defaults to `/bin/sh -c` on Linux... This option is not part of the OCI spec and produces a warning by default when building on podman.