### PR TITLE
[FIX] Don't crash updating UID/GID when the image's platform is different from the native CPU arch

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -69,7 +69,9 @@ jobs:
         registry-url: 'https://npm.pkg.github.com'
         scope: '@microsoft'
     - name: Install Dependencies
-      run: yarn install --frozen-lockfile
+      run: |
+        yarn install --frozen-lockfile
+        docker run --privileged --rm tonistiigi/binfmt --install all
     - name: Type-Check
       run: yarn type-check
     - name: Package

--- a/src/spec-common/cliHost.ts
+++ b/src/spec-common/cliHost.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved. 
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/spec-common/commonUtils.ts
+++ b/src/spec-common/commonUtils.ts
@@ -47,6 +47,7 @@ export type GoARCH = { [ARCH in NodeJS.Architecture]: ARCH extends 'x64' ? 'amd6
 export interface PlatformInfo {
 	os: GoOS;
 	arch: GoARCH;
+	variant?: string;
 }
 
 export interface PtyExec {

--- a/src/spec-common/commonUtils.ts
+++ b/src/spec-common/commonUtils.ts
@@ -41,6 +41,11 @@ export interface ExecFunction {
 	(params: ExecParameters): Promise<Exec>;
 }
 
+export interface PlatformInfo {
+	arch: NodeJS.Architecture;
+	os: NodeJS.Platform;
+}
+
 export interface PtyExec {
 	onData: Event<string>;
 	write?(data: string): void;

--- a/src/spec-common/commonUtils.ts
+++ b/src/spec-common/commonUtils.ts
@@ -41,9 +41,12 @@ export interface ExecFunction {
 	(params: ExecParameters): Promise<Exec>;
 }
 
+export type GoOS = { [OS in NodeJS.Platform]: OS extends 'win32' ? 'windows' : OS; }[NodeJS.Platform];
+export type GoARCH = { [ARCH in NodeJS.Architecture]: ARCH extends 'x64' ? 'amd64' : ARCH; }[NodeJS.Architecture];
+
 export interface PlatformInfo {
-	arch: NodeJS.Architecture;
-	os: NodeJS.Platform;
+	os: GoOS;
+	arch: GoARCH;
 }
 
 export interface PtyExec {

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -7,6 +7,7 @@ import * as crypto from 'crypto';
 import { Log, LogLevel } from '../spec-utils/log';
 import { isLocalFile, mkdirpLocal, readLocalFile, writeLocalFile } from '../spec-utils/pfs';
 import { requestEnsureAuthenticated } from './httpOCIRegistry';
+import { GoARCH, GoOS, PlatformInfo } from '../spec-common/commonUtils';
 
 export const DEVCONTAINER_MANIFEST_MEDIATYPE = 'application/vnd.devcontainers';
 export const DEVCONTAINER_TAR_LAYER_MEDIATYPE = 'application/vnd.devcontainers.layer.v1+tar';
@@ -116,7 +117,7 @@ const regexForVersionOrDigest = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/;
 
 // https://go.dev/doc/install/source#environment
 // Expected by OCI Spec as seen here: https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions
-export function mapNodeArchitectureToGOARCH(arch: NodeJS.Architecture): string {
+export function mapNodeArchitectureToGOARCH(arch: NodeJS.Architecture): GoARCH {
 	switch (arch) {
 		case 'x64':
 			return 'amd64';
@@ -127,7 +128,7 @@ export function mapNodeArchitectureToGOARCH(arch: NodeJS.Architecture): string {
 
 // https://go.dev/doc/install/source#environment
 // Expected by OCI Spec as seen here: https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions
-export function mapNodeOSToGOOS(os: NodeJS.Platform): string {
+export function mapNodeOSToGOOS(os: NodeJS.Platform): GoOS {
 	switch (os) {
 		case 'win32':
 			return 'windows';
@@ -272,13 +273,13 @@ export function getCollectionRef(output: Log, registry: string, namespace: strin
 export async function fetchOCIManifestIfExists(params: CommonParams, ref: OCIRef | OCICollectionRef, manifestDigest?: string): Promise<ManifestContainer | undefined> {
 	const { output } = params;
 
-	// Simple mechanism to avoid making a DNS request for 
+	// Simple mechanism to avoid making a DNS request for
 	// something that is not a domain name.
 	if (ref.registry.indexOf('.') < 0 && !ref.registry.startsWith('localhost')) {
 		return;
 	}
 
-	// TODO: Always use the manifest digest (the canonical digest) 
+	// TODO: Always use the manifest digest (the canonical digest)
 	//       instead of the `ref.version` by referencing some lock file (if available).
 	let reference = ref.version;
 	if (manifestDigest) {
@@ -338,7 +339,7 @@ export async function getManifest(params: CommonParams, url: string, ref: OCIRef
 }
 
 // https://github.com/opencontainers/image-spec/blob/main/manifest.md
-export async function getImageIndexEntryForPlatform(params: CommonParams, url: string, ref: OCIRef | OCICollectionRef, platformInfo: { arch: NodeJS.Architecture; os: NodeJS.Platform }, mimeType?: string): Promise<OCIImageIndexEntry | undefined> {
+export async function getImageIndexEntryForPlatform(params: CommonParams, url: string, ref: OCIRef | OCICollectionRef, platformInfo: PlatformInfo, mimeType?: string): Promise<OCIImageIndexEntry | undefined> {
 	const { output } = params;
 	const response = await getJsonWithMimeType<OCIImageIndex>(params, url, ref, mimeType || 'application/vnd.oci.image.index.v1+json');
 	if (!response) {
@@ -351,14 +352,9 @@ export async function getImageIndexEntryForPlatform(params: CommonParams, url: s
 		return undefined;
 	}
 
-	const ociFriendlyPlatformInfo = {
-		arch: mapNodeArchitectureToGOARCH(platformInfo.arch),
-		os: mapNodeOSToGOOS(platformInfo.os),
-	};
-
 	// Find a manifest for the current architecture and OS.
 	return imageIndex.manifests.find(m => {
-		if (m.platform?.architecture === ociFriendlyPlatformInfo.arch && m.platform?.os === ociFriendlyPlatformInfo.os) {
+		if (m.platform?.architecture === platformInfo.arch && m.platform?.os === platformInfo.os) {
 			return m;
 		}
 		return undefined;

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -92,6 +92,7 @@ interface OCIImageIndexEntry {
 	digest: string;
 	platform: {
 		architecture: string;
+		variant?: string;
 		os: string;
 	};
 }
@@ -355,7 +356,9 @@ export async function getImageIndexEntryForPlatform(params: CommonParams, url: s
 	// Find a manifest for the current architecture and OS.
 	return imageIndex.manifests.find(m => {
 		if (m.platform?.architecture === platformInfo.arch && m.platform?.os === platformInfo.os) {
-			return m;
+			if (!platformInfo.variant || m.platform?.variant === platformInfo.variant) {
+				return m;
+			}
 		}
 		return undefined;
 	});

--- a/src/spec-node/configContainer.ts
+++ b/src/spec-node/configContainer.ts
@@ -60,7 +60,7 @@ async function resolveWithLocalFolder(params: DockerResolverParameters, parsedAu
 
 	const { dockerCLI, dockerComposeCLI } = params;
 	const { env } = common;
-	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output };
+	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output, platformInfo: params.platformInfo };
 	await ensureNoDisallowedFeatures(cliParams, config, additionalFeatures, idLabels);
 
 	await runInitializeCommand({ ...params, common: { ...common, output: common.lifecycleHook.output } }, config.initializeCommand, common.lifecycleHook.onDidInput);

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -416,7 +416,7 @@ export async function updateRemoteUserUID(params: DockerResolverParameters, merg
 		'build',
 		'-f', destDockerfile,
 		'-t', fixedImageName,
-		'--platform', platform,
+		...(platform ? ['--platform', platform] : []),
 		'--build-arg', `BASE_IMAGE=${imageName}`,
 		'--build-arg', `REMOTE_USER=${remoteUser}`,
 		'--build-arg', `NEW_UID=${await cliHost.getuid!()}`,

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -388,7 +388,7 @@ export async function getRemoteUserUIDUpdateDetails(params: DockerResolverParame
 		imageName: fixedImageName,
 		remoteUser,
 		imageUser,
-		platform: `${details.Os}/${details.Architecture}`
+		platform: [details.Os, details.Architecture, details.Variant].filter(Boolean).join('/')
 	};
 }
 

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -22,7 +22,7 @@ import { ContainerError } from '../spec-common/errors';
 // Environment variables must contain:
 //      - alpha-numeric values, or
 //      - the '_' character, and
-//      - a number cannot be the first character 
+//      - a number cannot be the first character
 export const getSafeId = (str: string) => str
 	.replace(/[^\w_]/g, '_')
 	.replace(/^[\d_]+/g, '_')
@@ -344,7 +344,7 @@ function getFeatureEnvVariables(f: Feature) {
 	const values = getFeatureValueObject(f);
 	const idSafe = getSafeId(f.id);
 	const variables = [];
-	
+
 	if(f.internalVersion !== '2')
 	{
 		if (values) {
@@ -365,7 +365,7 @@ function getFeatureEnvVariables(f: Feature) {
 			variables.push(`${f.buildArg}=${getFeatureMainValue(f)}`);
 		}
 		return variables;
-	}	
+	}
 }
 
 export async function getRemoteUserUIDUpdateDetails(params: DockerResolverParameters, mergedConfig: MergedDevContainerConfig, imageName: string, imageDetails: () => Promise<ImageDetails>, runArgsUser: string | undefined) {
@@ -388,6 +388,7 @@ export async function getRemoteUserUIDUpdateDetails(params: DockerResolverParame
 		imageName: fixedImageName,
 		remoteUser,
 		imageUser,
+		platform: `${details.Os}/${details.Architecture}`
 	};
 }
 
@@ -399,7 +400,7 @@ export async function updateRemoteUserUID(params: DockerResolverParameters, merg
 	if (!updateDetails) {
 		return imageName;
 	}
-	const { imageName: fixedImageName, remoteUser, imageUser } = updateDetails;
+	const { imageName: fixedImageName, remoteUser, imageUser, platform } = updateDetails;
 
 	const dockerfileName = 'updateUID.Dockerfile';
 	const srcDockerfile = path.join(common.extensionPath, 'scripts', dockerfileName);
@@ -415,6 +416,7 @@ export async function updateRemoteUserUID(params: DockerResolverParameters, merg
 		'build',
 		'-f', destDockerfile,
 		'-t', fixedImageName,
+		'--platform', platform,
 		'--build-arg', `BASE_IMAGE=${imageName}`,
 		'--build-arg', `REMOTE_USER=${remoteUser}`,
 		'--build-arg', `NEW_UID=${await cliHost.getuid!()}`,

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -163,12 +163,21 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		env: cliHost.env,
 		output: common.output,
 	}, dockerPath, dockerComposePath);
+	const platformInfo = (common.buildxPlatform?.split('/') || []).reduce((platformInfo, element, idx) => {
+		switch (idx) {
+			case 0: platformInfo.os = <NodeJS.Platform> element; break;
+			case 1: platformInfo.arch = <NodeJS.Architecture> element; break;
+			default: break;
+		}
+		return platformInfo;
+	}, { os: cliHost.platform, arch: cliHost.arch });
 	const buildKitVersion = options.useBuildKit === 'never' ? undefined : (await dockerBuildKitVersion({
 		cliHost,
 		dockerCLI: dockerPath,
 		dockerComposeCLI,
 		env: cliHost.env,
-		output
+		output,
+		platformInfo
 	}));
 	return {
 		common,
@@ -195,6 +204,7 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		buildxPush: common.buildxPush,
 		buildxOutput: common.buildxOutput,
 		buildxCacheTo: common.buildxCacheTo,
+		platformInfo
 	};
 }
 

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -601,7 +601,7 @@ async function doBuild({
 			throw new ContainerError({ description: '--push true cannot be used with --output.' });
 		}
 
-		const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output };
+		const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output, platformInfo: params.platformInfo };
 		await ensureNoDisallowedFeatures(buildParams, config, additionalFeatures, undefined);
 
 		// Support multiple use of `--image-name`
@@ -622,8 +622,8 @@ async function doBuild({
 			}
 		} else if ('dockerComposeFile' in config) {
 
-			if (buildxPlatform || buildxPush) {
-				throw new ContainerError({ description: '--platform or --push not supported.' });
+			if (buildxPush) {
+				throw new ContainerError({ description: '--push not supported.' });
 			}
 
 			if (buildxOutput) {
@@ -1011,7 +1011,8 @@ async function readConfiguration({
 			dockerCLI,
 			dockerComposeCLI,
 			env: cliHost.env,
-			output
+			output,
+			platformInfo: { os: cliHost.platform, arch: cliHost.arch }
 		};
 		const { container, idLabels } = await findContainerAndIdLabels(params, containerId, providedIdLabels, workspaceFolder, configPath?.fsPath);
 		if (container) {

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -41,6 +41,7 @@ import { featuresResolveDependenciesHandler, featuresResolveDependenciesOptions 
 import { getFeatureIdWithoutVersion } from '../spec-configuration/containerFeaturesOCI';
 import { featuresUpgradeHandler, featuresUpgradeOptions } from './upgradeCommand';
 import { readFeaturesConfig } from './featureUtils';
+import { mapNodeOSToGOOS, mapNodeArchitectureToGOARCH } from '../spec-configuration/containerCollectionsOCI';
 
 const defaultDefaultUserEnvProbe: UserEnvProbe = 'loginInteractiveShell';
 
@@ -1012,7 +1013,10 @@ async function readConfiguration({
 			dockerComposeCLI,
 			env: cliHost.env,
 			output,
-			platformInfo: { os: cliHost.platform, arch: cliHost.arch }
+			platformInfo: {
+				os: mapNodeOSToGOOS(cliHost.platform),
+				arch: mapNodeArchitectureToGOARCH(cliHost.arch),
+			}
 		};
 		const { container, idLabels } = await findContainerAndIdLabels(params, containerId, providedIdLabels, workspaceFolder, configPath?.fsPath);
 		if (container) {

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -623,8 +623,8 @@ async function doBuild({
 			}
 		} else if ('dockerComposeFile' in config) {
 
-			if (buildxPush) {
-				throw new ContainerError({ description: '--push not supported.' });
+			if (buildxPlatform || buildxPush) {
+				throw new ContainerError({ description: '--platform or --push not supported.' });
 			}
 
 			if (buildxOutput) {

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -26,7 +26,7 @@ const serviceLabel = 'com.docker.compose.service';
 export async function openDockerComposeDevContainer(params: DockerResolverParameters, workspace: Workspace, config: SubstitutedConfig<DevContainerFromDockerComposeConfig>, idLabels: string[], additionalFeatures: Record<string, string | boolean | Record<string, string | boolean>>): Promise<ResolverResult> {
 	const { common, dockerCLI, dockerComposeCLI } = params;
 	const { cliHost, env, output } = common;
-	const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output };
+	const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output, platformInfo: params.platformInfo };
 	return _openDockerComposeDevContainer(params, buildParams, workspace, config, getRemoteWorkspaceFolder(config.config), idLabels, additionalFeatures);
 }
 
@@ -150,7 +150,7 @@ export async function buildAndExtendDockerCompose(configWithRaw: SubstitutedConf
 	const { cliHost, env, output } = common;
 	const { config } = configWithRaw;
 
-	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI: dockerComposeCLIFunc, env, output };
+	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI: dockerComposeCLIFunc, env, output, platformInfo: params.platformInfo };
 	const composeConfig = await readDockerComposeConfig(cliParams, localComposeFiles, envFile);
 	const composeService = composeConfig.services[config.service];
 
@@ -406,7 +406,7 @@ async function startContainer(params: DockerResolverParameters, buildParams: Doc
 		// Note: As a fallback, persistedFolder is set to the build's tmpDir() directory
 		const additionalLabels = labels ? idLabels.concat(Object.keys(labels).map(key => `${key}=${labels[key]}`)) : idLabels;
 		const overrideFilePath = await writeFeaturesComposeOverrideFile(updatedImageName, currentImageName, mergedConfig, config, versionPrefix, imageDetails, service, additionalLabels, params.additionalMounts, persistedFolder, featuresStartOverrideFilePrefix, buildCLIHost, params, output);
-    
+
 		if (overrideFilePath) {
 			// Add file path to override file as parameter
 			composeGlobalArgs.push('-f', overrideFilePath);
@@ -714,7 +714,7 @@ export function dockerComposeCLIConfig(params: Omit<PartialExecParameters, 'cmd'
 
 /**
  * Convert mount command arguments to Docker Compose volume
- * @param mount 
+ * @param mount
  * @returns mount command representation for Docker compose
  */
 function convertMountToVolume(mount: Mount): string {
@@ -731,7 +731,7 @@ function convertMountToVolume(mount: Mount): string {
 
 /**
  * Convert mount command arguments to volume top-level element
- * @param mount 
+ * @param mount
  * @returns mount object representation as volumes top-level element
  */
 function convertMountToVolumeTopLevelElement(mount: Mount): string {

--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -349,7 +349,7 @@ export async function getImageBuildInfo(params: DockerResolverParameters | Docke
 		const cwdEnvFile = cliHost.path.join(cliHost.cwd, '.env');
 		const envFile = Array.isArray(config.dockerComposeFile) && config.dockerComposeFile.length === 0 && await cliHost.isFile(cwdEnvFile) ? cwdEnvFile : undefined;
 		const composeFiles = await getDockerComposeFilePaths(cliHost, config, cliHost.env, cliHost.cwd);
-		const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env: cliHost.env, output };
+		const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env: cliHost.env, output, platformInfo: params.platformInfo };
 
 		const composeConfig = await readDockerComposeConfig(buildParams, composeFiles, envFile);
 		const services = Object.keys(composeConfig.services || {});

--- a/src/spec-node/upgradeCommand.ts
+++ b/src/spec-node/upgradeCommand.ts
@@ -18,6 +18,7 @@ import { Lockfile, generateLockfile, getLockfilePath, writeLockfile } from '../s
 import { isLocalFile, readLocalFile, writeLocalFile } from '../spec-utils/pfs';
 import { readFeaturesConfig } from './featureUtils';
 import { DevContainerConfig } from '../spec-configuration/configuration';
+import { mapNodeArchitectureToGOARCH, mapNodeOSToGOOS } from '../spec-configuration/containerCollectionsOCI';
 
 export function featuresUpgradeOptions(y: Argv) {
 	return y
@@ -92,6 +93,10 @@ async function featuresUpgrade({
 			dockerComposeCLI,
 			env: cliHost.env,
 			output,
+			platformInfo: {
+				os: mapNodeOSToGOOS(cliHost.platform),
+				arch: mapNodeArchitectureToGOARCH(cliHost.arch),
+			}
 		};
 
 		const workspace = workspaceFromPath(cliHost.path, workspaceFolder);

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -25,7 +25,7 @@ import { Event } from '../spec-utils/event';
 import { Mount } from '../spec-configuration/containerFeaturesConfiguration';
 import { PackageConfiguration } from '../spec-utils/product';
 import { ImageMetadataEntry } from './imageMetadata';
-import { getImageIndexEntryForPlatform, getManifest, getRef, mapNodeOSToGOOS, mapNodeArchitectureToGOARCH } from '../spec-configuration/containerCollectionsOCI';
+import { getImageIndexEntryForPlatform, getManifest, getRef } from '../spec-configuration/containerCollectionsOCI';
 import { requestEnsureAuthenticated } from '../spec-configuration/httpOCIRegistry';
 import { configFileLabel, findDevContainer, hostFolderLabel } from './singleContainer';
 
@@ -244,7 +244,7 @@ export async function inspectDockerImage(params: DockerResolverParameters | Dock
 	}
 }
 
-export async function inspectImageInRegistry(output: Log, platformInfo: { arch: NodeJS.Architecture; os: NodeJS.Platform }, name: string): Promise<ImageDetails> {
+export async function inspectImageInRegistry(output: Log, platformInfo: PlatformInfo, name: string): Promise<ImageDetails> {
 	const resourceAndVersion = qualifyImageName(name);
 	const params = { output, env: process.env };
 	const ref = getRef(output, resourceAndVersion);
@@ -295,8 +295,8 @@ export async function inspectImageInRegistry(output: Log, platformInfo: { arch: 
 	return {
 		Id: targetDigest,
 		Config: obj.config,
-		Os: mapNodeOSToGOOS(platformInfo.os),
-		Architecture: mapNodeArchitectureToGOARCH(platformInfo.arch),
+		Os: platformInfo.os,
+		Architecture: platformInfo.arch,
 	};
 }
 

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -25,7 +25,7 @@ import { Event } from '../spec-utils/event';
 import { Mount } from '../spec-configuration/containerFeaturesConfiguration';
 import { PackageConfiguration } from '../spec-utils/product';
 import { ImageMetadataEntry } from './imageMetadata';
-import { getImageIndexEntryForPlatform, getManifest, getRef } from '../spec-configuration/containerCollectionsOCI';
+import { getImageIndexEntryForPlatform, getManifest, getRef, mapNodeOSToGOOS, mapNodeArchitectureToGOARCH } from '../spec-configuration/containerCollectionsOCI';
 import { requestEnsureAuthenticated } from '../spec-configuration/httpOCIRegistry';
 import { configFileLabel, findDevContainer, hostFolderLabel } from './singleContainer';
 
@@ -295,8 +295,8 @@ export async function inspectImageInRegistry(output: Log, platformInfo: { arch: 
 	return {
 		Id: targetDigest,
 		Config: obj.config,
-		Os: platformInfo.os,
-		Architecture: platformInfo.arch,
+		Os: mapNodeOSToGOOS(platformInfo.os),
+		Architecture: mapNodeArchitectureToGOARCH(platformInfo.arch),
 	};
 }
 

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -296,6 +296,7 @@ export async function inspectImageInRegistry(output: Log, platformInfo: Platform
 		Id: targetDigest,
 		Config: obj.config,
 		Os: platformInfo.os,
+		Variant: platformInfo.variant,
 		Architecture: platformInfo.arch,
 	};
 }

--- a/src/spec-shutdown/dockerUtils.ts
+++ b/src/spec-shutdown/dockerUtils.ts
@@ -117,6 +117,7 @@ export async function inspectContainers(params: DockerCLIParameters | PartialExe
 export interface ImageDetails {
 	Id: string;
 	Architecture: string;
+	Variant?: string;
 	Os: string;
 	Config: {
 		User: string;

--- a/src/spec-shutdown/dockerUtils.ts
+++ b/src/spec-shutdown/dockerUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CLIHost, runCommand, runCommandNoPty, ExecFunction, ExecParameters, Exec, PtyExecFunction, PtyExec, PtyExecParameters, plainExecAsPtyExec } from '../spec-common/commonUtils';
+import { CLIHost, runCommand, runCommandNoPty, ExecFunction, ExecParameters, Exec, PtyExecFunction, PtyExec, PtyExecParameters, plainExecAsPtyExec, PlatformInfo } from '../spec-common/commonUtils';
 import { toErrorText } from '../spec-common/errors';
 import * as ptyType from 'node-pty';
 import { Log, makeLog } from '../spec-utils/log';
@@ -51,6 +51,7 @@ export interface DockerCLIParameters {
 	dockerComposeCLI: () => Promise<DockerComposeCLI>;
 	env: NodeJS.ProcessEnv;
 	output: Log;
+	platformInfo: PlatformInfo;
 }
 
 export interface PartialExecParameters {
@@ -115,6 +116,8 @@ export async function inspectContainers(params: DockerCLIParameters | PartialExe
 
 export interface ImageDetails {
 	Id: string;
+	Architecture: string;
+	Os: string;
 	Config: {
 		User: string;
 		Env: string[] | null;

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -196,17 +196,20 @@ describe('Dev Containers CLI', function () {
 			assert.equal(success, false, 'expect non-successful call');
 		});
 
-		it('file ${os.tmpdir()}/output.tar should exist when using --output type=oci,dest=${os.tmpdir()/output.tar', async () => {
+		it.only('file ${os.tmpdir()}/output.tar should exist when using --output type=oci,dest=${os.tmpdir()/output.tar', async () => {
 			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
 			const outputPath = `${os.tmpdir()}/output.tar`;
-			await shellExec('docker buildx create --name ocitest');
-			await shellExec('docker buildx use ocitest');
-			const res = await shellExec(`${cli} build --workspace-folder ${testFolder} --output 'type=oci,dest=${outputPath}'`);
-			await shellExec('docker buildx use default');
-			await shellExec('docker buildx rm ocitest');
-			const response = JSON.parse(res.stdout);
-			assert.equal(response.outcome, 'success');
-			assert.equal(fs.existsSync(outputPath), true);
+			try {
+				await shellExec('docker buildx create --name ocitest');
+				await shellExec('docker buildx use ocitest');
+				const res = await shellExec(`${cli} build --workspace-folder ${testFolder} --output 'type=oci,dest=${outputPath}'`);
+				const response = JSON.parse(res.stdout);
+				assert.equal(response.outcome, 'success');
+				assert.equal(fs.existsSync(outputPath), true);
+			} finally {
+				await shellExec('docker buildx use default');
+				await shellExec('docker buildx rm ocitest');
+			}
 		});
 
 		it(`should execute successfully and export buildx cache with container builder`, async () => {

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -196,7 +196,7 @@ describe('Dev Containers CLI', function () {
 			assert.equal(success, false, 'expect non-successful call');
 		});
 
-		it.only('file ${os.tmpdir()}/output.tar should exist when using --output type=oci,dest=${os.tmpdir()/output.tar', async () => {
+		it('file ${os.tmpdir()}/output.tar should exist when using --output type=oci,dest=${os.tmpdir()/output.tar', async () => {
 			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
 			const outputPath = `${os.tmpdir()}/output.tar`;
 			try {

--- a/src/test/configs/updateUIDamd64-platform-option/.devcontainer.json
+++ b/src/test/configs/updateUIDamd64-platform-option/.devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile",
+		"options": [
+			"--platform",
+			"linux/amd64"
+		]
+	},
+	"remoteUser": "foo",
+	"runArgs": [
+		"--platform",
+		"linux/amd64"
+	]
+}

--- a/src/test/configs/updateUIDamd64-platform-option/Dockerfile
+++ b/src/test/configs/updateUIDamd64-platform-option/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:latest
+
+RUN addgroup --gid 4321 foo
+RUN adduser --uid 1234 --gid 4321 foo

--- a/src/test/configs/updateUIDamd64/.devcontainer.json
+++ b/src/test/configs/updateUIDamd64/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"remoteUser": "foo"
+}

--- a/src/test/configs/updateUIDamd64/Dockerfile
+++ b/src/test/configs/updateUIDamd64/Dockerfile
@@ -1,0 +1,4 @@
+FROM --platform=linux/amd64 debian:latest
+
+RUN addgroup --gid 4321 foo
+RUN adduser --uid 1234 --gid 4321 foo

--- a/src/test/configs/updateUIDarm64-platform-option/.devcontainer.json
+++ b/src/test/configs/updateUIDarm64-platform-option/.devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile",
+		"options": [
+			"--platform",
+			"linux/arm64"
+		]
+	},
+	"remoteUser": "foo",
+	"runArgs": [
+		"--platform",
+		"linux/arm64"
+	]
+}

--- a/src/test/configs/updateUIDarm64-platform-option/Dockerfile
+++ b/src/test/configs/updateUIDarm64-platform-option/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:latest
+
+RUN addgroup --gid 4321 foo
+RUN adduser --uid 1234 --gid 4321 foo

--- a/src/test/configs/updateUIDarm64/.devcontainer.json
+++ b/src/test/configs/updateUIDarm64/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"remoteUser": "foo"
+}

--- a/src/test/configs/updateUIDarm64/Dockerfile
+++ b/src/test/configs/updateUIDarm64/Dockerfile
@@ -1,0 +1,4 @@
+FROM --platform=linux/arm64 debian:latest
+
+RUN addgroup --gid 4321 foo
+RUN adduser --uid 1234 --gid 4321 foo

--- a/src/test/configs/updateUIDarm64v8-platform-option/.devcontainer.json
+++ b/src/test/configs/updateUIDarm64v8-platform-option/.devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile",
+		"options": [
+			"--platform",
+			"linux/arm64/v8"
+		]
+	},
+	"remoteUser": "foo",
+	"runArgs": [
+		"--platform",
+		"linux/arm64/v8"
+	]
+}

--- a/src/test/configs/updateUIDarm64v8-platform-option/Dockerfile
+++ b/src/test/configs/updateUIDarm64v8-platform-option/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:latest
+
+RUN addgroup --gid 4321 foo
+RUN adduser --uid 1234 --gid 4321 foo

--- a/src/test/configs/updateUIDarm64v8/.devcontainer.json
+++ b/src/test/configs/updateUIDarm64v8/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"remoteUser": "foo"
+}

--- a/src/test/configs/updateUIDarm64v8/Dockerfile
+++ b/src/test/configs/updateUIDarm64v8/Dockerfile
@@ -1,0 +1,4 @@
+FROM --platform=linux/arm64/v8 debian:latest
+
+RUN addgroup --gid 4321 foo
+RUN adduser --uid 1234 --gid 4321 foo

--- a/src/test/dockerUtils.test.ts
+++ b/src/test/dockerUtils.test.ts
@@ -14,7 +14,7 @@ describe('Docker utils', function () {
 
 	it('inspect image in docker.io', async () => {
 		const imageName = 'docker.io/library/ubuntu:latest';
-		const config = await inspectImageInRegistry(output, { arch: 'x64', os: 'linux' }, imageName);
+		const config = await inspectImageInRegistry(output, { arch: 'amd64', os: 'linux' }, imageName);
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);
@@ -22,7 +22,7 @@ describe('Docker utils', function () {
 
 	it('inspect image in mcr.microsoft.com', async () => {
 		const imageName = 'mcr.microsoft.com/devcontainers/rust:1';
-		const config = await inspectImageInRegistry(output, { arch: 'x64', os: 'linux' }, imageName);
+		const config = await inspectImageInRegistry(output, { arch: 'amd64', os: 'linux' }, imageName);
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);
@@ -34,7 +34,7 @@ describe('Docker utils', function () {
 
 	it('inspect image in ghcr.io', async () => {
 		const imageName = 'ghcr.io/chrmarti/cache-from-test/images/test-cache:latest';
-		const config = await inspectImageInRegistry(output, { arch: 'x64', os: 'linux' }, imageName);
+		const config = await inspectImageInRegistry(output, { arch: 'amd64', os: 'linux' }, imageName);
 		assert.ok(config);
 		assert.ok(config.Id);
 		assert.ok(config.Config.Cmd);

--- a/src/test/dockerfileUtils.test.ts
+++ b/src/test/dockerfileUtils.test.ts
@@ -161,7 +161,9 @@ FROM ubuntu:latest as dev
                 },
                 Entrypoint: null,
                 Cmd: null
-            }
+            },
+						Os: 'linux',
+						Architecture: 'amd64'
         };
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
@@ -187,7 +189,9 @@ USER dockerfileUserB
                 Labels: null,
                 Entrypoint: null,
                 Cmd: null
-            }
+            },
+						Os: 'linux',
+						Architecture: 'amd64'
         };
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
@@ -282,7 +286,7 @@ FROM \${cloud:+mcr.microsoft.com/}azure-cli:latest
             const image = findBaseImage(extracted, {}, undefined);
             assert.strictEqual(image, 'azure-cli:latest');
         });
-        
+
         it('Negative variable expression with value specified', async () => {
             const dockerfile = `
 ARG cloud
@@ -295,7 +299,7 @@ FROM \${cloud:-mcr.microsoft.com/}azure-cli:latest
             }, undefined);
             assert.strictEqual(image, 'ghcr.io/azure-cli:latest');
         });
-        
+
         it('Negative variable expression with no value specified', async () => {
             const dockerfile = `
 ARG cloud
@@ -620,7 +624,7 @@ user D
         const stage = extracted.stages[0];
         assert.strictEqual(stage.from.image, 'E');
         assert.strictEqual(stage.instructions.length, 3);
-        
+
         const env = stage.instructions[0];
         assert.strictEqual(env.instruction, 'ENV');
         assert.strictEqual(env.name, 'A');

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -159,6 +159,7 @@ export async function createCLIParams(hostPath: string) {
 		dockerComposeCLI,
 		env: {},
 		output,
+		platformInfo: {os: cliHost.platform, arch: cliHost.arch}
 	};
 	return cliParams;
 }

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -9,6 +9,7 @@ import { SubstituteConfig } from '../spec-node/utils';
 import { LogLevel, createPlainLog, makeLog, nullLog } from '../spec-utils/log';
 import { dockerComposeCLIConfig } from '../spec-node/dockerCompose';
 import { DockerCLIParameters } from '../spec-shutdown/dockerUtils';
+import { mapNodeArchitectureToGOARCH, mapNodeOSToGOOS } from '../spec-configuration/containerCollectionsOCI';
 
 export interface BuildKitOption {
     text: string;
@@ -159,7 +160,10 @@ export async function createCLIParams(hostPath: string) {
 		dockerComposeCLI,
 		env: {},
 		output,
-		platformInfo: {os: cliHost.platform, arch: cliHost.arch}
-	};
+		platformInfo: {
+			os: mapNodeOSToGOOS(cliHost.platform),
+			arch: mapNodeArchitectureToGOARCH(cliHost.arch),
+		}
+};
 	return cliParams;
 }

--- a/src/test/updateUID.test.ts
+++ b/src/test/updateUID.test.ts
@@ -46,5 +46,25 @@ const pkg = require('../../package.json');
 			assert.strictEqual(gid.stdout.trim(), String(4321));
 			await devContainerDown({ containerId });
 		});
+
+		it('should update UID and GID when the platform is linux/amd64', async () => {
+			const testFolder = `${__dirname}/configs/updateUIDamd64`;
+			const containerId = (await devContainerUp(cli, testFolder)).containerId;
+			const uid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -u`);
+			assert.strictEqual(uid.stdout.trim(), String(process.getuid!()));
+			const gid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -g`);
+			assert.strictEqual(gid.stdout.trim(), String(process.getgid!()));
+			await devContainerDown({ containerId });
+		});
+
+		it('should update UID and GID when the platform is linux/arm64', async () => {
+			const testFolder = `${__dirname}/configs/updateUIDarm64`;
+			const containerId = (await devContainerUp(cli, testFolder)).containerId;
+			const uid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -u`);
+			assert.strictEqual(uid.stdout.trim(), String(process.getuid!()));
+			const gid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -g`);
+			assert.strictEqual(gid.stdout.trim(), String(process.getgid!()));
+			await devContainerDown({ containerId });
+		});
 	});
 });

--- a/src/test/updateUID.test.ts
+++ b/src/test/updateUID.test.ts
@@ -57,8 +57,48 @@ const pkg = require('../../package.json');
 			await devContainerDown({ containerId });
 		});
 
+		it('should update UID and GID when --platform is linux/amd64', async () => {
+			const testFolder = `${__dirname}/configs/updateUIDamd64-platform-option`;
+			const containerId = (await devContainerUp(cli, testFolder)).containerId;
+			const uid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -u`);
+			assert.strictEqual(uid.stdout.trim(), String(process.getuid!()));
+			const gid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -g`);
+			assert.strictEqual(gid.stdout.trim(), String(process.getgid!()));
+			await devContainerDown({ containerId });
+		});
+
 		it('should update UID and GID when the platform is linux/arm64', async () => {
 			const testFolder = `${__dirname}/configs/updateUIDarm64`;
+			const containerId = (await devContainerUp(cli, testFolder)).containerId;
+			const uid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -u`);
+			assert.strictEqual(uid.stdout.trim(), String(process.getuid!()));
+			const gid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -g`);
+			assert.strictEqual(gid.stdout.trim(), String(process.getgid!()));
+			await devContainerDown({ containerId });
+		});
+
+		it('should update UID and GID when --platform is linux/arm64', async () => {
+			const testFolder = `${__dirname}/configs/updateUIDarm64-platform-option`;
+			const containerId = (await devContainerUp(cli, testFolder)).containerId;
+			const uid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -u`);
+			assert.strictEqual(uid.stdout.trim(), String(process.getuid!()));
+			const gid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -g`);
+			assert.strictEqual(gid.stdout.trim(), String(process.getgid!()));
+			await devContainerDown({ containerId });
+		});
+
+		it('should update UID and GID when the platform is linux/arm64/v8', async () => {
+			const testFolder = `${__dirname}/configs/updateUIDarm64v8`;
+			const containerId = (await devContainerUp(cli, testFolder)).containerId;
+			const uid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -u`);
+			assert.strictEqual(uid.stdout.trim(), String(process.getuid!()));
+			const gid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -g`);
+			assert.strictEqual(gid.stdout.trim(), String(process.getgid!()));
+			await devContainerDown({ containerId });
+		});
+
+		it('should update UID and GID when --platform is linux/arm64/v8', async () => {
+			const testFolder = `${__dirname}/configs/updateUIDarm64v8-platform-option`;
 			const containerId = (await devContainerUp(cli, testFolder)).containerId;
 			const uid = await shellExec(`${cli} exec --workspace-folder ${testFolder} id -u`);
 			assert.strictEqual(uid.stdout.trim(), String(process.getuid!()));


### PR DESCRIPTION
If the user changes the platform to a non-native arch as suggested [here](https://github.com/microsoft/vscode-remote-release/issues/7779#issuecomment-1375375743), the devcontainers CLI fails to launch due to attempting to load the wrong platform during the "updateUID" image build.

Opening as a draft PR to show the behavior. Will follow up with a fix once I figure out where it should go.