### PR TITLE
fix: change increment syntax in test library script

### DIFF
--- a/src/spec-node/featuresCLI/utils.ts
+++ b/src/spec-node/featuresCLI/utils.ts
@@ -98,7 +98,7 @@ checkMultiple() {
     shift; MINIMUMPASSED=$1
     shift; EXPRESSION="$1"
     while [ "$EXPRESSION" != "" ]; do
-        if $EXPRESSION; then ((PASSED++)); fi
+        if $EXPRESSION; then ((PASSED+=1)); fi
         shift; EXPRESSION=$1
     done
     if [ $PASSED -ge $MINIMUMPASSED ]; then


### PR DESCRIPTION
Function `checkMultiple` which is available in `dev-container-features-test-lib` (test library script) doesn't work as intended

It exits while looping through the 1st command. For example, execution of this script:

```bash
#!/bin/bash

set -e

# Optional: Import test library
source dev-container-features-test-lib

checkMultiple "Test multiple" 2 "echo First" "echo Second"
```
Results in error: 
![Pasted image 20240915161640](https://github.com/user-attachments/assets/ab296717-0464-4206-9d4d-e40ef4f751af)

It seems that it's caused by the way how the `PASSED` variable is incremented: `((PASSED++))` - The value is returned first, then `PASSED` is incremented

For the first iteration the value of the expression is 0, so the return status is set to 1

> (( expression ))
> If the value of the expression is non-zero, the return status is 0; otherwise the return status is 1.
> https://www.gnu.org/software/bash/manual/bash.html#Conditional-Constructs

I changed it to `((PASSED+=1))`, and tested locally. It fixes the issue:

![image](https://github.com/user-attachments/assets/0a311fba-be1c-4332-aaa5-d4ef74808bec)
