### PR TITLE
Fix: propagate --cache-from to buildx build

### DIFF
--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -85,6 +85,9 @@ export async function extendImage(params: DockerResolverParameters, config: Subs
 		if (params.buildxCacheTo) {
 			args.push('--cache-to', params.buildxCacheTo);
 		}
+		if (!params.buildNoCache) {
+			params.additionalCacheFroms.forEach(cacheFrom => args.push('--cache-from', cacheFrom));
+		}
 
 		for (const buildContext in featureBuildInfo.buildKitContexts) {
 			args.push('--build-context', `${buildContext}=${featureBuildInfo.buildKitContexts[buildContext]}`);


### PR DESCRIPTION
I am trying to use the new `--cache-to` feature from #570 with a [registry cache](https://docs.docker.com/build/cache/backends/registry/).

If I understand it correctly this only works when using both `--cache-to` and `--cache-from`, but the devcontainers-cli does not send `--cache-from` to `docker buildx build`.