### PR TITLE
Disable cache on feature build when `--build-no-cache` is passed

### DIFF
--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -82,7 +82,7 @@ export async function extendImage(params: DockerResolverParameters, config: Subs
 				args.push('--load'); // (short for --output=docker, i.e. load into normal 'docker images' collection)
 			}
 		}
-		if (params.buildxCacheTo) {
+		if (params.buildxCacheTo && !params.buildNoCache) {
 			args.push('--cache-to', params.buildxCacheTo);
 		}
 
@@ -94,6 +94,9 @@ export async function extendImage(params: DockerResolverParameters, config: Subs
 		args.push(
 			'build',
 		);
+	}
+	if (params.buildNoCache) {
+		args.push('--no-cache');
 	}
 	for (const buildArg in featureBuildInfo.buildArgs) {
 		args.push('--build-arg', `${buildArg}=${featureBuildInfo.buildArgs[buildArg]}`);

--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -82,7 +82,7 @@ export async function extendImage(params: DockerResolverParameters, config: Subs
 				args.push('--load'); // (short for --output=docker, i.e. load into normal 'docker images' collection)
 			}
 		}
-		if (params.buildxCacheTo && !params.buildNoCache) {
+		if (params.buildxCacheTo) {
 			args.push('--cache-to', params.buildxCacheTo);
 		}
 

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -64,7 +64,7 @@ describe('Dev Containers CLI', function () {
 			});
 		});
 
-		it.only('should not use docker cache for features when `--no-cache` flag is passed', async () => {
+		it('should not use docker cache for features when `--no-cache` flag is passed', async () => {
 			// Arrange
 			const testFolder = `${__dirname}/configs/image-with-features`;
 			const devContainerJson = `${testFolder}/.devcontainer.json`;

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -78,9 +78,9 @@ describe('Dev Containers CLI', function () {
 			const buildWithoutCacheCommand = `${commandBase} --image-name ${nonCachedImageName} --no-cache`;
 
 			// Act
-			await shellExec(buildCommand); // initial run of command
-			await shellExec(cachedBuildCommand); // rerun command using cache
-			await shellExec(buildWithoutCacheCommand); // rerun command without cache
+			await shellExec(buildCommand);
+			await shellExec(cachedBuildCommand);
+			await shellExec(buildWithoutCacheCommand);
 
 			// Assert
 			const originalImageInspectCommandResult = await shellExec(`docker inspect ${originalImageName}`);
@@ -95,8 +95,8 @@ describe('Dev Containers CLI', function () {
 			const cachedImageLayers: string[] = cachedImageDetails[0].RootFS.Layers;
 			const nonCachedImageLayers: string[] = noCacheImageDetails[0].RootFS.Layers;
 
-			assert.deepEqual(originalImageLayers, cachedImageLayers);
-			assert.notDeepEqual(cachedImageLayers, nonCachedImageLayers);
+			assert.deepEqual(originalImageLayers, cachedImageLayers, 'because they were built csequentially and should have used caching');
+			assert.notDeepEqual(cachedImageLayers, nonCachedImageLayers, 'because we passed the --no-cache argument disabling caching');
 		});
 
 		it('should fail with "not found" error when config is not found', async () => {


### PR DESCRIPTION
# Changes
Add `--no-cache` arg to the docker build command that extends the base image with the feature images when `--build-no-cache` is passed.

# Context
The build will always use a cached feature image if it has one. This was making it impossible to replicate a problem in our CI process caused by [this issue](https://github.com/Azure/azure-cli/issues/28676). Our CI pipeline was failing to install the Azure CLI, but building locally worked fine. The CI pipeline uses GitHub actions, so no cache of the build was available, however, I had cached versions of the image locally and passing the `--build-no-cache` continued to use the cache. I had to remove all the images via `docker images -q "vsc-$MY_IMAGE*" | xargs docker rmi -f` order to get a build representative of my CI environment working locally.

Closes #508 