### PR TITLE
Fix and refactor the generate-docs subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/*.test.ts",
 		"test-matrix": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/*.test.ts",
-		"test-container-features-cli": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/featuresCLICommands.test.ts",
 		"test-container-templates": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-templates/*.test.ts"
 	},
 	"files": [

--- a/src/spec-node/collectionCommonUtils/generateDocs.ts
+++ b/src/spec-node/collectionCommonUtils/generateDocs.ts
@@ -1,0 +1,38 @@
+import { Argv } from 'yargs';
+import { CLIHost } from '../../spec-common/cliHost';
+import { Log } from '../../spec-utils/log';
+
+const targetPositionalDescription = (collectionType: GenerateDocsCollectionType) => `
+Generate docs of ${collectionType}s at provided [target] (default is cwd), where [target] is either:
+   1. A path to the src folder of the collection with [1..n] ${collectionType}s.
+   2. A path to a single ${collectionType} that contains a devcontainer-${collectionType}.json.
+`;
+
+export function GenerateDocsOptions(y: Argv, collectionType: GenerateDocsCollectionType) {
+	return y
+		.options({
+			'registry': { type: 'string', alias: 'r', default: 'ghcr.io', description: 'Name of the OCI registry.', hidden: collectionType !== 'feature' },
+			'namespace': { type: 'string', alias: 'n', require: collectionType === 'feature', description: `Unique indentifier for the collection of features. Example: <owner>/<repo>`, hidden: collectionType !== 'feature' },
+			'github-owner': { type: 'string', default: '', description: `GitHub owner for docs.` },
+			'github-repo': { type: 'string', default: '', description: `GitHub repo for docs.` },
+			'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' }
+		})
+		.positional('target', { type: 'string', default: '.', description: targetPositionalDescription(collectionType) })
+		.check(_argv => {
+			return true;
+		});
+}
+
+export type GenerateDocsCollectionType = 'feature' | 'template';
+
+export interface GenerateDocsCommandInput {
+	cliHost: CLIHost;
+	targetFolder: string;
+	registry?: string;
+	namespace?: string;
+	gitHubOwner: string;
+	gitHubRepo: string;
+	output: Log;
+	disposables: (() => Promise<unknown> | undefined)[];
+	isSingle?: boolean; // Generating docs for a collection of many features/templates. Should autodetect.
+}

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -80,12 +80,12 @@ const mountRegex = /^type=(bind|volume),source=([^,]+),target=([^,]+)(?:,externa
 		y.command('publish <target>', 'Package and publish Features', featuresPublishOptions, featuresPublishHandler);
 		y.command('info <mode> <feature>', 'Fetch metadata for a published Feature', featuresInfoOptions, featuresInfoHandler);
 		y.command('resolve-dependencies', 'Read and resolve dependency graph from a configuration', featuresResolveDependenciesOptions, featuresResolveDependenciesHandler);
-		y.command('generate-docs', 'Generate documentation', featuresGenerateDocsOptions, featuresGenerateDocsHandler);
+		y.command('generate-docs <target>', 'Generate documentation', featuresGenerateDocsOptions, featuresGenerateDocsHandler);
 	});
 	y.command('templates', 'Templates commands', (y: Argv) => {
 		y.command('apply', 'Apply a template to the project', templateApplyOptions, templateApplyHandler);
 		y.command('publish <target>', 'Package and publish templates', templatesPublishOptions, templatesPublishHandler);
-		y.command('generate-docs', 'Generate documentation', templatesGenerateDocsOptions, templatesGenerateDocsHandler);
+		y.command('generate-docs <target>', 'Generate documentation', templatesGenerateDocsOptions, templatesGenerateDocsHandler);
 	});
 	y.command(restArgs ? ['exec', '*'] : ['exec <cmd> [args..]'], 'Execute a command on a running dev container', execOptions, execHandler);
 	y.epilog(`devcontainer@${version} ${packageFolder}`);

--- a/src/test/container-templates/templatesCLICommands.test.ts
+++ b/src/test/container-templates/templatesCLICommands.test.ts
@@ -8,7 +8,7 @@ import { Template } from '../../spec-configuration/containerTemplatesConfigurati
 import { PackageCommandInput } from '../../spec-node/collectionCommonUtils/package';
 import { getCLIHost } from '../../spec-common/cliHost';
 import { loadNativeModule } from '../../spec-common/commonUtils';
-import { generateTemplatesDocumentation } from '../../spec-node/collectionCommonUtils/generateDocsCommandImpl';
+import { generateDocumentation } from '../../spec-node/collectionCommonUtils/generateDocsCommandImpl';
 
 export const output = makeLog(createPlainLog(text => process.stderr.write(text), () => LogLevel.Trace));
 
@@ -172,17 +172,29 @@ describe('tests packageTemplates()', async function () {
 	});
 });
 
-describe('tests generateTemplateDocumentation()', async function () {
+describe('tests generateTemplateDocumentation(isSingle = false)', async function () {
 	this.timeout('120s');
 
+	const cwd = process.cwd();
+	const cliHost = await getCLIHost(cwd, loadNativeModule, true);
 	const projectFolder = `${__dirname}/example-templates-sets/simple/src`;
 
 	after('clean', async () => {
-		await shellExec(`rm ${projectFolder}/**/README.md`);
+		await shellExec(`rm ${projectFolder}/**/README.md || true`);
 	});
 
-	it('tests generate-docs', async function () {
-		await generateTemplatesDocumentation(projectFolder, 'devcontainers', 'cli', output);
+	it('should generate docs for the templates collection', async function () {
+		await shellExec(`rm ${projectFolder}/**/README.md || true`);
+
+		await generateDocumentation({
+			cliHost: cliHost,
+			targetFolder: projectFolder,
+			gitHubOwner: 'devcontainers',
+			gitHubRepo: 'cli',
+			output: output,
+			isSingle: false,
+			disposables: [],
+		}, 'template');
 
 		const alpineDocsExists = await isLocalFile(`${projectFolder}/alpine/README.md`);
 		assert.isTrue(alpineDocsExists);
@@ -195,5 +207,34 @@ describe('tests generateTemplateDocumentation()', async function () {
 
 		const invalidDocsExists = await isLocalFile(`${projectFolder}/not-a-template/README.md`);
 		assert.isFalse(invalidDocsExists);
+	});
+});
+
+describe('tests generateTemplateDocumentation(isSingle = true)', async function () {
+	this.timeout('120s');
+
+	const cwd = process.cwd();
+	const cliHost = await getCLIHost(cwd, loadNativeModule, true);
+	const projectFolder = `${__dirname}/example-templates-sets/simple/src/alpine`;
+
+	after('clean', async () => {
+		await shellExec(`rm ${projectFolder}/README.md || true`);
+	});
+
+	it('should generate docs for the template', async function () {
+		await shellExec(`rm ${projectFolder}/README.md || true`);
+
+		await generateDocumentation({
+			cliHost: cliHost,
+			targetFolder: projectFolder,
+			gitHubOwner: 'devcontainers',
+			gitHubRepo: 'cli',
+			output: output,
+			isSingle: true,
+			disposables: [],
+		}, 'template');
+
+		const alpineDocsExists = await isLocalFile(`${projectFolder}/README.md`);
+		assert.isTrue(alpineDocsExists);
 	});
 });


### PR DESCRIPTION
Related to https://github.com/devcontainers/cli/pull/759

Sorry it should not be the `project-folder`, but the `src` folder directly, for example:

should be `./src/test/container-templates/example-templates-sets/simple/src` not `./src/test/container-templates/example-templates-sets/simple`

So I rename it in order to avoid the confusing.