### PR TITLE
publish Templates with metadata attached to manifest

### DIFF
--- a/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
+++ b/src/spec-node/collectionCommonUtils/publishCommandImpl.ts
@@ -39,7 +39,7 @@ export function getSemanticTags(version: string, tags: string[], output: Log) {
 	return semanticVersions;
 }
 
-export async function doPublishCommand(params: CommonParams, version: string, ociRef: OCIRef, outputDir: string, collectionType: string, archiveName: string, featureAnnotations = {}) {
+export async function doPublishCommand(params: CommonParams, version: string, ociRef: OCIRef, outputDir: string, collectionType: string, archiveName: string, annotations: { [key: string]: string } = {}) {
 	const { output } = params;
 
 	output.write(`Fetching published versions...`, LogLevel.Info);
@@ -54,7 +54,7 @@ export async function doPublishCommand(params: CommonParams, version: string, oc
 	if (!!semanticTags) {
 		output.write(`Publishing tags: ${semanticTags.toString()}...`, LogLevel.Info);
 		const pathToTgz = path.join(outputDir, archiveName);
-		const digest = await pushOCIFeatureOrTemplate(params, ociRef, pathToTgz, semanticTags, collectionType, featureAnnotations);
+		const digest = await pushOCIFeatureOrTemplate(params, ociRef, pathToTgz, semanticTags, collectionType, annotations);
 		if (!digest) {
 			output.write(`(!) ERR: Failed to publish ${collectionType}: '${ociRef.resource}'`, LogLevel.Error);
 			return;

--- a/src/spec-node/templatesCLI/publish.ts
+++ b/src/spec-node/templatesCLI/publish.ts
@@ -88,7 +88,14 @@ async function templatesPublish({
         }
 
         const archiveName = getArchiveName(t.id, collectionType);
-        const publishResult = await doPublishCommand(params, t.version, templateRef, outputDir, collectionType, archiveName);
+
+        // Properties here are available on the manifest without needing to download the full Template archive.
+        const templateAnnotations = {
+            'dev.containers.metadata': JSON.stringify(t),
+        };
+        output.write(`Template Annotations: ${JSON.stringify(templateAnnotations)}`, LogLevel.Debug);
+
+        const publishResult = await doPublishCommand(params, t.version, templateRef, outputDir, collectionType, archiveName, templateAnnotations);
         if (!publishResult) {
             output.write(`(!) ERR: Failed to publish '${resource}'`, LogLevel.Error);
             process.exit(1);


### PR DESCRIPTION
Just like with Features, attach a complete copy of the metadata (the `devcontainer-template.json`) to the OCI manifest.  This is useful for tooling to query.

This will be immediately useful for https://github.com/microsoft/vscode-remote-release/issues/10095, allowing the extension to read various metadata properties before applying the Template.

Example Template with the metadata attached can be seen here (displayed under 'labels' on GitHub): https://github.com/codspace/templates/pkgs/container/templates%2Fmytemplate/251579251?tag=latest