### PR TITLE
Add hidden `--omit-syntax-directive` flag

### DIFF
--- a/src/spec-common/injectHeadless.ts
+++ b/src/spec-common/injectHeadless.ts
@@ -68,6 +68,7 @@ export interface ResolverParameters {
 	skipPersistingCustomizationsFromFeatures: boolean;
 	omitConfigRemotEnvFromMetadata?: boolean;
 	secretsP?: Promise<Record<string, string>>;
+	ignoreSyntaxDirective?: boolean;
 }
 
 export interface LifecycleHook {

--- a/src/spec-common/injectHeadless.ts
+++ b/src/spec-common/injectHeadless.ts
@@ -68,7 +68,7 @@ export interface ResolverParameters {
 	skipPersistingCustomizationsFromFeatures: boolean;
 	omitConfigRemotEnvFromMetadata?: boolean;
 	secretsP?: Promise<Record<string, string>>;
-	ignoreSyntaxDirective?: boolean;
+	omitSyntaxDirective?: boolean;
 }
 
 export interface LifecycleHook {

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -243,8 +243,8 @@ async function getFeaturesBuildOptions(params: DockerResolverParameters, devCont
 		.replace('#{containerEnvMetadata}', generateContainerEnvs(devContainerConfig.config.containerEnv, true))
 		;
 	const syntax = imageBuildInfo.dockerfile?.preamble.directives.syntax;
-	const ignoreSyntaxDirective = common.ignoreSyntaxDirective; // Can be removed when https://github.com/moby/buildkit/issues/4556 is fixed
-	const dockerfilePrefixContent = `${ignoreSyntaxDirective ? '' :
+	const omitSyntaxDirective = common.omitSyntaxDirective; // Can be removed when https://github.com/moby/buildkit/issues/4556 is fixed
+	const dockerfilePrefixContent = `${omitSyntaxDirective ? '' :
 		useBuildKitBuildContexts && !(imageBuildInfo.dockerfile && supportsBuildContexts(imageBuildInfo.dockerfile)) ? '# syntax=docker/dockerfile:1.4' :
 		syntax ? `# syntax=${syntax}` : ''}
 ARG _DEV_CONTAINERS_BASE_IMAGE=placeholder

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -243,8 +243,9 @@ async function getFeaturesBuildOptions(params: DockerResolverParameters, devCont
 		.replace('#{containerEnvMetadata}', generateContainerEnvs(devContainerConfig.config.containerEnv, true))
 		;
 	const syntax = imageBuildInfo.dockerfile?.preamble.directives.syntax;
-	const dockerfilePrefixContent = `${useBuildKitBuildContexts && !(imageBuildInfo.dockerfile && supportsBuildContexts(imageBuildInfo.dockerfile)) ?
-		'# syntax=docker/dockerfile:1.4' :
+	const ignoreSyntaxDirective = common.ignoreSyntaxDirective; // Can be removed when https://github.com/moby/buildkit/issues/4556 is fixed
+	const dockerfilePrefixContent = `${ignoreSyntaxDirective ? '' :
+		useBuildKitBuildContexts && !(imageBuildInfo.dockerfile && supportsBuildContexts(imageBuildInfo.dockerfile)) ? '# syntax=docker/dockerfile:1.4' :
 		syntax ? `# syntax=${syntax}` : ''}
 ARG _DEV_CONTAINERS_BASE_IMAGE=placeholder
 `;

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -67,6 +67,7 @@ export interface ProvisionOptions {
 	experimentalLockfile?: boolean;
 	experimentalFrozenLockfile?: boolean;
 	secretsP?: Promise<Record<string, string>>;
+	ignoreSyntaxDirective?: boolean;
 }
 
 export async function launch(options: ProvisionOptions, providedIdLabels: string[] | undefined, disposables: (() => Promise<unknown> | undefined)[]) {
@@ -151,7 +152,8 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 			repository: options.dotfiles.repository,
 			installCommand: options.dotfiles.installCommand,
 			targetPath: options.dotfiles.targetPath || '~/dotfiles',
-		}
+		},
+		ignoreSyntaxDirective: options.ignoreSyntaxDirective,
 	};
 
 	const dockerPath = options.dockerPath || 'docker';

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -67,7 +67,7 @@ export interface ProvisionOptions {
 	experimentalLockfile?: boolean;
 	experimentalFrozenLockfile?: boolean;
 	secretsP?: Promise<Record<string, string>>;
-	ignoreSyntaxDirective?: boolean;
+	omitSyntaxDirective?: boolean;
 }
 
 export async function launch(options: ProvisionOptions, providedIdLabels: string[] | undefined, disposables: (() => Promise<unknown> | undefined)[]) {
@@ -153,7 +153,7 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 			installCommand: options.dotfiles.installCommand,
 			targetPath: options.dotfiles.targetPath || '~/dotfiles',
 		},
-		ignoreSyntaxDirective: options.ignoreSyntaxDirective,
+		omitSyntaxDirective: options.omitSyntaxDirective,
 	};
 
 	const dockerPath = options.dockerPath || 'docker';

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -130,7 +130,7 @@ function provisionOptions(y: Argv) {
 		'secrets-file': { type: 'string', description: 'Path to a json file containing secret environment variables as key-value pairs.' },
 		'experimental-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Write lockfile' },
 		'experimental-frozen-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Ensure lockfile remains unchanged' },
-		'ignore-syntax-directive': { type: 'boolean', default: false, hidden: true, description: 'Ignore injecting Dockerfile syntax directive into Features extended Dockerfile' },
+		'omit-syntax-directive': { type: 'boolean', default: false, hidden: true, description: 'Omit Dockerfile syntax directives' },
 	})
 		.check(argv => {
 			const idLabels = (argv['id-label'] && (Array.isArray(argv['id-label']) ? argv['id-label'] : [argv['id-label']])) as string[] | undefined;
@@ -200,7 +200,7 @@ async function provision({
 	'secrets-file': secretsFile,
 	'experimental-lockfile': experimentalLockfile,
 	'experimental-frozen-lockfile': experimentalFrozenLockfile,
-	'ignore-syntax-directive': ignoreSyntaxDirective,
+	'omit-syntax-directive': omitSyntaxDirective,
 }: ProvisionArgs) {
 
 	const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
@@ -266,7 +266,7 @@ async function provision({
 		omitConfigRemotEnvFromMetadata: omitConfigRemotEnvFromMetadata,
 		experimentalLockfile,
 		experimentalFrozenLockfile,
-		ignoreSyntaxDirective,
+		omitSyntaxDirective: omitSyntaxDirective,
 	};
 
 	const result = await doProvision(options, providedIdLabels);
@@ -491,7 +491,8 @@ function buildOptions(y: Argv) {
 		'skip-feature-auto-mapping': { type: 'boolean', default: false, hidden: true, description: 'Temporary option for testing.' },
 		'skip-persisting-customizations-from-features': { type: 'boolean', default: false, hidden: true, description: 'Do not save customizations from referenced Features as image metadata' },
 		'experimental-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Write lockfile' },
-		'experimental-frozen-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Ensure lockfile remains unchanged' }
+		'experimental-frozen-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Ensure lockfile remains unchanged' },
+		'omit-syntax-directive': { type: 'boolean', default: false, hidden: true, description: 'Omit Dockerfile syntax directives' },
 	});
 }
 
@@ -529,7 +530,8 @@ async function doBuild({
 	'skip-feature-auto-mapping': skipFeatureAutoMapping,
 	'skip-persisting-customizations-from-features': skipPersistingCustomizationsFromFeatures,
 	'experimental-lockfile': experimentalLockfile,
-	'experimental-frozen-lockfile': experimentalFrozenLockfile
+	'experimental-frozen-lockfile': experimentalFrozenLockfile,
+	'omit-syntax-directive': omitSyntaxDirective,
 }: BuildArgs) {
 	const disposables: (() => Promise<unknown> | undefined)[] = [];
 	const dispose = async () => {
@@ -576,7 +578,8 @@ async function doBuild({
 			skipPersistingCustomizationsFromFeatures: skipPersistingCustomizationsFromFeatures,
 			dotfiles: {},
 			experimentalLockfile,
-			experimentalFrozenLockfile
+			experimentalFrozenLockfile,
+			omitSyntaxDirective,
 		}, disposables);
 
 		const { common, dockerCLI, dockerComposeCLI } = params;

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -129,7 +129,8 @@ function provisionOptions(y: Argv) {
 		'omit-config-remote-env-from-metadata': { type: 'boolean', default: false, hidden: true, description: 'Omit remoteEnv from devcontainer.json for container metadata label' },
 		'secrets-file': { type: 'string', description: 'Path to a json file containing secret environment variables as key-value pairs.' },
 		'experimental-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Write lockfile' },
-		'experimental-frozen-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Ensure lockfile remains unchanged' }
+		'experimental-frozen-lockfile': { type: 'boolean', default: false, hidden: true, description: 'Ensure lockfile remains unchanged' },
+		'ignore-syntax-directive': { type: 'boolean', default: false, hidden: true, description: 'Ignore injecting Dockerfile syntax directive into Features extended Dockerfile' },
 	})
 		.check(argv => {
 			const idLabels = (argv['id-label'] && (Array.isArray(argv['id-label']) ? argv['id-label'] : [argv['id-label']])) as string[] | undefined;
@@ -198,7 +199,8 @@ async function provision({
 	'omit-config-remote-env-from-metadata': omitConfigRemotEnvFromMetadata,
 	'secrets-file': secretsFile,
 	'experimental-lockfile': experimentalLockfile,
-	'experimental-frozen-lockfile': experimentalFrozenLockfile
+	'experimental-frozen-lockfile': experimentalFrozenLockfile,
+	'ignore-syntax-directive': ignoreSyntaxDirective,
 }: ProvisionArgs) {
 
 	const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
@@ -264,6 +266,7 @@ async function provision({
 		omitConfigRemotEnvFromMetadata: omitConfigRemotEnvFromMetadata,
 		experimentalLockfile,
 		experimentalFrozenLockfile,
+		ignoreSyntaxDirective,
 	};
 
 	const result = await doProvision(options, providedIdLabels);

--- a/src/test/dockerfileUtils.test.ts
+++ b/src/test/dockerfileUtils.test.ts
@@ -166,7 +166,7 @@ FROM ubuntu:latest as dev
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
             return details;
-        }, dockerfile, {}, undefined, testSubstitute, nullLog);
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false);
         assert.strictEqual(info.user, 'imageUser');
         assert.strictEqual(info.metadata.config.length, 1);
         assert.strictEqual(info.metadata.config[0].id, 'testid-substituted');
@@ -192,7 +192,7 @@ USER dockerfileUserB
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
             return details;
-        }, dockerfile, {}, undefined, testSubstitute, nullLog);
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false);
         assert.strictEqual(info.user, 'dockerfileUserB');
         assert.strictEqual(info.metadata.config.length, 0);
         assert.strictEqual(info.metadata.raw.length, 0);


### PR DESCRIPTION
Unblocks bug with `#syntax` directives + buildkit + user namespace remapping by not auto-injecting the `#syntax` directive in the extended (Features) intermediate Dockerfile, and ignoring user-contributed syntax directives.  

See https://github.com/moby/buildkit/issues/4556 for more info.

Enable with hidden `--omit-syntax-directive` `up` and `build` flag.  **This flag will be removed once upstream is fixed.**

ref: https://github.com/github/codespaces/issues/15748