### PR TITLE
update string in `isBuildKitImagePolicyError`

### DIFF
--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -205,9 +205,14 @@ export async function checkDockerSupportForGPU(params: DockerCLIParameters | Doc
 }
 
 export function isBuildKitImagePolicyError(err: any): boolean {
-	const imagePolicyErrorString = 'could not resolve image due to policy';
-	return (err?.cmdOutput && typeof err.cmdOutput === 'string' && err.cmdOutput.indexOf(imagePolicyErrorString) > -1) ||
-		(err?.stderr && typeof err.stderr === 'string' && err.stderr.indexOf(imagePolicyErrorString) > -1);
+	const imagePolicyErrorString = 'could not resolve image due to policy'; // Seen in Buildkit 0.11.0
+	const sourceDeniedString = 'source denied by policy'; // Seen in Buildkit 0.12.0
+
+	const errCmdOutput = err?.cmdOutput;
+	const errStderr = err?.stderr;
+
+	return (errCmdOutput && typeof errCmdOutput === 'string' && errCmdOutput.includes(imagePolicyErrorString) || errCmdOutput.includes(sourceDeniedString))
+		|| (errStderr && typeof errStderr === 'string' && errStderr.includes(imagePolicyErrorString) || errStderr.includes(sourceDeniedString));
 }
 
 export async function inspectDockerImage(params: DockerResolverParameters | DockerCLIParameters, imageName: string, pullImageOnError: boolean) {

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -211,8 +211,8 @@ export function isBuildKitImagePolicyError(err: any): boolean {
 	const errCmdOutput = err?.cmdOutput;
 	const errStderr = err?.stderr;
 
-	return (errCmdOutput && typeof errCmdOutput === 'string' && errCmdOutput.includes(imagePolicyErrorString) || errCmdOutput.includes(sourceDeniedString))
-		|| (errStderr && typeof errStderr === 'string' && errStderr.includes(imagePolicyErrorString) || errStderr.includes(sourceDeniedString));
+	return (errCmdOutput && typeof errCmdOutput === 'string' && (errCmdOutput.includes(imagePolicyErrorString) || errCmdOutput.includes(sourceDeniedString)))
+		|| (errStderr && typeof errStderr === 'string' && (errStderr.includes(imagePolicyErrorString) || errStderr.includes(sourceDeniedString)));
 }
 
 export async function inspectDockerImage(params: DockerResolverParameters | DockerCLIParameters, imageName: string, pullImageOnError: boolean) {


### PR DESCRIPTION
I was testing detection of buildx source policy errors (see https://github.com/devcontainers/cli/pull/627), and noticed the error message has changed in 0.12.x.  I haven't seen a better form of detection yet (+ asked the author a while back).

![image](https://github.com/devcontainers/cli/assets/23246594/e7538ae5-8662-42e5-92f1-bb925f813a37)
