### PR TITLE
add `--dry-run` to upgrade command

### DIFF
--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -129,6 +129,15 @@ describe('Lockfile', function () {
 		assert.equal(actual.toString(), expected.toString());
 	});
 
+	it('upgrade command in --dry-run mode', async () => {
+		const workspaceFolder = path.join(__dirname, 'configs/lockfile-dependson');
+		const res = await shellExec(`${cli} upgrade --dry-run --workspace-folder ${workspaceFolder}`);
+		const lockfile = JSON.parse(res.stdout);
+		assert.ok(lockfile);
+		assert.ok(lockfile.features);
+		assert.ok(lockfile.features['ghcr.io/codspace/dependson/A:2']);
+	});
+
 	it('OCI feature integrity', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-oci-integrity');
 


### PR DESCRIPTION
ref: https://github.com/github/codespaces/issues/15791

Adds a `--dry-run` flag to the upgrade command, printing the generated lockfile to standard out instead of the default of writing lockfile to disk.

I think this may be useful for dependabot and more generally I think it could be useful to users.