### PR TITLE
Ignore non-versioned Features when generating `outdated` report

### DIFF
--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -142,6 +142,12 @@ export function getRef(output: Log, input: string): OCIRef | undefined {
 	// Normalize input by downcasing entire string
 	input = input.toLowerCase();
 
+	// Invalid if first character is a dot
+	if (input.startsWith('.')) {
+		output.write(`Input '${input}' failed validation.  Expected input to not start with '.'`, LogLevel.Error);
+		return;
+	}
+
 	const indexOfLastColon = input.lastIndexOf(':');
 	const indexOfLastAtCharacter = input.lastIndexOf('@');
 

--- a/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
@@ -6,7 +6,7 @@
 		"ghcr.io/devcontainers/features/github-cli": "latest",
 		"ghcr.io/devcontainers/features/azure-cli:0": "latest",
 		"ghcr.io/codspace/versioning/foo:0.3.1": "latest",
-		"./mylocalfeature": {},
-		"terraform": "latest"
+		// "./mylocalfeature": {},
+		// "terraform": "latest"
 	}
 }

--- a/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
@@ -5,6 +5,8 @@
 		"ghcr.io/devcontainers/features/git-lfs@sha256:24d5802c837b2519b666a8403a9514c7296d769c9607048e9f1e040e7d7e331c": "latest",
 		"ghcr.io/devcontainers/features/github-cli": "latest",
 		"ghcr.io/devcontainers/features/azure-cli:0": "latest",
-		"ghcr.io/codspace/versioning/foo:0.3.1": "latest"
+		"ghcr.io/codspace/versioning/foo:0.3.1": "latest",
+		"./mylocalfeature": {},
+		"terraform": "latest"
 	}
 }

--- a/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
+++ b/src/test/container-features/configs/lockfile-outdated-command/.devcontainer.json
@@ -3,10 +3,12 @@
 	"features": {
 		"ghcr.io/devcontainers/features/git:1.0": "latest",
 		"ghcr.io/devcontainers/features/git-lfs@sha256:24d5802c837b2519b666a8403a9514c7296d769c9607048e9f1e040e7d7e331c": "latest",
+		"./features/mylocalfeature2": "latest",
 		"ghcr.io/devcontainers/features/github-cli": "latest",
 		"ghcr.io/devcontainers/features/azure-cli:0": "latest",
 		"ghcr.io/codspace/versioning/foo:0.3.1": "latest",
-		// "./mylocalfeature": {},
-		// "terraform": "latest"
+		"./mylocalfeature": {},
+		"terraform": "latest",
+		"https://myfeatures.com/features.tgz": "latest"
 	}
 }

--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -145,6 +145,11 @@ describe('Lockfile', function () {
 		assert.ok(response.includes('ghcr.io/devcontainers/features/github-cli'), 'github-cli Feature is missing');
 		assert.ok(response.includes('ghcr.io/devcontainers/features/azure-cli'), 'azure-cli Feature is missing');
 		assert.ok(response.includes('ghcr.io/codspace/versioning/foo'), 'foo Feature is missing');
+
+		// Check that filtered Features are not present
+		assert.ok(!response.includes('mylocalfeature'));
+		assert.ok(!response.includes('terraform'));
+		assert.ok(!response.includes('myfeatures'));
 	});
 
 	it('upgrade command', async () => {

--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -87,7 +87,7 @@ describe('Lockfile', function () {
 		}
 	});
 
-	it('outdated command', async () => {
+	it('outdated command with json output', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
 
 		const res = await shellExec(`${cli} outdated --workspace-folder ${workspaceFolder} --output-format json`);
@@ -123,6 +123,28 @@ describe('Lockfile', function () {
 		assert.strictEqual(foo.wantedMajor, '0');
 		assert.strictEqual(foo.latest, '2.11.1');
 		assert.strictEqual(foo.latestMajor, '2');
+	});
+
+	it('outdated command with text output', async () => {
+		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
+
+		const res = await shellExec(`${cli} outdated --workspace-folder ${workspaceFolder} --output-format text`);
+		const response = res.stdout;
+		// Count number of lines of output
+		assert.strictEqual(response.split('\n').length, 7); // 5 valid Features + header + empty line
+
+		// Check that the header is present
+		assert.ok(response.includes('Current'), 'Current column is missing');
+		assert.ok(response.includes('Wanted'), 'Wanted column is missing');
+		assert.ok(response.includes('Latest'), 'Latest column is missing');
+
+		// Check that the features are present
+		// The version values are checked for correctness in the json variant of this test
+		assert.ok(response.includes('ghcr.io/devcontainers/features/git'), 'git Feature is missing');
+		assert.ok(response.includes('ghcr.io/devcontainers/features/git-lfs'), 'git-lfs Feature is missing');
+		assert.ok(response.includes('ghcr.io/devcontainers/features/github-cli'), 'github-cli Feature is missing');
+		assert.ok(response.includes('ghcr.io/devcontainers/features/azure-cli'), 'azure-cli Feature is missing');
+		assert.ok(response.includes('ghcr.io/codspace/versioning/foo'), 'foo Feature is missing');
 	});
 
 	it('upgrade command', async () => {

--- a/src/test/container-templates/containerTemplatesOCI.test.ts
+++ b/src/test/container-templates/containerTemplatesOCI.test.ts
@@ -111,8 +111,8 @@ describe('fetchTemplate', async function () {
 		const files = await fetchTemplate({ output, env: process.env }, selectedTemplate, dest);
 		assert.ok(files);
 		// Expected:
-		// ./environment.yml, ./.devcontainer/.env, ./.devcontainer/Dockerfile, ./.devcontainer/devcontainer.json, ./.devcontainer/docker-compose.yml, ./.devcontainer/noop.txt
-		assert.strictEqual(files.length, 6);
+		// ./environment.yml, ./.devcontainer/.env, ./.devcontainer/Dockerfile, ./.devcontainer/devcontainer.json, ./.devcontainer/docker-compose.yml, ./.devcontainer/noop.txt, ./.github/dependabot.yml
+		assert.strictEqual(files.length, 7);
 
 		// Read file modified by templated value
 		const dockerfile = (await readLocalFile(path.join(dest, '.devcontainer', 'Dockerfile'))).toString();


### PR DESCRIPTION
Made a couple changes to the `outdated` command.

- Addresses https://github.com/devcontainers/cli/issues/712 by omitting the deprecated "short-hand" Feature syntax from the output of `outdated`.  
    - This is a bit opinionated, but my reasoning here is that - since there is no way for the user to alter these Feature versions (they're "held back" to the major version from when they were deprecated) - it doesn't make sense to surface in `outdated`.  
    - Omitting these Features from `outdated` will subsequently cause the [dependabot integration](https://github.com/dependabot/dependabot-core/blob/main/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb#L47) to not consider them for version updates, which [is already being done as an exceptional case](https://github.com/dependabot/dependabot-core/blob/main/devcontainers/lib/dependabot/devcontainers/file_parser/feature_dependency_parser.rb#L70).
- Updates to `getRef()` to better filter out non-OCI Features, namely "local Features".
- Fix a sorting bug that caused `--output-format text` to exit unsuccessfully if a "local Feature" was present in the config.
    -  Added a test to exercise that code path
