### PR TITLE
Remove dependency on ip package

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License. See License.txt in the project root for license information.
 ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}
 
 RUN mkdir -p /workspaces && chown node:node /workspaces
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			"VARIANT": "18-bullseye"
+			"VARIANT": "18-bookworm"
 		}
 	},
 	"mounts": [

--- a/example-usage/workspace/.devcontainer/Dockerfile
+++ b/example-usage/workspace/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
+FROM mcr.microsoft.com/devcontainers/base:1-bookworm

--- a/example-usage/workspace/.devcontainer/devcontainer.json
+++ b/example-usage/workspace/.devcontainer/devcontainer.json
@@ -35,7 +35,7 @@
 			"nodeGypDependencies": false
 		},
 		"ghcr.io/devcontainers/features/desktop-lite:1": { },
-		"ghcr.io/devcontainers/features/docker-in-docker:1": { },
+		"ghcr.io/devcontainers/features/docker-in-docker:2": { },
 		// Optional - For tools that require SSH
 		"ghcr.io/devcontainers/features/sshd:1": { }
 	},

--- a/src/test/configs/compose-Dockerfile-with-features/.devcontainer/Dockerfile
+++ b/src/test/configs/compose-Dockerfile-with-features/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
 ARG VARIANT=16-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-${VARIANT}
 
 # Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)
 ARG MONGO_TOOLS_VERSION=5.0

--- a/src/test/configs/compose-Dockerfile-with-features/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-Dockerfile-with-features/.devcontainer/devcontainer.json
@@ -3,13 +3,17 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint",
-		"mongodb.mongodb-vscode"
-	],
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"mongodb.mongodb-vscode"
+			]
+		}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [3000, 27017],
 	// Use 'postCreateCommand' to run commands after the container is created.
@@ -17,7 +21,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"features": {
-		"docker-in-docker": "latest",
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}

--- a/src/test/configs/compose-Dockerfile-with-features/.devcontainer/docker-compose.yml
+++ b/src/test/configs/compose-Dockerfile-with-features/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         # Update 'VARIANT' to pick an LTS version of Node.js: 18, 16, 14.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 16-bullseye
+        VARIANT: 18-bookworm
     volumes:
       - ..:/workspace:cached
 

--- a/src/test/configs/compose-Dockerfile-with-target/.devcontainer/Dockerfile
+++ b/src/test/configs/compose-Dockerfile-with-target/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ ARG VARIANT=16-bullseye
 FROM alpine as false-start 
 
 
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT} as desired-image
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-${VARIANT} as desired-image
 
 # Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)
 ARG MONGO_TOOLS_VERSION=5.0

--- a/src/test/configs/compose-Dockerfile-with-target/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-Dockerfile-with-target/.devcontainer/devcontainer.json
@@ -3,13 +3,17 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint",
-		"mongodb.mongodb-vscode"
-	],
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"mongodb.mongodb-vscode"
+			]
+		}
+	},
 	"postCreateCommand": "touch /tmp/postCreateCommand.testmarker",
 	"postStartCommand": "touch /tmp/postStartCommand.testmarker",
 	"postAttachCommand": "touch /tmp/postAttachCommand.testmarker",
@@ -20,7 +24,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"features": {
-		"docker-in-docker": "latest",
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}

--- a/src/test/configs/compose-Dockerfile-with-target/.devcontainer/docker-compose.yml
+++ b/src/test/configs/compose-Dockerfile-with-target/.devcontainer/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         # Update 'VARIANT' to pick an LTS version of Node.js: 18, 16, 14.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 16-bullseye
+        VARIANT: 18-bookworm
     volumes:
       - ..:/workspace:cached
 

--- a/src/test/configs/compose-image-with-features/.devcontainer/devcontainer.json
+++ b/src/test/configs/compose-image-with-features/.devcontainer/devcontainer.json
@@ -3,13 +3,17 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"dbaeumer.vscode-eslint",
-		"mongodb.mongodb-vscode"
-	],
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"mongodb.mongodb-vscode"
+			]
+		}
+	},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [3000, 27017],
 	// Use 'postCreateCommand' to run commands after the container is created.
@@ -17,7 +21,7 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
 	"features": {
-		"docker-in-docker": "latest",
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}

--- a/src/test/configs/compose-image-with-features/.devcontainer/docker-compose.yml
+++ b/src/test/configs/compose-image-with-features/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    image: mcr.microsoft.com/vscode/devcontainers/javascript-node:0-16-bullseye
+    image: mcr.microsoft.com/devcontainers/javascript-node:1-18-bookworm
     volumes:
       - ..:/workspace:cached
 

--- a/src/test/configs/dockerfile-with-features/.devcontainer.json
+++ b/src/test/configs/dockerfile-with-features/.devcontainer.json
@@ -2,7 +2,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			"VARIANT": "16-bullseye"
+			"VARIANT": "18-bookworm"
 		}
 	},
 	"features": {

--- a/src/test/configs/dockerfile-with-features/Dockerfile
+++ b/src/test/configs/dockerfile-with-features/Dockerfile
@@ -1,4 +1,4 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License. See License.txt in the project root for license information.
 ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}

--- a/src/test/configs/dockerfile-with-syntax/.devcontainer.json
+++ b/src/test/configs/dockerfile-with-syntax/.devcontainer.json
@@ -2,11 +2,11 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			"VARIANT": "16-bullseye"
+			"VARIANT": "18-bookworm"
 		}
 	},
 	"features": {
-		"docker-in-docker": "latest",
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}

--- a/src/test/configs/dockerfile-with-syntax/Dockerfile
+++ b/src/test/configs/dockerfile-with-syntax/Dockerfile
@@ -2,4 +2,4 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License. See License.txt in the project root for license information.
 ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}

--- a/src/test/configs/dockerfile-with-target/.devcontainer.json
+++ b/src/test/configs/dockerfile-with-target/.devcontainer.json
@@ -3,7 +3,7 @@
 		"dockerfile": "Dockerfile",
 		"target": "desired-image",
 		"args": { 
-			"VARIANT": "16-bullseye"
+			"VARIANT": "18-bookworm"
 		},
 		"options": [ "--label", "test_build_options=success" ]
 	},
@@ -11,7 +11,7 @@
 	"postStartCommand": "touch /tmp/postStartCommand.testmarker",
 	"postAttachCommand": "touch /tmp/postAttachCommand.testmarker",
 	"features": {
-		"docker-in-docker": "latest",
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"codspace/myfeatures/helloworld": {
 			"greeting": "howdy"
 		}

--- a/src/test/configs/dockerfile-with-target/Dockerfile
+++ b/src/test/configs/dockerfile-with-target/Dockerfile
@@ -5,7 +5,7 @@ ARG VARIANT="16-bullseye"
 # Target should skip this layer
 FROM alpine as false-start 
 
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT} as desired-image
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT} as desired-image
 
 RUN echo "||test-content||" | sudo tee /var/test-marker
 

--- a/src/test/configs/image-with-features/.devcontainer.json
+++ b/src/test/configs/image-with-features/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-16",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/feature-starter/hello:1": {

--- a/src/test/container-features/configs/dockerfile-with-v2-oci-features/.devcontainer.json
+++ b/src/test/container-features/configs/dockerfile-with-v2-oci-features/.devcontainer.json
@@ -2,7 +2,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"VARIANT": "16-bullseye"
+			"VARIANT": "18-bookworm"
 		}
 	},
 	"features": {

--- a/src/test/container-features/configs/dockerfile-with-v2-oci-features/Dockerfile
+++ b/src/test/container-features/configs/dockerfile-with-v2-oci-features/Dockerfile
@@ -1,4 +1,4 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License. See License.txt in the project root for license information.
 ARG VARIANT="16-bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}

--- a/src/test/container-features/configs/image-with-v2-tarball/.devcontainer.json
+++ b/src/test/container-features/configs/image-with-v2-tarball/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:0-16",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bookworm",
 	"features": {
 		"https://github.com/codspace/features/releases/download/tarball02/devcontainer-feature-docker-in-docker.tgz": {}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,15 +1957,13 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-ip@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
-  integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
-
-ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
+ip-address@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
+  dependencies:
+    jsbn "1.1.0"
+    sprintf-js "^1.1.3"
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -2202,6 +2200,11 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -2663,12 +2666,11 @@ pac-proxy-agent@^7.0.1:
     socks-proxy-agent "^8.0.2"
 
 pac-resolver@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-7.0.0.tgz#79376f1ca26baf245b96b34c339d79bff25e900c"
-  integrity sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-7.0.1.tgz#54675558ea368b64d210fd9c92a640b5f3b8abb6"
+  integrity sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==
   dependencies:
     degenerator "^5.0.0"
-    ip "^1.1.8"
     netmask "^2.0.2"
 
 parent-module@^1.0.0:
@@ -3165,11 +3167,11 @@ socks-proxy-agent@^8.0.2:
     socks "^2.7.1"
 
 socks@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
-  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.3.tgz#7d8a75d7ce845c0a96f710917174dba0d543a785"
+  integrity sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==
   dependencies:
-    ip "^2.0.0"
+    ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
 source-map@~0.6.1:
@@ -3209,6 +3211,11 @@ split@^1.0.1:
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
+
+sprintf-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
- Removing dependency on `ip` package to address https://github.com/advisories/GHSA-78xj-cgh5-2h22.
- Fixing tests to make `docker-in-docker` work again.