### PR TITLE
Add `--omit-paths` flag to `templates apply`

### DIFF
--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -542,10 +542,10 @@ export async function getBlob(params: CommonParams, url: string, ociCacheDir: st
 
 		await mkdirpLocal(destCachePath);
 		await writeLocalFile(tempTarballPath, resBody);
-		
+
 		// https://github.com/devcontainers/spec/blob/main/docs/specs/devcontainer-templates.md#the-optionalpaths-property
-		const directoriesToOmit = omitDuringExtraction.filter(f => f.endsWith("/*")).map(f => f.slice(0, -1));
-		const filesToOmit = omitDuringExtraction.filter(f => !f.endsWith("/*"));
+		const directoriesToOmit = omitDuringExtraction.filter(f => f.endsWith('/*')).map(f => f.slice(0, -1));
+		const filesToOmit = omitDuringExtraction.filter(f => !f.endsWith('/*'));
 		
 		output.write(`omitDuringExtraction: '${omitDuringExtraction.join(', ')}`, LogLevel.Trace);
 		output.write(`Files to omit: '${filesToOmit.join(', ')}'`, LogLevel.Info);

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -560,11 +560,11 @@ export async function getBlob(params: CommonParams, url: string, ociCacheDir: st
 				cwd: destCachePath,
 				filter: (tPath: string, stat: tar.FileStat) => {
 					output.write(`Testing '${tPath}'(${stat.type})`, LogLevel.Trace);
-					tPath = tPath
+					const cleanedPath = tPath
 						.replace(/\\/g, '/')
 						.replace(/^\.\//, '');
 
-					if (filesToOmit.includes(tPath) || directoriesToOmit.some(d => tPath.startsWith(d))) {
+					if (filesToOmit.includes(cleanedPath) || directoriesToOmit.some(d => cleanedPath.startsWith(d))) {
 						output.write(`  Omitting '${tPath}'`, LogLevel.Trace);
 						return false; // Skip
 					}

--- a/src/spec-configuration/containerTemplatesOCI.ts
+++ b/src/spec-configuration/containerTemplatesOCI.ts
@@ -19,12 +19,13 @@ export interface SelectedTemplate {
 	id: string;
 	options: TemplateOptions;
 	features: TemplateFeatureOption[];
+	omitPaths: string[];
 }
 
 export async function fetchTemplate(params: CommonParams, selectedTemplate: SelectedTemplate, templateDestPath: string, userProvidedTmpDir?: string): Promise<string[] | undefined> {
 	const { output } = params;
 
-	let { id: userSelectedId, options: userSelectedOptions } = selectedTemplate;
+	let { id: userSelectedId, options: userSelectedOptions, omitPaths } = selectedTemplate;
 	const templateRef = getRef(output, userSelectedId);
 	if (!templateRef) {
 		output.write(`Failed to parse template ref for ${userSelectedId}`, LogLevel.Error);
@@ -46,7 +47,7 @@ export async function fetchTemplate(params: CommonParams, selectedTemplate: Sele
 	output.write(`blob url: ${blobUrl}`, LogLevel.Trace);
 
 	const tmpDir = userProvidedTmpDir || path.join(os.tmpdir(), 'vsch-template-temp', `${Date.now()}`);
-	const blobResult = await getBlob(params, blobUrl, tmpDir, templateDestPath, templateRef, blobDigest, ['devcontainer-template.json', 'README.md', 'NOTES.md'], 'devcontainer-template.json');
+	const blobResult = await getBlob(params, blobUrl, tmpDir, templateDestPath, templateRef, blobDigest, [...omitPaths, 'devcontainer-template.json', 'README.md', 'NOTES.md'], 'devcontainer-template.json');
 
 	if (!blobResult) {
 		throw new Error(`Failed to download package for ${templateRef.resource}`);

--- a/src/spec-node/templatesCLI/apply.ts
+++ b/src/spec-node/templatesCLI/apply.ts
@@ -15,7 +15,7 @@ export function templateApplyOptions(y: Argv) {
 			'features': { type: 'string', alias: 'f', default: '[]', description: 'Features to add to the provided Template, provided as JSON.' },
 			'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
 			'tmp-dir': { type: 'string', description: 'Directory to use for temporary files. If not provided, the system default will be inferred.' },
-			'omit-paths': { type: 'string', default: '[]', description: 'List of paths within the Template to omit applying, provided as JSON.  To ignore a directory append a trailing slash. Eg: \'[".github/", "projects/A/", "file.ts"]\'' },
+			'omit-paths': { type: 'string', default: '[]', description: 'List of paths within the Template to omit applying, provided as JSON.  To ignore a directory append \'/*\'. Eg: \'[".github/*", "dir/a/*", "file.ts"]\'' },
 		})
 		.check(_argv => {
 			return true;
@@ -72,7 +72,7 @@ async function templateApply({
 		let omitPathsErrors: jsonc.ParseError[] = [];
 		omitPaths = jsonc.parse(omitPathsArg, omitPathsErrors);
 		if (!Array.isArray(omitPaths)) {
-			output.write('Invalid \'--omitPaths\' argument provided. Provide as a JSON array, eg: \'[".github", "project/"]\'', LogLevel.Error);
+			output.write('Invalid \'--omitPaths\' argument provided. Provide as a JSON array, eg: \'[".github/*", "dir/a/*", "file.ts"]\'', LogLevel.Error);
 			process.exit(1);
 		}
 	}

--- a/src/spec-node/templatesCLI/apply.ts
+++ b/src/spec-node/templatesCLI/apply.ts
@@ -15,7 +15,7 @@ export function templateApplyOptions(y: Argv) {
 			'features': { type: 'string', alias: 'f', default: '[]', description: 'Features to add to the provided Template, provided as JSON.' },
 			'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
 			'tmp-dir': { type: 'string', description: 'Directory to use for temporary files. If not provided, the system default will be inferred.' },
-			'omit-paths': { type: 'string', default: '[]', description: 'List of paths within the Template to omit applying, provided as JSON.  Likely resolved from the Template\'s \'optionalPaths\' property.' },
+			'omit-paths': { type: 'string', default: '[]', description: 'List of paths within the Template to omit applying, provided as JSON.  To ignore a directory append a trailing slash. Eg: \'[".github/", "projects/A/", "file.ts"]\'' },
 		})
 		.check(_argv => {
 			return true;

--- a/src/test/container-templates/containerTemplatesOCI.test.ts
+++ b/src/test/container-templates/containerTemplatesOCI.test.ts
@@ -132,8 +132,8 @@ describe('fetchTemplate', async function () {
 	describe('omit-path', async function () {
 		this.timeout('120s');
 
-		// https://github.com/codspace/templates/pkgs/container/templates%2Fmytemplate/252099017?tag=1.0.3
-		const id = 'ghcr.io/codspace/templates/mytemplate@sha256:c44cb27efa68ee87a71838a59d1d2892b3c2de24be6f94c136652e45a19f017e';
+		// https://github.com/codspace/templates/pkgs/container/templates%2Fmytemplate/255979159?tag=1.0.4
+		const id = 'ghcr.io/codspace/templates/mytemplate@sha256:57cbf968907c74c106b7b2446063d114743ab3f63345f7c108c577915c535185';
 		const templateFiles = [
 			'./c1.ts',
 			'./c2.ts',
@@ -178,7 +178,7 @@ describe('fetchTemplate', async function () {
 				id,
 				options: {},
 				features: [],
-				omitPaths: ['example-projects/exampleB/'],
+				omitPaths: ['example-projects/exampleB/*'],
 			};
 
 			const files = await fetchTemplate(
@@ -205,7 +205,7 @@ describe('fetchTemplate', async function () {
 				id,
 				options: {},
 				features: [],
-				omitPaths: ['.github/', 'example-projects/exampleA/', 'c1.ts'],
+				omitPaths: ['.github/*', 'example-projects/exampleA/*', 'c1.ts'],
 			};
 
 			const files = await fetchTemplate(


### PR DESCRIPTION
Related: https://github.com/devcontainers/spec/pull/484, https://github.com/microsoft/vscode-remote-release/issues/10095

The `templates apply` command now exposes a flag `--omit-paths`.  Following the same file/folder syntax as shown in https://github.com/devcontainers/spec/pull/484, the provided array of paths will not be extracts from the tarball when applying a Template.

Expanded upon `getBlob()`'s existing filtering logic.