### PR TITLE
Escape * to prevent linux globbing from dumping random files into argument

### DIFF
--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -567,7 +567,7 @@ export async function readDockerComposeConfig(params: DockerCLIParameters, compo
 		}
 		const composeCLI = await params.dockerComposeCLI();
 		if ((parseVersion(composeCLI.version) || [])[0] >= 2) {
-			composeGlobalArgs.push('--profile', '*');
+			composeGlobalArgs.push('--profile', '\\*');
 		}
 		try {
 			const partial = toExecParameters(params, 'dockerComposeCLI' in params ? await params.dockerComposeCLI() : undefined);


### PR DESCRIPTION
While attempting to "Reopen in Container" in VSCode (Running Ubuntu through WSL with Docker CLI, no Docker Desktop) on a devcontainer.json targeting a docker-compose.yml, similar to the following: 
```json
{
	"name": "xyzdef",
        "service": "xyzdef",
        "workspaceFolder": "/xyzdef",
        "dockerComposeFile": [ "../../docker-compose.yml" ] //docker-compose has a service named xyzdef
}
```
I got the error:
![image](https://github.com/devcontainers/cli/assets/53534357/ad796c1a-9be2-4e7e-b9e9-5957a5bdc1c6)
further up:
![image](https://github.com/devcontainers/cli/assets/53534357/2543da50-78a8-438d-bba4-b1f51358c0ec)
![image](https://github.com/devcontainers/cli/assets/53534357/7e0c2960-abd7-4d7e-b65b-6cceba641317)
The `*` being placed in the docker compose cli call was getting globbed as a file wildcard, resulting in a random file from the workspace folder root being passed to the `--profile` parameter

Editing `~/.vscode-remote-containers/dist/dev-containers-cli-0.321.0/dist/spec-node/devContainersSpecCLI.js` with the following change fixed the problem.