### PR TITLE
fix version sorting and report major version in `outdated`

### DIFF
--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -474,14 +474,13 @@ export async function getPublishedVersions(params: CommonParams, ref: OCIRef, so
 			return publishedVersionsResponse.tags;
 		}
 
-		// Sort tags in descending order, removing latest.
-		const hasLatest = publishedVersionsResponse.tags.includes('latest');
 		const sortedVersions = publishedVersionsResponse.tags
-			.filter(f => f !== 'latest')
-			.sort((a, b) => semver.compareIdentifiers(a, b));
+			.filter(f => semver.valid(f)) // Remove all major,minor,latest tags
+			.sort((a, b) => semver.compare(a, b));
 
+		output.write(`Published versions (sorted) for '${ref.id}': ${JSON.stringify(sortedVersions, undefined, 2)}`, LogLevel.Trace);
 
-		return hasLatest ? ['latest', ...sortedVersions] : sortedVersions;
+		return sortedVersions;
 	} catch (e) {
 		output.write(`Failed to parse published versions: ${e}`, LogLevel.Error);
 		return;

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -17,7 +17,7 @@ import { Log, LogLevel } from '../spec-utils/log';
 import { request } from '../spec-utils/httpRequest';
 import { fetchOCIFeature, tryGetOCIFeatureSet, fetchOCIFeatureManifestIfExistsFromUserIdentifier } from './containerFeaturesOCI';
 import { uriToFsPath } from './configurationCommonUtils';
-import { CommonParams, ManifestContainer, OCIManifest, OCIRef, getPublishedVersions, getRef } from './containerCollectionsOCI';
+import { CommonParams, ManifestContainer, OCIManifest, OCIRef, getRef, getVersionsStrictSorted } from './containerCollectionsOCI';
 import { Lockfile, readLockfile, writeLockfile } from './lockfile';
 import { computeDependsOnInstallationOrder } from './containerFeaturesOrder';
 import { logFeatureAdvisories } from './featureAdvisories';
@@ -591,7 +591,7 @@ export async function loadVersionInfo(params: ContainerFeatureInternalParams, co
 		const updatedFeatureId = getBackwardCompatibleFeatureId(output, userFeatureId);
 		const featureRef = getRef(output, updatedFeatureId);
 		if (featureRef) {
-			const versions = (await getPublishedVersions(params, featureRef, true))
+			const versions = (await getVersionsStrictSorted(params, featureRef))
 				?.reverse();
 			if (versions) {
 				const lockfileVersion = lockfile?.features[userFeatureId]?.version;

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -613,9 +613,9 @@ export async function loadVersionInfo(params: ContainerFeatureInternalParams, co
 				features[userFeatureId] = {
 					current: lockfileVersion || wanted,
 					wanted,
-					wantedMajor: wanted && semver.major(wanted),
+					wantedMajor: wanted && semver.major(wanted)?.toString(),
 					latest: versions[0],
-					latestMajor: semver.major(versions[0]),
+					latestMajor: semver.major(versions[0])?.toString(),
 				};
 			}
 		}

--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -613,7 +613,9 @@ export async function loadVersionInfo(params: ContainerFeatureInternalParams, co
 				features[userFeatureId] = {
 					current: lockfileVersion || wanted,
 					wanted,
+					wantedMajor: wanted && semver.major(wanted),
 					latest: versions[0],
+					latestMajor: semver.major(versions[0]),
 				};
 			}
 		}

--- a/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
+++ b/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
@@ -43,13 +43,13 @@ export async function doPublishCommand(params: CommonParams, version: string, oc
 	const { output } = params;
 
 	output.write(`Fetching published versions...`, LogLevel.Info);
-	const publishedVersions = await getPublishedTags(params, ociRef);
+	const publishedTags = await getPublishedTags(params, ociRef);
 
-	if (!publishedVersions) {
+	if (!publishedTags) {
 		return;
 	}
 
-	const semanticVersions: string[] | undefined = getSemanticVersions(version, publishedVersions, output);
+	const semanticVersions: string[] | undefined = getSemanticVersions(version, publishedTags, output);
 
 	if (!!semanticVersions) {
 		output.write(`Publishing versions: ${semanticVersions.toString()}...`, LogLevel.Info);

--- a/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
+++ b/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import * as semver from 'semver';
 import { Log, LogLevel } from '../../spec-utils/log';
-import { CommonParams, getPublishedVersions, OCICollectionRef, OCIRef } from '../../spec-configuration/containerCollectionsOCI';
+import { CommonParams, getPublishedTags, OCICollectionRef, OCIRef } from '../../spec-configuration/containerCollectionsOCI';
 import { OCICollectionFileName } from './packageCommandImpl';
 import { pushCollectionMetadata, pushOCIFeatureOrTemplate } from '../../spec-configuration/containerCollectionsOCIPush';
 
@@ -43,7 +43,7 @@ export async function doPublishCommand(params: CommonParams, version: string, oc
 	const { output } = params;
 
 	output.write(`Fetching published versions...`, LogLevel.Info);
-	const publishedVersions = await getPublishedVersions(params, ociRef);
+	const publishedVersions = await getPublishedTags(params, ociRef);
 
 	if (!publishedVersions) {
 		return;

--- a/src/spec-node/featuresCLI/info.ts
+++ b/src/spec-node/featuresCLI/info.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { OCIManifest, OCIRef, fetchOCIManifestIfExists, getPublishedVersions, getRef } from '../../spec-configuration/containerCollectionsOCI';
+import { OCIManifest, OCIRef, fetchOCIManifestIfExists, getPublishedTags, getRef } from '../../spec-configuration/containerCollectionsOCI';
 import { Log, LogLevel, mapLogLevel } from '../../spec-utils/log';
 import { getPackageConfig } from '../../spec-utils/product';
 import { createLog } from '../devContainers';
@@ -27,7 +27,7 @@ export function featuresInfoHandler(args: FeaturesInfoArgs) {
 interface InfoJsonOutput {
 	manifest?: OCIManifest;
 	canonicalId?: string;
-	publishedVersions?: string[];
+	publishedTags?: string[];
 }
 
 async function featuresInfo({
@@ -86,12 +86,12 @@ async function featuresInfo({
 
 	// --- Get all published tags for resource
 	if (mode === 'tags' || mode === 'verbose') {
-		const publishedVersions = await getTags(params, featureRef);
+		const publishedTags = await getTags(params, featureRef);
 		if (outputFormat === 'text') {
-			console.log(encloseStringInBox('Published Version'));
-			console.log(`${publishedVersions.join('\n   ')}`);
+			console.log(encloseStringInBox('Published Tags'));
+			console.log(`${publishedTags.join('\n   ')}`);
 		} else {
-			jsonOutput.publishedVersions = publishedVersions;
+			jsonOutput.publishedTags = publishedTags;
 		}
 	}
 
@@ -145,8 +145,8 @@ async function getManifest(params: { output: Log; env: NodeJS.ProcessEnv; output
 
 async function getTags(params: { output: Log; env: NodeJS.ProcessEnv; outputFormat: string }, featureRef: OCIRef) {
 	const { outputFormat } = params;
-	const publishedVersions = await getPublishedVersions(params, featureRef, true);
-	if (!publishedVersions || publishedVersions.length === 0) {
+	const publishedTags = await getPublishedTags(params, featureRef);
+	if (!publishedTags || publishedTags.length === 0) {
 		if (outputFormat === 'json') {
 			console.log(JSON.stringify({}));
 		} else {
@@ -154,7 +154,7 @@ async function getTags(params: { output: Log; env: NodeJS.ProcessEnv; outputForm
 		}
 		process.exit(1);
 	}
-	return publishedVersions;
+	return publishedTags;
 }
 
 function encloseStringInBox(str: string, indent: number = 0) {

--- a/src/spec-node/featuresCLI/publish.ts
+++ b/src/spec-node/featuresCLI/publish.ts
@@ -100,7 +100,7 @@ async function featuresPublish({
             process.exit(1);
         }
 
-        const isPublished = (publishResult?.digest && publishResult?.publishedVersions.length > 0);
+        const isPublished = (publishResult?.digest && publishResult?.publishedTags.length > 0);
         let thisResult = isPublished ? {
             ...publishResult,
             version: f.version,
@@ -126,7 +126,7 @@ async function featuresPublish({
                     process.exit(1);
                 }
 
-                if (publishResult?.digest && publishResult?.publishedVersions.length > 0) {
+                if (publishResult?.digest && publishResult?.publishedTags.length > 0) {
                     publishedLegacyIds.push(legacyId);
                 }
             }

--- a/src/spec-node/templatesCLI/publish.ts
+++ b/src/spec-node/templatesCLI/publish.ts
@@ -94,7 +94,7 @@ async function templatesPublish({
             process.exit(1);
         }
 
-        const thisResult = (publishResult?.digest && publishResult?.publishedVersions?.length > 0) ? {
+        const thisResult = (publishResult?.digest && publishResult?.publishedTags?.length > 0) ? {
             ...publishResult,
             version: t.version,
         } : {};

--- a/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
@@ -4,6 +4,7 @@
 		"ghcr.io/devcontainers/features/git:1.0": "latest",
 		"ghcr.io/devcontainers/features/git-lfs@sha256:24d5802c837b2519b666a8403a9514c7296d769c9607048e9f1e040e7d7e331c": "latest",
 		"ghcr.io/devcontainers/features/github-cli": "latest",
-		"ghcr.io/devcontainers/features/azure-cli:0": "latest"
+		"ghcr.io/devcontainers/features/azure-cli:0": "latest",
+		"ghcr.io/codspace/versioning/foo:0.3.1": "latest"
 	}
 }

--- a/src/test/container-features/containerFeaturesOCIPush.test.ts
+++ b/src/test/container-features/containerFeaturesOCIPush.test.ts
@@ -124,7 +124,7 @@ registry`;
 		assert.isDefined(infoTagsResult);
 		const tags = JSON.parse(infoTagsResult.stdout);
 		const publishedVersions: string[] = tags['publishedVersions'];
-		assert.equal(publishedVersions.length, 4);
+		assert.equal(publishedVersions.length, 1);
 
 		success = false; // Reset success flag.
 		try {
@@ -300,7 +300,7 @@ registry`;
 		assert.isDefined(infoTagsResult);
 		const tags = JSON.parse(infoTagsResult.stdout);
 		const publishedVersions: string[] = tags['publishedVersions'];
-		assert.equal(publishedVersions.length, 4);
+		assert.equal(publishedVersions.length, 1);
 	});
 });
 

--- a/src/test/container-features/containerFeaturesOCIPush.test.ts
+++ b/src/test/container-features/containerFeaturesOCIPush.test.ts
@@ -300,7 +300,7 @@ registry`;
 		assert.isDefined(infoTagsResult);
 		const tags = JSON.parse(infoTagsResult.stdout);
 		const publishedTags: string[] = tags['publishedTags'];
-		assert.equal(publishedTags.length, 1);
+		assert.equal(publishedTags.length, 4);
 	});
 });
 

--- a/src/test/container-features/containerFeaturesOCIPush.test.ts
+++ b/src/test/container-features/containerFeaturesOCIPush.test.ts
@@ -15,7 +15,7 @@ export const output = makeLog(createPlainLog(text => process.stdout.write(text),
 const testAssetsDir = `${__dirname}/assets`;
 
 interface PublishResult {
-	publishedVersions: string[];
+	publishedTags: string[];
 	digest: string;
 	version: string;
 	publishedLegacyIds?: string[];
@@ -87,7 +87,7 @@ registry`;
 			const color = result['color'];
 			assert.isDefined(color);
 			assert.isDefined(color.digest);
-			assert.deepEqual(color.publishedVersions, [
+			assert.deepEqual(color.publishedTags, [
 				'1',
 				'1.0',
 				'1.0.0',
@@ -99,7 +99,7 @@ registry`;
 			const hello = result['hello'];
 			assert.isDefined(hello);
 			assert.isDefined(hello.digest);
-			assert.deepEqual(hello.publishedVersions, [
+			assert.deepEqual(hello.publishedTags, [
 				'1',
 				'1.0',
 				'1.0.0',
@@ -123,8 +123,8 @@ registry`;
 		assert.isTrue(success);
 		assert.isDefined(infoTagsResult);
 		const tags = JSON.parse(infoTagsResult.stdout);
-		const publishedVersions: string[] = tags['publishedVersions'];
-		assert.equal(publishedVersions.length, 1);
+		const publishedTags: string[] = tags['publishedTags'];
+		assert.equal(publishedTags.length, 4);
 
 		success = false; // Reset success flag.
 		try {
@@ -172,15 +172,15 @@ registry`;
 			assert.isObject(color);
 			// Check that the color object has no properties
 			assert.isUndefined(color.digest);
-			assert.isUndefined(color.publishedVersions);
+			assert.isUndefined(color.publishedTags);
 			assert.isUndefined(color.version);
 
 			// -- The breakfix version of hello was updated, so major and minor should be published again, too.
 			const hello = result['hello'];
 			assert.isDefined(hello);
 			assert.isDefined(hello.digest);
-			assert.isArray(hello.publishedVersions);
-			assert.deepEqual(hello.publishedVersions, [
+			assert.isArray(hello.publishedTags);
+			assert.deepEqual(hello.publishedTags, [
 				'1',
 				'1.0',
 				'1.0.1',
@@ -219,7 +219,7 @@ registry`;
 			const newColor = result['new-color'];
 			assert.isDefined(newColor);
 			assert.isDefined(newColor.digest);
-			assert.deepEqual(newColor.publishedVersions, [
+			assert.deepEqual(newColor.publishedTags, [
 				'1',
 				'1.0',
 				'1.0.1',
@@ -234,7 +234,7 @@ registry`;
 			const hello = result['hello'];
 			assert.isDefined(hello);
 			assert.isDefined(hello.digest);
-			assert.deepEqual(hello.publishedVersions, [
+			assert.deepEqual(hello.publishedTags, [
 				'1',
 				'1.0',
 				'1.0.0',
@@ -299,8 +299,8 @@ registry`;
 		assert.isTrue(success);
 		assert.isDefined(infoTagsResult);
 		const tags = JSON.parse(infoTagsResult.stdout);
-		const publishedVersions: string[] = tags['publishedVersions'];
-		assert.equal(publishedVersions.length, 1);
+		const publishedTags: string[] = tags['publishedTags'];
+		assert.equal(publishedTags.length, 1);
 	});
 });
 

--- a/src/test/container-features/featuresCLICommands.test.ts
+++ b/src/test/container-features/featuresCLICommands.test.ts
@@ -553,6 +553,57 @@ describe('test function getPublishedVersions', async () => {
 			assert.fail('featureRef should not be undefined');
 		}
 		const versionsList = await getPublishedVersions({ output, env: process.env }, featureRef) ?? [];
-		assert.includeMembers(versionsList, ['1', '1.0', '1.0.0', 'latest']);
+		assert.includeMembers(versionsList, ['1', '1.0', '1.0.0']);
 	});
+
+	it('should list published versions in an advanced case', async () => {
+		// https://github.com/codspace/versioning/pkgs/container/versioning%2Ffoo/versions
+		const resource = 'ghcr.io/codspace/versioning/foo';
+		const ref = getRef(output, resource);
+		if (!ref) {
+			assert.fail('ref should not be undefined');
+		}
+		const versionsList = await getPublishedVersions({ output, env: process.env }, ref, true) ?? [];
+		console.log(versionsList);
+		const expected = [
+			'0.0.0',
+			'0.0.1',
+			'0.0.2',
+			'0.1.0',
+			'0.2.0',
+			'0.3.0',
+			'0.3.1',
+			'0.3.2',
+			'0.3.3',
+			'0.3.4',
+			'0.3.5',
+			'0.3.6',
+			'0.3.7',
+			'0.3.8',
+			'0.3.9',
+			'0.3.10',
+			'0.3.11',
+			'0.3.12',
+			'0.4.0',
+			'1.0.0',
+			'1.1.0',
+			'2.0.0',
+			'2.1.0',
+			'2.2.0',
+			'2.2.1',
+			'2.3.0',
+			'2.4.0',
+			'2.5.0',
+			'2.6.0',
+			'2.7.0',
+			'2.8.0',
+			'2.9.0',
+			'2.10.0',
+			'2.10.1',
+			'2.11.0',
+			'2.11.1',
+		];
+		assert.deepStrictEqual(versionsList, expected);
+	});
+
 });

--- a/src/test/container-features/featuresCLICommands.test.ts
+++ b/src/test/container-features/featuresCLICommands.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 import { isLocalFile, readLocalFile } from '../../spec-utils/pfs';
 import { ExecResult, shellExec } from '../testUtils';
-import { getSemanticVersions } from '../../spec-node/collectionCommonUtils/publishCommandImpl';
+import { getSemanticTags } from '../../spec-node/collectionCommonUtils/publishCommandImpl';
 import { getRef, getPublishedTags, getVersionsStrictSorted } from '../../spec-configuration/containerCollectionsOCI';
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
 
@@ -484,63 +484,63 @@ describe('CLI features subcommands', async function () {
 describe('test function getSermanticVersions', () => {
 	it('should generate correct semantic versions for first publishing', async () => {
 		let version = '1.0.0';
-		let publishedVersions: string[] = [];
+		let publishedTags: string[] = [];
 		let expectedSemVer = ['1', '1.0', '1.0.0', 'latest'];
 
-		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticTags(version, publishedTags, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
 	it('should generate correct semantic versions for publishing new patch version', async () => {
 		let version = '1.0.1';
-		let publishedVersions = ['1', '1.0', '1.0.0', 'latest'];
+		let publishedTags = ['1', '1.0', '1.0.0', 'latest'];
 		let expectedSemVer = ['1', '1.0', '1.0.1', 'latest'];
 
-		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticTags(version, publishedTags, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
 	it('should generate correct semantic versions for publishing new minor version', async () => {
 		let version = '1.1.0';
-		let publishedVersions = ['1', '1.0', '1.0.0', '1.0.1', 'latest'];
+		let publishedTags = ['1', '1.0', '1.0.0', '1.0.1', 'latest'];
 		let expectedSemVer = ['1', '1.1', '1.1.0', 'latest'];
 
-		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticTags(version, publishedTags, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
 	it('should generate correct semantic versions for publishing new major version', async () => {
 		let version = '2.0.0';
-		let publishedVersions = ['1', '1.0', '1.0.0', 'latest'];
+		let publishedTags = ['1', '1.0', '1.0.0', 'latest'];
 		let expectedSemVer = ['2', '2.0', '2.0.0', 'latest'];
 
-		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticTags(version, publishedTags, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
 	it('should generate correct semantic versions for publishing hotfix patch version', async () => {
 		let version = '1.0.2';
-		let publishedVersions = ['1', '1.0', '1.0.0', '1.0.1', '1.1', '1.1.0', '2', '2.0', '2.0.0', 'latest'];
+		let publishedTags = ['1', '1.0', '1.0.0', '1.0.1', '1.1', '1.1.0', '2', '2.0', '2.0.0', 'latest'];
 		let expectedSemVer = ['1.0', '1.0.2'];
 
-		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticTags(version, publishedTags, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
 	it('should generate correct semantic versions for publishing hotfix minor version', async () => {
 		let version = '1.0.1';
-		let publishedVersions = ['1', '1.0', '1.0.0', '2', '2.0', '2.0.0', 'latest'];
+		let publishedTags = ['1', '1.0', '1.0.0', '2', '2.0', '2.0.0', 'latest'];
 		let expectedSemVer = ['1', '1.0', '1.0.1'];
 
-		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticTags(version, publishedTags, output);
 		assert.equal(semanticVersions?.toString(), expectedSemVer.toString());
 	});
 
 	it('should return undefined for already published version', async () => {
 		let version = '1.0.1';
-		let publishedVersions = ['1', '1.0', '1.0.0', '1.0.1', '2', '2.0', '2.0.0', 'latest'];
+		let publishedTags = ['1', '1.0', '1.0.0', '1.0.1', '2', '2.0', '2.0.0', 'latest'];
 
-		let semanticVersions = getSemanticVersions(version, publishedVersions, output);
+		let semanticVersions = getSemanticTags(version, publishedTags, output);
 		assert.isUndefined(semanticVersions);
 	});
 });

--- a/src/test/container-features/featuresCLICommands.test.ts
+++ b/src/test/container-features/featuresCLICommands.test.ts
@@ -4,7 +4,7 @@ import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 import { isLocalFile, readLocalFile } from '../../spec-utils/pfs';
 import { ExecResult, shellExec } from '../testUtils';
 import { getSemanticVersions } from '../../spec-node/collectionCommonUtils/publishCommandImpl';
-import { getRef, getPublishedVersions } from '../../spec-configuration/containerCollectionsOCI';
+import { getRef, getPublishedTags, getVersionsStrictSorted } from '../../spec-configuration/containerCollectionsOCI';
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
 
 const pkg = require('../../../package.json');
@@ -545,14 +545,14 @@ describe('test function getSermanticVersions', () => {
 	});
 });
 
-describe('test function getPublishedVersions', async () => {
+describe('test function getVersionsStrictSorted', async () => {
 	it('should list published versions', async () => {
 		const resource = 'ghcr.io/devcontainers/features/node';
 		const featureRef = getRef(output, resource);
 		if (!featureRef) {
 			assert.fail('featureRef should not be undefined');
 		}
-		const versionsList = await getPublishedVersions({ output, env: process.env }, featureRef) ?? [];
+		const versionsList = await getPublishedTags({ output, env: process.env }, featureRef) ?? [];
 		assert.includeMembers(versionsList, ['1', '1.0', '1.0.0']);
 	});
 
@@ -563,7 +563,7 @@ describe('test function getPublishedVersions', async () => {
 		if (!ref) {
 			assert.fail('ref should not be undefined');
 		}
-		const versionsList = await getPublishedVersions({ output, env: process.env }, ref, true) ?? [];
+		const versionsList = await getVersionsStrictSorted({ output, env: process.env }, ref) ?? [];
 		console.log(versionsList);
 		const expected = [
 			'0.0.0',

--- a/src/test/container-features/featuresCLICommands.test.ts
+++ b/src/test/container-features/featuresCLICommands.test.ts
@@ -545,15 +545,15 @@ describe('test function getSermanticVersions', () => {
 	});
 });
 
-describe('test function getVersionsStrictSorted', async () => {
+describe('test functions getVersionsStrictSorted and getPublishedTags', async () => {
 	it('should list published versions', async () => {
 		const resource = 'ghcr.io/devcontainers/features/node';
 		const featureRef = getRef(output, resource);
 		if (!featureRef) {
 			assert.fail('featureRef should not be undefined');
 		}
-		const versionsList = await getPublishedTags({ output, env: process.env }, featureRef) ?? [];
-		assert.includeMembers(versionsList, ['1', '1.0', '1.0.0']);
+		const publishedTags = await getPublishedTags({ output, env: process.env }, featureRef) ?? [];
+		assert.includeMembers(publishedTags, ['1', '1.0', '1.0.0', 'latest']);
 	});
 
 	it('should list published versions in an advanced case', async () => {
@@ -565,7 +565,7 @@ describe('test function getVersionsStrictSorted', async () => {
 		}
 		const versionsList = await getVersionsStrictSorted({ output, env: process.env }, ref) ?? [];
 		console.log(versionsList);
-		const expected = [
+		const expectedVersions = [
 			'0.0.0',
 			'0.0.1',
 			'0.0.2',
@@ -603,7 +603,76 @@ describe('test function getVersionsStrictSorted', async () => {
 			'2.11.0',
 			'2.11.1',
 		];
-		assert.deepStrictEqual(versionsList, expected);
+		// Order matters here
+		assert.deepStrictEqual(versionsList, expectedVersions);
+
+
+		const publishedTags = await getPublishedTags({ output, env: process.env }, ref) ?? [];
+		const expectedTags = [
+			'latest',
+			'0',
+			'1',
+			'2',
+			'0.0',
+			'0.0.0',
+			'0.0.1',
+			'0.0.2',
+			'0.1',
+			'0.1.0',
+			'0.2',
+			'0.2.0',
+			'0.3',
+			'0.3.0',
+			'0.3.1',
+			'0.3.10',
+			'0.3.11',
+			'0.3.12',
+			'0.3.2',
+			'0.3.3',
+			'0.3.4',
+			'0.3.5',
+			'0.3.6',
+			'0.3.7',
+			'0.3.8',
+			'0.3.9',
+			'0.4',
+			'0.4.0',
+			'1.0',
+			'1.0.0',
+			'1.1',
+			'1.1.0',
+			'2.0',
+			'2.0.0',
+			'2.1',
+			'2.1.0',
+			'2.10',
+			'2.10.0',
+			'2.10.1',
+			'2.11',
+			'2.11.0',
+			'2.11.1',
+			'2.2',
+			'2.2.0',
+			'2.2.1',
+			'2.3',
+			'2.3.0',
+			'2.4',
+			'2.4.0',
+			'2.5',
+			'2.5.0',
+			'2.6',
+			'2.6.0',
+			'2.7',
+			'2.7.0',
+			'2.8',
+			'2.8.0',
+			'2.9',
+			'2.9.0'
+		];
+		// Order is not guaranteed here (up to however the registry returns the tags)
+		assert.strictEqual(publishedTags.length, expectedTags.length);
+		assert.includeMembers(publishedTags, expectedTags);
+
 	});
 
 });

--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -115,6 +115,14 @@ describe('Lockfile', function () {
 		assert.strictEqual(azure.current, undefined);
 		assert.strictEqual(azure.wanted, undefined);
 		assert.ok(azure.latest);
+
+		const foo = response.features['ghcr.io/codspace/versioning/foo:0.3.1'];
+		assert.ok(foo);
+		assert.strictEqual(foo.current, '0.3.1');
+		assert.strictEqual(foo.wanted, '0.3.1');
+		assert.strictEqual(foo.wantedMajor, '0');
+		assert.strictEqual(foo.latest, '2.11.1');
+		assert.strictEqual(foo.latestMajor, '2');
 	});
 
 	it('upgrade command', async () => {


### PR DESCRIPTION
Ref: https://github.com/devcontainers/cli/issues/676

Reported in https://github.com/devcontainers/spec/discussions/327

Previously the comparision done to sort versions would incorrectly place patch versions >=10 above versions x.x.2-x.x.9.  This is due to the versions seemingly being sorted as string.

Eg:
![image](https://github.com/devcontainers/cli/assets/23246594/4bcf75aa-20fd-466c-abc0-bd20b7bdeae9)
Note that `1.0.11` is not the final entry.