### PR TITLE
Stop races docker-compose.devcontainer.containerFeatures file

### DIFF
--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -19,6 +19,7 @@ import { Mount, parseMount } from '../spec-configuration/containerFeaturesConfig
 import path from 'path';
 import { getDevcontainerMetadata, getImageBuildInfoFromDockerfile, getImageBuildInfoFromImage, getImageMetadataFromContainer, ImageBuildInfo, lifecycleCommandOriginMapFromMetadata, mergeConfiguration, MergedDevContainerConfig } from './imageMetadata';
 import { ensureDockerfileHasFinalStageName } from './dockerfileUtils';
+import { randomUUID } from 'crypto';
 
 const projectLabel = 'com.docker.compose.project';
 const serviceLabel = 'com.docker.compose.service';
@@ -483,7 +484,7 @@ async function writeFeaturesComposeOverrideFile(
 	if (overrideFileHasContents) {
 		output.write(`Docker Compose override file for creating container:\n${composeOverrideContent}`);
 
-		const fileName = `${overrideFilePrefix}-${Date.now()}.yml`;
+		const fileName = `${overrideFilePrefix}-${Date.now()}-${randomUUID()}.yml`;
 		const composeFolder = buildCLIHost.path.join(overrideFilePath, 'docker-compose');
 		const composeOverrideFile = buildCLIHost.path.join(composeFolder, fileName);
 		output.write(`Writing ${fileName} to ${composeFolder}`);


### PR DESCRIPTION
This commit adds a UUID to the filename for `docker-compose.devcontainer.containerFeatures`.

The current filename uses a timestamp to avoid collisions, which causes different invocations of the CLI to overwrite each others files.

We hit this because our end to end tests invoke the cli, and they run in parallel via go's `t.Parallel()`.