### PR TITLE
Docker compose: Updates create error description to include cause for docker auth plugin errors

### DIFF
--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -423,7 +423,13 @@ async function startContainer(params: DockerResolverParameters, buildParams: Doc
 		}
 	} catch (err) {
 		cancel!();
-		throw new ContainerError({ description: 'An error occurred starting Docker Compose up.', originalError: err, data: { fileWithError: localComposeFiles[0] } });
+
+		let description = 'An error occurred starting Docker Compose up.';
+		if (err?.cmdOutput?.includes('Cannot create container for service app: authorization denied by plugin')) {
+			description = err.cmdOutput;
+		}
+
+		throw new ContainerError({ description, originalError: err, data: { fileWithError: localComposeFiles[0] } });
 	}
 
 	await started;


### PR DESCRIPTION
Similar to https://github.com/devcontainers/cli/pull/656 changes for docker compose scenarios

If the container creation with devcontainer up command fails due to a [docker authz plugin](https://docs.docker.com/engine/extend/plugins_authorization/#access-authorization-plugin), then this change updates the CLI's failure description (surfacing the root cause of the failures)

<img width="1236" alt="image" src="https://github.com/devcontainers/cli/assets/24955913/27b24adb-939a-4449-991b-78debcc1da6f">
