### PR TITLE
Edit a Feature pinned version via upgrade cmd

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -18,7 +18,7 @@ import { request } from '../spec-utils/httpRequest';
 import { fetchOCIFeature, tryGetOCIFeatureSet, fetchOCIFeatureManifestIfExistsFromUserIdentifier } from './containerFeaturesOCI';
 import { uriToFsPath } from './configurationCommonUtils';
 import { CommonParams, ManifestContainer, OCIManifest, OCIRef, getRef, getVersionsStrictSorted } from './containerCollectionsOCI';
-import { Lockfile, readLockfile, writeLockfile } from './lockfile';
+import { Lockfile, generateLockfile, readLockfile, writeLockfile } from './lockfile';
 import { computeDependsOnInstallationOrder } from './containerFeaturesOrder';
 import { logFeatureAdvisories } from './featureAdvisories';
 import { getEntPasswdShellCommand } from '../spec-common/commonUtils';
@@ -570,7 +570,7 @@ export async function generateFeaturesConfig(params: ContainerFeatureInternalPar
 	await fetchFeatures(params, featuresConfig, locallyCachedFeatureSet, dstFolder, localFeaturesFolder, ociCacheDir, lockfile);
 
 	await logFeatureAdvisories(params, featuresConfig);
-	await writeLockfile(params, config, featuresConfig, initLockfile);
+	await writeLockfile(params, config, await generateLockfile(featuresConfig), initLockfile);
 	return featuresConfig;
 }
 

--- a/src/spec-node/upgradeCommand.ts
+++ b/src/spec-node/upgradeCommand.ts
@@ -1,5 +1,3 @@
-import * as jsonc from 'jsonc-parser';
-
 import { Argv } from 'yargs';
 import { UnpackArgv } from './devContainersSpecCLI';
 import { dockerComposeCLIConfig } from './dockerCompose';

--- a/src/test/container-features/configs/lockfile-upgrade-feature/.gitignore
+++ b/src/test/container-features/configs/lockfile-upgrade-feature/.gitignore
@@ -1,0 +1,2 @@
+.devcontainer-lock.json
+.devcontainer.json

--- a/src/test/container-features/configs/lockfile-upgrade-feature/expected.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-upgrade-feature/expected.devcontainer.json
@@ -3,8 +3,10 @@
 	// Comment
 	"features": {
 		"ghcr.io/codspace/versioning/bar:1.0.0": {},
-		"ghcr.io/codspace/versioning/foo:2": {
-			"hello": "world"
+		// Comment
+		"ghcr.io/codspace/versioning/foo:2": { // Comment
+			"hello": "world" // Comment
 		}
+		// Comment
 	}
 }

--- a/src/test/container-features/configs/lockfile-upgrade-feature/expected.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-upgrade-feature/expected.devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base",
+	// Comment
+	"features": {
+		"ghcr.io/codspace/versioning/bar:1.0.0": {},
+		"ghcr.io/codspace/versioning/foo:2": {
+			"hello": "world"
+		}
+	}
+}

--- a/src/test/container-features/configs/lockfile-upgrade-feature/input.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-upgrade-feature/input.devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base",
+	// Comment
+	"features": {
+		"ghcr.io/codspace/versioning/bar:1.0.0": {},
+		"ghcr.io/codspace/versioning/foo:1": {
+			"hello": "world"
+		}
+	}
+}

--- a/src/test/container-features/configs/lockfile-upgrade-feature/input.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-upgrade-feature/input.devcontainer.json
@@ -3,8 +3,10 @@
 	// Comment
 	"features": {
 		"ghcr.io/codspace/versioning/bar:1.0.0": {},
-		"ghcr.io/codspace/versioning/foo:1": {
-			"hello": "world"
+		// Comment
+		"ghcr.io/codspace/versioning/foo:1": { // Comment
+			"hello": "world" // Comment
 		}
+		// Comment
 	}
 }

--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -146,6 +146,24 @@ describe('Lockfile', function () {
 		assert.ok(lockfile.features['ghcr.io/codspace/dependson/A:2']);
 	});
 
+	it('upgrade command with --feature', async () => {
+		const workspaceFolder = path.join(__dirname, 'configs/lockfile-upgrade-feature');
+		await cpLocal(path.join(workspaceFolder, 'input.devcontainer.json'), path.join(workspaceFolder, '.devcontainer.json'));
+
+		const res = await shellExec(`${cli} upgrade --dry-run --workspace-folder ${workspaceFolder} --feature ghcr.io/codspace/versioning/foo --target-version 2`);
+
+		// Check devcontainer.json was updated
+		const actual = await readLocalFile(path.join(workspaceFolder, '.devcontainer.json'));
+		const expected = await readLocalFile(path.join(workspaceFolder, 'expected.devcontainer.json'));
+		assert.equal(actual.toString(), expected.toString());
+
+		// Check lockfile was updated
+		const lockfile = JSON.parse(res.stdout);
+		assert.ok(lockfile);
+		assert.ok(lockfile.features);
+		assert.ok(lockfile.features['ghcr.io/codspace/versioning/foo:2'].version === '2.11.1');
+	});
+
 	it('OCI feature integrity', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-oci-integrity');
 


### PR DESCRIPTION
This change adds new arguments to the `upgrade` command to facilitate updating a single Feature in a `devcontainer.json`.  After the edit to the `devcontainer.json` is made, the lockfile is updated according to the requirements (version tags) of each Feature. 

https://github.com/devcontainers/cli/assets/23246594/68073ae6-3590-4c6a-9193-edeed5dd7883



This is useful in dependbot's [`file_updater`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/file_updaters/README.md) step, allowing us to do shell out to the CLI directly for this operation. This is similar to the [Swift's `file_updater` implementation in dependabot core](https://github.com/joshspicer/dependabot-core/blob/joshspicer/devcontainers/swift/lib/dependabot/swift/file_updater/lockfile_updater.rb#L37)

I've marked this arguments as 'hidden' while I do some initial experimentation. Today the entire lockfile will be regenerated even if `--feature` is used.

ref: https://github.com/github/codespaces/issues/15791