### PR TITLE
Added test for labels with dockerfile

### DIFF
--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -27,8 +27,17 @@ describe('Dev Containers CLI', function () {
 
 	describe('Command build', () => {
 
-		it('should build successfully with valid image metadata --label property', async () => {
+		it('should build successfully with valid image metadata --label property (image)', async () => {
 			const testFolder = `${__dirname}/configs/example`;
+			const response = await shellExec(`${cli} build --workspace-folder ${testFolder} --label 'name=label-test' --label 'type=multiple-labels'`);
+			const res = JSON.parse(response.stdout);
+			assert.equal(res.outcome, 'success');
+			const labels = await shellExec(`docker inspect --format '{{json .Config.Labels}}' ${res.imageName} | jq`);
+			assert.match(labels.stdout.toString(), /\"name\": \"label-test\"/);
+		});
+
+		it('should build successfully with valid image metadata --label property (dockerfile)', async () => {
+			const testFolder = `${__dirname}/configs/example-dockerfile`;
 			const response = await shellExec(`${cli} build --workspace-folder ${testFolder} --label 'name=label-test' --label 'type=multiple-labels'`);
 			const res = JSON.parse(response.stdout);
 			assert.equal(res.outcome, 'success');

--- a/src/test/configs/example-dockerfile/.devcontainer.json
+++ b/src/test/configs/example-dockerfile/.devcontainer.json
@@ -1,0 +1,11 @@
+// Example devcontainer.json configuration with a Dockerfile
+{
+	"build": {
+		"dockerfile": "mcr.microsoft.com/devcontainers/base:latest"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "latest"
+		}
+	}
+}

--- a/src/test/configs/example-dockerfile/Dockerfile
+++ b/src/test/configs/example-dockerfile/Dockerfile
@@ -1,0 +1,2 @@
+#FROM dev-containers-docker-local.repo.pnet.ch/pf/additional/dev-container-build:1.0.202410310854
+FROM linux-docker-local.repo.pnet.ch/pf/debian:11.0.202410081002-bullseye


### PR DESCRIPTION
This PR adds a test to add labels via cli to a devcontainer that is based on a Dockerfile. The test currently fails.