### PR TITLE
Updates create error description to include cause for docker auth plugin errors

### DIFF
--- a/src/spec-common/commonUtils.ts
+++ b/src/spec-common/commonUtils.ts
@@ -218,7 +218,6 @@ export async function runCommand(options: {
 				resolve({ cmdOutput });
 			}
 		});
-
 		p.exit.then(({ code, signal }) => {
 			try {
 				if (print === 'end') {

--- a/src/spec-common/commonUtils.ts
+++ b/src/spec-common/commonUtils.ts
@@ -218,6 +218,16 @@ export async function runCommand(options: {
 				resolve({ cmdOutput });
 			}
 		});
+		
+		p.onData(data => {
+			if (data.includes('authorization denied by plugin')) {
+				reject({
+					message: `Command failed due to authorization denied by plugin: ${cmd} ${(args || []).join(' ')}`,
+					cmdOutput,
+				});
+			}
+		});
+
 		p.exit.then(({ code, signal }) => {
 			try {
 				if (print === 'end') {

--- a/src/spec-common/commonUtils.ts
+++ b/src/spec-common/commonUtils.ts
@@ -218,15 +218,6 @@ export async function runCommand(options: {
 				resolve({ cmdOutput });
 			}
 		});
-		
-		p.onData(data => {
-			if (data.includes('authorization denied by plugin')) {
-				reject({
-					message: `Command failed due to authorization denied by plugin: ${cmd} ${(args || []).join(' ')}`,
-					cmdOutput,
-				});
-			}
-		});
 
 		p.exit.then(({ code, signal }) => {
 			try {

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -71,8 +71,14 @@ export async function openDockerfileDevContainer(params: DockerResolverParameter
 }
 
 function createSetupError(originalError: any, container: ContainerDetails | undefined, params: DockerResolverParameters, containerProperties: ContainerProperties | undefined, config: DevContainerConfig | undefined): ContainerError {
+	let description = 'An error occurred setting up the container.';
+
+	if (originalError?.cmdOutput?.includes('docker: Error response from daemon: authorization denied by plugin')) {
+		description = originalError.cmdOutput;
+	}
+
 	const err = originalError instanceof ContainerError ? originalError : new ContainerError({
-		description: 'An error occurred setting up the container.',
+		description,
 		originalError
 	});
 	if (container) {


### PR DESCRIPTION
If the container creation with `devcontainer up` command fails due to a [docker authz plugin](https://docs.docker.com/engine/extend/plugins_authorization/#access-authorization-plugin), then this change updates the CLI's failure `description` (surfacing the root cause of the failures)

![image](https://github.com/devcontainers/cli/assets/24955913/41cd98a3-6a68-40d8-b4a7-f5bb542ce778)
