### PR TITLE
template apply: Provide default feature options.

### DIFF
--- a/src/spec-configuration/containerTemplatesOCI.ts
+++ b/src/spec-configuration/containerTemplatesOCI.ts
@@ -161,7 +161,7 @@ async function addFeatures(output: Log, newFeatures: TemplateFeatureOption[], co
 			const propertyPath = ['features', newFeature.id];
 
 			edits = edits.concat(
-				jsonc.modify(updatedText, propertyPath, newFeature.options, { formattingOptions: {} }
+				jsonc.modify(updatedText, propertyPath, newFeature.options ?? {}, { formattingOptions: {} }
 				));
 
 			updatedText = jsonc.applyEdits(updatedText, edits);


### PR DESCRIPTION
## Problem

The `options` of a feature is never validated. So therefore, if the user does not spell it out, the value is simply `undefined`.

https://github.com/devcontainers/cli/blob/71180e791b13371f8313d981dfcf06b3c8fcd2ab/src/spec-node/templatesCLI/apply.ts#L123-L129

This drops the entire feature from the intended edit.

## Example

Apply the "go" template with a feature of "git". Specifically, do not provide any `"options"` for the _git_ feature.

```shell
$ devcontainer templates apply --workspace-folder ./example-go \
                               -t ghcr.io/devcontainers/templates/go:latest \
                               -f '[{"id":"ghcr.io/devcontainers/features/git:1"}]'
```

As a result, I would expect that devcontainer.json would be generated like so.

```jsonc
// For format details, see https://aka.ms/devcontainer.json. For config options, see the
// README at: https://github.com/devcontainers/templates/tree/main/src/go
{
	"name": "Go",
	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye",
	"features": {
		"ghcr.io/devcontainers/features/git:1": {}
	}

	// ... snip comments ...
}
```