### PR TITLE
feat: Uses cwd as default workspace folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",
 		"clean-built": "rimraf built",
-		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.exec.buildKit.1.test.ts",
+		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/*.test.ts",
 		"test-matrix": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/*.test.ts",
 		"test-container-features-cli": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/featuresCLICommands.test.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",
 		"clean-built": "rimraf built",
-		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.build.test.ts",
+		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.test.ts",
 		"test-matrix": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/*.test.ts",
 		"test-container-features-cli": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/featuresCLICommands.test.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",
 		"clean-built": "rimraf built",
-		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.test.ts",
+		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.set-up.test.ts",
 		"test-matrix": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/*.test.ts",
 		"test-container-features-cli": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/featuresCLICommands.test.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",
 		"clean-built": "rimraf built",
-		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/lockfile.test.ts",
+		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.exec.buildKit.1.test.ts",
 		"test-matrix": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/*.test.ts",
 		"test-container-features-cli": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/featuresCLICommands.test.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",
 		"clean-built": "rimraf built",
-		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.set-up.test.ts",
+		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/lockfile.test.ts",
 		"test-matrix": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/*.test.ts",
 		"test-container-features-cli": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/featuresCLICommands.test.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"clean": "npm-run-all clean-dist clean-built",
 		"clean-dist": "rimraf dist",
 		"clean-built": "rimraf built",
-		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/*.test.ts",
+		"test": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/cli.build.test.ts",
 		"test-matrix": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit",
 		"test-container-features": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/*.test.ts",
 		"test-container-features-cli": "env TS_NODE_PROJECT=src/test/tsconfig.json mocha -r ts-node/register --exit src/test/container-features/featuresCLICommands.test.ts",

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -501,7 +501,7 @@ function buildOptions(y: Argv) {
 		'user-data-folder': { type: 'string', description: 'Host path to a directory that is intended to be persisted and share state between sessions.' },
 		'docker-path': { type: 'string', description: 'Docker CLI path.' },
 		'docker-compose-path': { type: 'string', description: 'Docker Compose CLI path.' },
-		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.', default: '.', defaultDescription: 'Current Working Directory' },
 		'config': { type: 'string', description: 'devcontainer.json path. The default is to use .devcontainer/devcontainer.json or, if that does not exist, .devcontainer.json in the workspace folder.' },
 		'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
 		'log-format': { choices: ['text' as 'text', 'json' as 'json'], default: 'text' as 'text', description: 'Log format.' },
@@ -568,7 +568,7 @@ async function doBuild({
 		await Promise.all(disposables.map(d => d()));
 	};
 	try {
-		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
 		const configFile: URI | undefined = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;
 		const overrideConfigFile: URI | undefined = /* overrideConfig ? URI.file(path.resolve(process.cwd(), overrideConfig)) : */ undefined;
 		const addCacheFroms = addCacheFrom ? (Array.isArray(addCacheFrom) ? addCacheFrom as string[] : [addCacheFrom]) : [];

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -1091,7 +1091,7 @@ async function readConfiguration({
 function outdatedOptions(y: Argv) {
 	return y.options({
 		'user-data-folder': { type: 'string', description: 'Host path to a directory that is intended to be persisted and share state between sessions.' },
-		'workspace-folder': { type: 'string', required: true, description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
 		'config': { type: 'string', description: 'devcontainer.json path. The default is to use .devcontainer/devcontainer.json or, if that does not exist, .devcontainer.json in the workspace folder.' },
 		'output-format': { choices: ['text' as 'text', 'json' as 'json'], default: 'text', description: 'Output format.' },
 		'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level for the --terminal-log-file. When set to trace, the log level for --log-file will also be set to trace.' },
@@ -1123,7 +1123,7 @@ async function outdated({
 	};
 	let output: Log | undefined;
 	try {
-		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;
 		const cliHost = await getCLIHost(workspaceFolder, loadNativeModule, logFormat === 'text');
 		const extensionPath = path.join(__dirname, '..', '..');

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -144,16 +144,6 @@ function provisionOptions(y: Argv) {
 		'include-merged-configuration': { type: 'boolean', default: false, description: 'Include merged configuration in result.' },
 	})
 		.check(argv => {
-			const idLabels = (argv['id-label'] && (Array.isArray(argv['id-label']) ? argv['id-label'] : [argv['id-label']])) as string[] | undefined;
-			if (idLabels?.some(idLabel => !/.+=.+/.test(idLabel))) {
-				throw new Error('Unmatched argument format: id-label must match <name>=<value>');
-			}
-			if (!(argv['workspace-folder'] || argv['id-label'])) {
-				throw new Error('Missing required argument: workspace-folder or id-label');
-			}
-			if (!(argv['workspace-folder'] || argv['override-config'])) {
-				throw new Error('Missing required argument: workspace-folder or override-config');
-			}
 			const mounts = (argv.mount && (Array.isArray(argv.mount) ? argv.mount : [argv.mount])) as string[] | undefined;
 			if (mounts?.some(mount => !mountRegex.test(mount))) {
 				throw new Error('Unmatched argument format: mount must match type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]');
@@ -218,7 +208,7 @@ async function provision({
 	'include-merged-configuration': includeMergedConfig,
 }: ProvisionArgs) {
 
-	const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
+	const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
 	const addRemoteEnvs = addRemoteEnv ? (Array.isArray(addRemoteEnv) ? addRemoteEnv as string[] : [addRemoteEnv]) : [];
 	const addCacheFroms = addCacheFrom ? (Array.isArray(addCacheFrom) ? addCacheFrom as string[] : [addCacheFrom]) : [];
 	const additionalFeatures = additionalFeaturesJson ? jsonc.parse(additionalFeaturesJson) as Record<string, string | boolean | Record<string, string | boolean>> : {};

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -961,9 +961,6 @@ function readConfigurationOptions(y: Argv) {
 			if (idLabels?.some(idLabel => !/.+=.+/.test(idLabel))) {
 				throw new Error('Unmatched argument format: id-label must match <name>=<value>');
 			}
-			if (!argv['container-id'] && !idLabels?.length && !argv['workspace-folder']) {
-				throw new Error('Missing required argument: One of --container-id, --id-label or --workspace-folder is required.');
-			}
 			return true;
 		});
 }
@@ -999,7 +996,7 @@ async function readConfiguration({
 	};
 	let output: Log | undefined;
 	try {
-		const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
 		const providedIdLabels = idLabel ? Array.isArray(idLabel) ? idLabel as string[] : [idLabel] : undefined;
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;
 		const overrideConfigFile = overrideConfig ? URI.file(path.resolve(process.cwd(), overrideConfig)) : undefined;

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -774,9 +774,6 @@ function runUserCommandsOptions(y: Argv) {
 			if (remoteEnvs?.some(remoteEnv => !/.+=.*/.test(remoteEnv))) {
 				throw new Error('Unmatched argument format: remote-env must match <name>=<value>');
 			}
-			if (!argv['container-id'] && !idLabels?.length && !argv['workspace-folder']) {
-				throw new Error('Missing required argument: One of --container-id, --id-label or --workspace-folder is required.');
-			}
 			return true;
 		});
 }
@@ -830,7 +827,7 @@ async function doRunUserCommands({
 		await Promise.all(disposables.map(d => d()));
 	};
 	try {
-		const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
 		const providedIdLabels = idLabel ? Array.isArray(idLabel) ? idLabel as string[] : [idLabel] : undefined;
 		const addRemoteEnvs = addRemoteEnv ? (Array.isArray(addRemoteEnv) ? addRemoteEnv as string[] : [addRemoteEnv]) : [];
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -103,7 +103,7 @@ function provisionOptions(y: Argv) {
 		'docker-compose-path': { type: 'string', description: 'Docker Compose CLI path.' },
 		'container-data-folder': { type: 'string', description: 'Container data folder where user data inside the container will be stored.' },
 		'container-system-data-folder': { type: 'string', description: 'Container system data folder where system data inside the container will be stored.' },
-		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.', default: '.', defaultDescription: 'Current Working Directory' },
 		'workspace-mount-consistency': { choices: ['consistent' as 'consistent', 'cached' as 'cached', 'delegated' as 'delegated'], default: 'cached' as 'cached', description: 'Workspace mount consistency.' },
 		'gpu-availability': { choices: ['all' as 'all', 'detect' as 'detect', 'none' as 'none'], default: 'detect' as 'detect', description: 'Availability of GPUs in case the dev container requires any. `all` expects a GPU to be available.' },
 		'mount-workspace-git-root': { type: 'boolean', default: true, description: 'Mount the workspace using its Git root.' },
@@ -212,7 +212,7 @@ async function provision({
 	'include-merged-configuration': includeMergedConfig,
 }: ProvisionArgs) {
 
-	const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
+	const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
 	const addRemoteEnvs = addRemoteEnv ? (Array.isArray(addRemoteEnv) ? addRemoteEnv as string[] : [addRemoteEnv]) : [];
 	const addCacheFroms = addCacheFrom ? (Array.isArray(addCacheFrom) ? addCacheFrom as string[] : [addCacheFrom]) : [];
 	const additionalFeatures = additionalFeaturesJson ? jsonc.parse(additionalFeaturesJson) as Record<string, string | boolean | Record<string, string | boolean>> : {};
@@ -674,7 +674,7 @@ async function doBuild({
 			if (envFile) {
 				composeGlobalArgs.push('--env-file', envFile);
 			}
-			
+
 			const composeConfig = await readDockerComposeConfig(buildParams, composeFiles, envFile);
 			const projectName = await getProjectName(params, workspace, composeFiles, composeConfig);
 			const services = Object.keys(composeConfig.services || {});
@@ -746,7 +746,7 @@ function runUserCommandsOptions(y: Argv) {
 		'docker-compose-path': { type: 'string', description: 'Docker Compose CLI path.' },
 		'container-data-folder': { type: 'string', description: 'Container data folder where user data inside the container will be stored.' },
 		'container-system-data-folder': { type: 'string', description: 'Container system data folder where system data inside the container will be stored.' },
-		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.', default: '.', defaultDescription: 'Current Working Directory' },
 		'mount-workspace-git-root': { type: 'boolean', default: true, description: 'Mount the workspace using its Git root.' },
 		'container-id': { type: 'string', description: 'Id of the container to run the user commands for.' },
 		'id-label': { type: 'string', description: 'Id label(s) of the format name=value. If no --container-id is given the id labels will be used to look up the container. If no --id-label is given, one will be inferred from the --workspace-folder path.' },
@@ -831,7 +831,7 @@ async function doRunUserCommands({
 		await Promise.all(disposables.map(d => d()));
 	};
 	try {
-		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
 		const providedIdLabels = idLabel ? Array.isArray(idLabel) ? idLabel as string[] : [idLabel] : undefined;
 		const addRemoteEnvs = addRemoteEnv ? (Array.isArray(addRemoteEnv) ? addRemoteEnv as string[] : [addRemoteEnv]) : [];
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;
@@ -945,7 +945,7 @@ function readConfigurationOptions(y: Argv) {
 		'user-data-folder': { type: 'string', description: 'Host path to a directory that is intended to be persisted and share state between sessions.' },
 		'docker-path': { type: 'string', description: 'Docker CLI path.' },
 		'docker-compose-path': { type: 'string', description: 'Docker Compose CLI path.' },
-		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.', default: '.', defaultDescription: 'Current Working Directory' },
 		'mount-workspace-git-root': { type: 'boolean', default: true, description: 'Mount the workspace using its Git root.' },
 		'container-id': { type: 'string', description: 'Id of the container to run the user commands for.' },
 		'id-label': { type: 'string', description: 'Id label(s) of the format name=value. If no --container-id is given the id labels will be used to look up the container. If no --id-label is given, one will be inferred from the --workspace-folder path.' },
@@ -1000,7 +1000,7 @@ async function readConfiguration({
 	};
 	let output: Log | undefined;
 	try {
-		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
 		const providedIdLabels = idLabel ? Array.isArray(idLabel) ? idLabel as string[] : [idLabel] : undefined;
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;
 		const overrideConfigFile = overrideConfig ? URI.file(path.resolve(process.cwd(), overrideConfig)) : undefined;
@@ -1095,7 +1095,7 @@ async function readConfiguration({
 function outdatedOptions(y: Argv) {
 	return y.options({
 		'user-data-folder': { type: 'string', description: 'Host path to a directory that is intended to be persisted and share state between sessions.' },
-		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.', default: '.', defaultDescription: 'Current Working Directory' },
 		'config': { type: 'string', description: 'devcontainer.json path. The default is to use .devcontainer/devcontainer.json or, if that does not exist, .devcontainer.json in the workspace folder.' },
 		'output-format': { choices: ['text' as 'text', 'json' as 'json'], default: 'text', description: 'Output format.' },
 		'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level for the --terminal-log-file. When set to trace, the log level for --log-file will also be set to trace.' },
@@ -1127,7 +1127,7 @@ async function outdated({
 	};
 	let output: Log | undefined;
 	try {
-		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;
 		const cliHost = await getCLIHost(workspaceFolder, loadNativeModule, logFormat === 'text');
 		const extensionPath = path.join(__dirname, '..', '..');
@@ -1197,7 +1197,7 @@ function execOptions(y: Argv) {
 		'docker-compose-path': { type: 'string', description: 'Docker Compose CLI path.' },
 		'container-data-folder': { type: 'string', description: 'Container data folder where user data inside the container will be stored.' },
 		'container-system-data-folder': { type: 'string', description: 'Container system data folder where system data inside the container will be stored.' },
-		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.', default: '.', defaultDescription: 'Current Working Directory' },
 		'mount-workspace-git-root': { type: 'boolean', default: true, description: 'Mount the workspace using its Git root.' },
 		'container-id': { type: 'string', description: 'Id of the container to run the user commands for.' },
 		'id-label': { type: 'string', description: 'Id label(s) of the format name=value. If no --container-id is given the id labels will be used to look up the container. If no --id-label is given, one will be inferred from the --workspace-folder path.' },
@@ -1277,7 +1277,7 @@ export async function doExec({
 	let output: Log | undefined;
 	const isTTY = process.stdin.isTTY && process.stdout.isTTY || logFormat === 'json'; // If stdin or stdout is a pipe, we don't want to use a PTY.
 	try {
-		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
 		const providedIdLabels = idLabel ? Array.isArray(idLabel) ? idLabel as string[] : [idLabel] : undefined;
 		const addRemoteEnvs = addRemoteEnv ? (Array.isArray(addRemoteEnv) ? addRemoteEnv as string[] : [addRemoteEnv]) : [];
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -497,7 +497,7 @@ function buildOptions(y: Argv) {
 		'user-data-folder': { type: 'string', description: 'Host path to a directory that is intended to be persisted and share state between sessions.' },
 		'docker-path': { type: 'string', description: 'Docker CLI path.' },
 		'docker-compose-path': { type: 'string', description: 'Docker Compose CLI path.' },
-		'workspace-folder': { type: 'string', required: true, description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
+		'workspace-folder': { type: 'string', description: 'Workspace folder path. The devcontainer.json will be looked up relative to this path.' },
 		'config': { type: 'string', description: 'devcontainer.json path. The default is to use .devcontainer/devcontainer.json or, if that does not exist, .devcontainer.json in the workspace folder.' },
 		'log-level': { choices: ['info' as 'info', 'debug' as 'debug', 'trace' as 'trace'], default: 'info' as 'info', description: 'Log level.' },
 		'log-format': { choices: ['text' as 'text', 'json' as 'json'], default: 'text' as 'text', description: 'Log format.' },
@@ -564,7 +564,7 @@ async function doBuild({
 		await Promise.all(disposables.map(d => d()));
 	};
 	try {
-		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
 		const configFile: URI | undefined = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;
 		const overrideConfigFile: URI | undefined = /* overrideConfig ? URI.file(path.resolve(process.cwd(), overrideConfig)) : */ undefined;
 		const addCacheFroms = addCacheFrom ? (Array.isArray(addCacheFrom) ? addCacheFrom as string[] : [addCacheFrom]) : [];

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -144,6 +144,10 @@ function provisionOptions(y: Argv) {
 		'include-merged-configuration': { type: 'boolean', default: false, description: 'Include merged configuration in result.' },
 	})
 		.check(argv => {
+			const idLabels = (argv['id-label'] && (Array.isArray(argv['id-label']) ? argv['id-label'] : [argv['id-label']])) as string[] | undefined;
+			if (idLabels?.some(idLabel => !/.+=.+/.test(idLabel))) {
+				throw new Error('Unmatched argument format: id-label must match <name>=<value>');
+			}
 			const mounts = (argv.mount && (Array.isArray(argv.mount) ? argv.mount : [argv.mount])) as string[] | undefined;
 			if (mounts?.some(mount => !mountRegex.test(mount))) {
 				throw new Error('Unmatched argument format: mount must match type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]');

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -1226,9 +1226,6 @@ function execOptions(y: Argv) {
 			if (remoteEnvs?.some(remoteEnv => !/.+=.*/.test(remoteEnv))) {
 				throw new Error('Unmatched argument format: remote-env must match <name>=<value>');
 			}
-			if (!argv['container-id'] && !idLabels?.length && !argv['workspace-folder']) {
-				throw new Error('Missing required argument: One of --container-id, --id-label or --workspace-folder is required.');
-			}
 			return true;
 		});
 }
@@ -1276,7 +1273,7 @@ export async function doExec({
 	let output: Log | undefined;
 	const isTTY = process.stdin.isTTY && process.stdout.isTTY || logFormat === 'json'; // If stdin or stdout is a pipe, we don't want to use a PTY.
 	try {
-		const workspaceFolder = workspaceFolderArg ? path.resolve(process.cwd(), workspaceFolderArg) : undefined;
+		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg ?? '.');
 		const providedIdLabels = idLabel ? Array.isArray(idLabel) ? idLabel as string[] : [idLabel] : undefined;
 		const addRemoteEnvs = addRemoteEnv ? (Array.isArray(addRemoteEnv) ? addRemoteEnv as string[] : [addRemoteEnv]) : [];
 		const configFile = configParam ? URI.file(path.resolve(process.cwd(), configParam)) : undefined;

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -53,7 +53,7 @@ describe('Dev Containers CLI', function () {
 				await shellExec(`${cli} build --workspace-folder ${testFolder} --image-name demo:v1`);
 				const tags = await shellExec(`docker images --format "{{.Tag}}" demo`);
 				const imageTags = tags.stdout.trim().split('\n').filter(tag => tag !== '<none>');
-				assert.equal(imageTags.length, 1, 'There should be only one tag for demo:v1'); 
+				assert.equal(imageTags.length, 1, 'There should be only one tag for demo:v1');
 			} catch (error) {
 				assert.equal(error.code, 'ERR_ASSERTION', 'Should fail with ERR_ASSERTION');
 			}
@@ -424,7 +424,7 @@ describe('Dev Containers CLI', function () {
 			assert.strictEqual(envListToObj(details.Config.Env).SUBFOLDER_CONFIG_IMAGE_ENV, 'true');
 		});
 
-		it.only('should apply build options', async () => {
+		it'should apply build options', async () => {
 			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
 			const res = await shellExec(`${cli} build --workspace-folder ${testFolder}`);
 			const response = JSON.parse(res.stdout);
@@ -434,7 +434,7 @@ describe('Dev Containers CLI', function () {
 			assert.strictEqual(details.Config.Labels?.test_build_options, 'success');
 		});
 
-		it.only('should build with default workspace folder', async () => {
+		it'should build with default workspace folder', async () => {
 			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
 			const res = await shellExec(`${cli} build`, { cwd: testFolder });
 			const response = JSON.parse(res.stdout);

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -424,7 +424,7 @@ describe('Dev Containers CLI', function () {
 			assert.strictEqual(envListToObj(details.Config.Env).SUBFOLDER_CONFIG_IMAGE_ENV, 'true');
 		});
 
-		it'should apply build options', async () => {
+		it('should apply build options', async () => {
 			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
 			const res = await shellExec(`${cli} build --workspace-folder ${testFolder}`);
 			const response = JSON.parse(res.stdout);
@@ -434,7 +434,7 @@ describe('Dev Containers CLI', function () {
 			assert.strictEqual(details.Config.Labels?.test_build_options, 'success');
 		});
 
-		it'should build with default workspace folder', async () => {
+		it('should build with default workspace folder', async () => {
 			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
 			const res = await shellExec(`${cli} build`, { cwd: testFolder });
 			const response = JSON.parse(res.stdout);

--- a/src/test/cli.build.test.ts
+++ b/src/test/cli.build.test.ts
@@ -16,7 +16,7 @@ const pkg = require('../../package.json');
 describe('Dev Containers CLI', function () {
 	this.timeout('120s');
 
-	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
+	const tmp = path.join(__dirname, 'tmp');
 	const cli = `npx --prefix ${tmp} devcontainer`;
 
 	before('Install', async () => {
@@ -424,9 +424,19 @@ describe('Dev Containers CLI', function () {
 			assert.strictEqual(envListToObj(details.Config.Env).SUBFOLDER_CONFIG_IMAGE_ENV, 'true');
 		});
 
-		it('should apply build options', async () => {
+		it.only('should apply build options', async () => {
 			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
 			const res = await shellExec(`${cli} build --workspace-folder ${testFolder}`);
+			const response = JSON.parse(res.stdout);
+			assert.equal(response.outcome, 'success');
+			assert.ok(response.imageName);
+			const details = JSON.parse((await shellExec(`docker inspect ${response.imageName}`)).stdout)[0] as ImageDetails;
+			assert.strictEqual(details.Config.Labels?.test_build_options, 'success');
+		});
+
+		it.only('should build with default workspace folder', async () => {
+			const testFolder = `${__dirname}/configs/dockerfile-with-target`;
+			const res = await shellExec(`${cli} build`, { cwd: testFolder });
 			const response = JSON.parse(res.stdout);
 			assert.equal(response.outcome, 'success');
 			assert.ok(response.imageName);

--- a/src/test/cli.exec.base.ts
+++ b/src/test/cli.exec.base.ts
@@ -14,7 +14,7 @@ export function describeTests1({ text, options }: BuildKitOption) {
 	describe('Dev Containers CLI', function () {
 		this.timeout('360s');
 
-		const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
+		const tmp = path.join(__dirname, 'tmp');
 		const cli = `npx --prefix ${tmp} devcontainer`;
 
 		before('Install', async () => {
@@ -30,8 +30,14 @@ export function describeTests1({ text, options }: BuildKitOption) {
 				const testFolder = `${__dirname}/configs/image`;
 				beforeEach(async () => containerId = (await devContainerUp(cli, testFolder, options)).containerId);
 				afterEach(async () => await devContainerDown({ containerId }));
-				it('should execute successfully', async () => {
+				it.only('should execute successfully', async () => {
 					const res = await shellBufferExec(`${cli} exec --workspace-folder ${testFolder} echo hi`);
+					assert.strictEqual(res.code, 0);
+					assert.equal(res.signal, undefined);
+					assert.strictEqual(res.stdout.toString(), 'hi\n');
+				});
+				it.only('should execute without a workspace folder', async () => {
+					const res = await shellBufferExec(`${cli} exec echo hi`, { cwd: testFolder});
 					assert.strictEqual(res.code, 0);
 					assert.equal(res.signal, undefined);
 					assert.strictEqual(res.stdout.toString(), 'hi\n');

--- a/src/test/cli.exec.base.ts
+++ b/src/test/cli.exec.base.ts
@@ -30,13 +30,13 @@ export function describeTests1({ text, options }: BuildKitOption) {
 				const testFolder = `${__dirname}/configs/image`;
 				beforeEach(async () => containerId = (await devContainerUp(cli, testFolder, options)).containerId);
 				afterEach(async () => await devContainerDown({ containerId }));
-				it'should execute successfully', async () => {
+				it('should execute successfully', async () => {
 					const res = await shellBufferExec(`${cli} exec --workspace-folder ${testFolder} echo hi`);
 					assert.strictEqual(res.code, 0);
 					assert.equal(res.signal, undefined);
 					assert.strictEqual(res.stdout.toString(), 'hi\n');
 				});
-				it'should execute without a workspace folder', async () => {
+				it('should execute without a workspace folder', async () => {
 					const res = await shellBufferExec(`${cli} exec echo hi`, { cwd: testFolder});
 					assert.strictEqual(res.code, 0);
 					assert.equal(res.signal, undefined);

--- a/src/test/cli.exec.base.ts
+++ b/src/test/cli.exec.base.ts
@@ -30,13 +30,13 @@ export function describeTests1({ text, options }: BuildKitOption) {
 				const testFolder = `${__dirname}/configs/image`;
 				beforeEach(async () => containerId = (await devContainerUp(cli, testFolder, options)).containerId);
 				afterEach(async () => await devContainerDown({ containerId }));
-				it.only('should execute successfully', async () => {
+				it'should execute successfully', async () => {
 					const res = await shellBufferExec(`${cli} exec --workspace-folder ${testFolder} echo hi`);
 					assert.strictEqual(res.code, 0);
 					assert.equal(res.signal, undefined);
 					assert.strictEqual(res.stdout.toString(), 'hi\n');
 				});
-				it.only('should execute without a workspace folder', async () => {
+				it'should execute without a workspace folder', async () => {
 					const res = await shellBufferExec(`${cli} exec echo hi`, { cwd: testFolder});
 					assert.strictEqual(res.code, 0);
 					assert.equal(res.signal, undefined);
@@ -388,7 +388,7 @@ export function describeTests2({ text, options }: BuildKitOption) {
 						assert.match(res.stdout, /howdy, node/);
 					});
 				});
-		
+
 				it('should fail with "not found" error when config is not found', async () => {
 					let success = false;
 					try {

--- a/src/test/cli.set-up.test.ts
+++ b/src/test/cli.set-up.test.ts
@@ -12,7 +12,7 @@ const pkg = require('../../package.json');
 describe('Dev Containers CLI', function () {
 	this.timeout('120s');
 
-	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
+	const tmp = path.join(__dirname, 'tmp');
 	const cli = `npx --prefix ${tmp} devcontainer`;
 
 	before('Install', async () => {
@@ -79,7 +79,7 @@ describe('Dev Containers CLI', function () {
 		});
 	});
 
-	describe('Command read-configuration', () => {
+	describe.only('Command read-configuration', () => {
 		it('should succeed and return postAttachCommand from config', async () => {
 
 			const containerId = (await shellExec(`docker run -d alpine:3.17 sleep inf`)).stdout.trim();
@@ -98,6 +98,18 @@ describe('Dev Containers CLI', function () {
 			const containerId = (await shellExec(`docker run -d devcontainer-set-up-test sleep inf`)).stdout.trim();
 
 			const res = await shellExec(`${cli} read-configuration --container-id ${containerId} --include-merged-configuration`);
+			const response = JSON.parse(res.stdout);
+			assert.strictEqual(response.mergedConfiguration.postCreateCommands.length, 1);
+
+			await shellExec(`docker rm -f ${containerId}`);
+		});
+
+		it('should succeed without a workspace folder', async () => {
+
+			await shellExec(`docker build -t devcontainer-set-up-test ${__dirname}/configs/set-up-with-metadata`);
+			const containerId = (await shellExec(`docker run -d devcontainer-set-up-test sleep inf`)).stdout.trim();
+
+			const res = await shellExec(`${cli} read-configuration --include-merged-configuration`, { cwd: `${__dirname}/configs/set-up-with-metadata` });
 			const response = JSON.parse(res.stdout);
 			assert.strictEqual(response.mergedConfiguration.postCreateCommands.length, 1);
 

--- a/src/test/cli.set-up.test.ts
+++ b/src/test/cli.set-up.test.ts
@@ -79,7 +79,7 @@ describe('Dev Containers CLI', function () {
 		});
 	});
 
-	describe'Command read-configuration', () => {
+	describe('Command read-configuration', () => {
 		it('should succeed and return postAttachCommand from config', async () => {
 
 			const containerId = (await shellExec(`docker run -d alpine:3.17 sleep inf`)).stdout.trim();

--- a/src/test/cli.set-up.test.ts
+++ b/src/test/cli.set-up.test.ts
@@ -79,7 +79,7 @@ describe('Dev Containers CLI', function () {
 		});
 	});
 
-	describe.only('Command read-configuration', () => {
+	describe'Command read-configuration', () => {
 		it('should succeed and return postAttachCommand from config', async () => {
 
 			const containerId = (await shellExec(`docker run -d alpine:3.17 sleep inf`)).stdout.trim();

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -12,7 +12,7 @@ const pkg = require('../../package.json');
 describe('Dev Containers CLI', function () {
 	this.timeout('120s');
 
-	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
+	const tmp = path.join(__dirname, 'tmp');
 	const cli = `npx --prefix ${tmp} devcontainer`;
 
 	before('Install', async () => {
@@ -27,13 +27,18 @@ describe('Dev Containers CLI', function () {
 	});
 
 	describe('Command run-user-commands', () => {
-		describe('with valid config', () => {
+		describe.only('with valid config', () => {
 			let containerId: string | null = null;
 			const testFolder = `${__dirname}/configs/image`;
 			beforeEach(async () => containerId = (await devContainerUp(cli, testFolder)).containerId);
 			afterEach(async () => await devContainerDown({ containerId }));
 			it('should execute successfully', async () => {
 				const res = await shellExec(`${cli} run-user-commands --workspace-folder ${testFolder}`);
+				const response = JSON.parse(res.stdout);
+				assert.equal(response.outcome, 'success');
+			});
+			it('should execute successfully', async () => {
+				const res = await shellExec(`${cli} run-user-commands`, { cwd: testFolder });
 				const response = JSON.parse(res.stdout);
 				assert.equal(response.outcome, 'success');
 			});

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -27,7 +27,7 @@ describe('Dev Containers CLI', function () {
 	});
 
 	describe('Command run-user-commands', () => {
-		describe'with valid config', () => {
+		describe('with valid config', () => {
 			let containerId: string | null = null;
 			const testFolder = `${__dirname}/configs/image`;
 			beforeEach(async () => containerId = (await devContainerUp(cli, testFolder)).containerId);

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -27,7 +27,7 @@ describe('Dev Containers CLI', function () {
 	});
 
 	describe('Command run-user-commands', () => {
-		describe.only('with valid config', () => {
+		describe'with valid config', () => {
 			let containerId: string | null = null;
 			const testFolder = `${__dirname}/configs/image`;
 			beforeEach(async () => containerId = (await devContainerUp(cli, testFolder)).containerId);

--- a/src/test/cli.up.test.ts
+++ b/src/test/cli.up.test.ts
@@ -26,7 +26,7 @@ describe('Dev Containers CLI', function () {
 
 	describe('Command up', () => {
 
-		it.only('should execute successfully with valid config', async () => {
+		it('should execute successfully with valid config', async () => {
 			const res = await shellExec(`${cli} up --workspace-folder ${__dirname}/configs/image --include-configuration --include-merged-configuration`);
 			const response = JSON.parse(res.stdout);
 			assert.equal(response.outcome, 'success');
@@ -69,7 +69,7 @@ describe('Dev Containers CLI', function () {
 			assert.equal(success, false, 'expect non-successful call');
 		});
 
-		it.only('should succeed when run without a workspace-folder in a workspace root', async () => {
+		it('should succeed when run without a workspace-folder in a workspace root', async () => {
 			const res = await shellExec(`${cli} up`, { cwd: `${__dirname}/configs/image-with-features` });
 			const response = JSON.parse(res.stdout);
 			assert.equal(response.outcome, 'success');

--- a/src/test/cli.up.test.ts
+++ b/src/test/cli.up.test.ts
@@ -14,7 +14,7 @@ const pkg = require('../../package.json');
 describe('Dev Containers CLI', function () {
 	this.timeout('240s');
 
-	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
+	const tmp = path.join(__dirname, 'tmp');
 	const cli = `npx --prefix ${tmp} devcontainer`;
 
 
@@ -26,7 +26,7 @@ describe('Dev Containers CLI', function () {
 
 	describe('Command up', () => {
 
-		it('should execute successfully with valid config', async () => {
+		it.only('should execute successfully with valid config', async () => {
 			const res = await shellExec(`${cli} up --workspace-folder ${__dirname}/configs/image --include-configuration --include-merged-configuration`);
 			const response = JSON.parse(res.stdout);
 			assert.equal(response.outcome, 'success');
@@ -67,6 +67,15 @@ describe('Dev Containers CLI', function () {
 				assert.match(res.message, /Dev container config \(.*\) not found./);
 			}
 			assert.equal(success, false, 'expect non-successful call');
+		});
+
+		it.only('should succeed when run without a workspace-folder in a workspace root', async () => {
+			const res = await shellExec(`${cli} up`, { cwd: `${__dirname}/configs/image-with-features` });
+			const response = JSON.parse(res.stdout);
+			assert.equal(response.outcome, 'success');
+			const containerId: string = response.containerId;
+			assert.ok(containerId, 'Container id not found.');
+			await shellExec(`docker rm -f ${containerId}`);
 		});
 
 		// docker-compose variations _without_ features are here (under 'up' tests)
@@ -283,7 +292,7 @@ describe('Dev Containers CLI', function () {
 			assert.equal('Hello, World!', evalEnvWithCommand.stdout);
 
 			const envWithTestMessage = await shellExec(`docker exec ${containerId} bash -c 'echo -n $Test_Message'`);
-			assert.equal('H"\\n\\ne"\'\'\'llo M:;a/t?h&^iKa%#@!``ni,sk_a-', envWithTestMessage.stdout);			
+			assert.equal('H"\\n\\ne"\'\'\'llo M:;a/t?h&^iKa%#@!``ni,sk_a-', envWithTestMessage.stdout);
 
 			const envWithFormat = await shellExec(`docker exec ${containerId} bash -c 'echo -n $ROSCONSOLE_FORMAT'`);
 			assert.equal('[$${severity}] [$${walltime:%Y-%m-%d %H:%M:%S}] [$${node}]: $${message}', envWithFormat.stdout);
@@ -295,10 +304,10 @@ describe('Dev Containers CLI', function () {
 			assert.equal('value with $dollar sign', envWithDollar.stdout);
 
 			const envWithBackSlash = await shellExec(`docker exec ${containerId} bash -c 'echo -n $VAR_WITH_BACK_SLASH'`);
-			assert.equal('value with \\back slash', envWithBackSlash.stdout);	
+			assert.equal('value with \\back slash', envWithBackSlash.stdout);
 
 			await shellExec(`docker rm -f ${containerId}`);
-		});		
+		});
 
 		it('should run with config in subfolder', async () => {
 			const upRes = await shellExec(`${cli} up --workspace-folder ${__dirname}/configs/dockerfile-without-features --config ${__dirname}/configs/dockerfile-without-features/.devcontainer/subfolder/devcontainer.json`);

--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -14,7 +14,7 @@ const pkg = require('../../../package.json');
 describe('Lockfile', function () {
 	this.timeout('240s');
 
-	const tmp = path.relative(process.cwd(), path.join(__dirname, 'tmp'));
+	const tmp = path.join(__dirname, 'tmp');
 	const cli = `npx --prefix ${tmp} devcontainer`;
 
 	before('Install', async () => {
@@ -125,7 +125,7 @@ describe('Lockfile', function () {
 		assert.strictEqual(foo.latestMajor, '2');
 	});
 
-	it('outdated command with text output', async () => {
+	it.only('outdated command with text output', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
 
 		const res = await shellExec(`${cli} outdated --workspace-folder ${workspaceFolder} --output-format text`);
@@ -150,6 +150,20 @@ describe('Lockfile', function () {
 		assert.ok(!response.includes('mylocalfeature'));
 		assert.ok(!response.includes('terraform'));
 		assert.ok(!response.includes('myfeatures'));
+	});
+	
+	it.only('outdated command without workspace', async () => {
+		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
+
+		const res = await shellExec(`${cli} outdated  --output-format text`, { cwd: workspaceFolder });
+		const response = res.stdout;
+		// Count number of lines of output
+		assert.strictEqual(response.split('\n').length, 7); // 5 valid Features + header + empty line
+
+		// Check that the header is present
+		assert.ok(response.includes('Current'), 'Current column is missing');
+		assert.ok(response.includes('Wanted'), 'Wanted column is missing');
+		assert.ok(response.includes('Latest'), 'Latest column is missing');
 	});
 
 	it('upgrade command', async () => {

--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -92,7 +92,7 @@ describe('Lockfile', function () {
 
 		const res = await shellExec(`${cli} outdated --workspace-folder ${workspaceFolder} --output-format json`);
 		const response = JSON.parse(res.stdout);
-		
+
 		const git = response.features['ghcr.io/devcontainers/features/git:1.0'];
 		assert.ok(git);
 		assert.strictEqual(git.current, '1.0.4');
@@ -125,7 +125,7 @@ describe('Lockfile', function () {
 		assert.strictEqual(foo.latestMajor, '2');
 	});
 
-	it.only('outdated command with text output', async () => {
+	it'outdated command with text output', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
 
 		const res = await shellExec(`${cli} outdated --workspace-folder ${workspaceFolder} --output-format text`);
@@ -151,8 +151,8 @@ describe('Lockfile', function () {
 		assert.ok(!response.includes('terraform'));
 		assert.ok(!response.includes('myfeatures'));
 	});
-	
-	it.only('outdated command without workspace', async () => {
+
+	it'outdated command without workspace', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
 
 		const res = await shellExec(`${cli} outdated  --output-format text`, { cwd: workspaceFolder });

--- a/src/test/container-features/lockfile.test.ts
+++ b/src/test/container-features/lockfile.test.ts
@@ -125,7 +125,7 @@ describe('Lockfile', function () {
 		assert.strictEqual(foo.latestMajor, '2');
 	});
 
-	it'outdated command with text output', async () => {
+	it('outdated command with text output', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
 
 		const res = await shellExec(`${cli} outdated --workspace-folder ${workspaceFolder} --output-format text`);
@@ -152,7 +152,7 @@ describe('Lockfile', function () {
 		assert.ok(!response.includes('myfeatures'));
 	});
 
-	it'outdated command without workspace', async () => {
+	it('outdated command without workspace', async () => {
 		const workspaceFolder = path.join(__dirname, 'configs/lockfile-outdated-command');
 
 		const res = await shellExec(`${cli} outdated  --output-format text`, { cwd: workspaceFolder });

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -59,8 +59,8 @@ export interface BufferExecResult {
     signal?: string | null;
 }
 
-export async function shellBufferExec(command: string, options: { stdin?: Buffer } = {}): Promise<BufferExecResult> {
-    const exec = await plainExec(undefined);
+export async function shellBufferExec(command: string, options: { stdin?: Buffer, cwd?: string } = {}): Promise<BufferExecResult> {
+    const exec = await plainExec(options.cwd);
     return runCommandNoPty({
         exec,
         cmd: '/bin/sh',


### PR DESCRIPTION
This basically makes the equivalent of `--workspace-folder .` the default.

I'd imagine that this is 99% of use cases already, and those that need something else will know they need something else.

I think I covered all the commands this would apply to with the tests.