### PR TITLE
Set maxBodyLength to 100MB to allow larger feature uploads

### DIFF
--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { RequestOptions } from 'https';
-import { https, http } from 'follow-redirects';
+import { https, http, FollowOptions } from 'follow-redirects';
 import { ProxyAgent } from 'proxy-agent';
 import * as url from 'url';
 import * as tls from 'tls';
@@ -85,8 +85,9 @@ export async function requestResolveHeaders(options: { type: string; url: string
 	const secureContext = await secureContextWithExtraCerts(output);
 	return new Promise<{ statusCode: number; resHeaders: Record<string, string>; resBody: Buffer }>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
-		const reqOptions: RequestOptions & tls.CommonConnectionOptions = {
+		const reqOptions: RequestOptions & tls.CommonConnectionOptions & FollowOptions<any> = {
 			hostname: parsed.hostname,
+			maxBodyLength: 100 * 1024 * 1024,
 			port: parsed.port,
 			path: parsed.pathname + parsed.search,
 			method: options.type,


### PR DESCRIPTION
`follow-redirects` [npm doc](https://www.npmjs.com/package/follow-redirects) states that it's a drop-in replacement for the native http and https modules, but it turns out that's not quite true as it additionally sets a maximum HTTP request body length of 10MB by default.  I expect this is because the request body is cached internally so it can be replayed, so is done in order to manage memory usage.

This overrides the default maxBodySize to 100MB as a quick fix to allow larger devcontainer features to be published with the CLI.  Without this, some more expensive solution like chunking would be required.

Fixes #270 