### PR TITLE
adding example-usage/tool-vscodium-server/ --- Allow VSCodium as client <-> devcontainer running vscodium server

### DIFF
--- a/example-usage/tool-vscodium-server/server/init-vscodium-server.sh
+++ b/example-usage/tool-vscodium-server/server/init-vscodium-server.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -xe
+
+# Default version - should be updated periodically
+VSCODIUM_VERSION="1.96.4.25017"
+INSTALL_LOCATION="$HOME/.vscodium-server"
+
+if [ ! -e "$INSTALL_LOCATION/bin" ]; then
+    echo "Downloading VSCodium Remote Server..."
+    mkdir -p "$INSTALL_LOCATION"
+    curl -fsSL "https://github.com/VSCodium/vscodium/releases/download/${VSCODIUM_VERSION}/vscodium-reh-linux-x64-${VSCODIUM_VERSION}.tar.gz" -o /tmp/vscodium-server.tar.gz
+    echo "Extracting..."
+    tar --strip 1 -xzf /tmp/vscodium-server.tar.gz -C "$INSTALL_LOCATION"
+    rm -f /tmp/vscodium-server.tar.gz
+    chmod +x "$INSTALL_LOCATION/bin/codium-server"
+fi
+
+if ! pidof codium-server > /dev/null 2>&1; then
+    # Process customizations and features configuration
+    if ! type jq > /dev/null 2>&1; then
+        sudo apt-get -y install jq
+    fi
+    
+    tmp_dir="$(mktemp -d)"
+    mkdir -p "${tmp_dir}" "$HOME/.vscodium-server/data/Machine"
+
+    # Get list of extensions
+    extensions=( $(jq -r -M '[
+        .mergedConfiguration.customizations?.vscodium[]?.extensions[]?,
+        .mergedConfiguration.extensions[]?
+        ] | .[]
+    ' /server/configuration.json ) )
+
+    # Install extensions if any are specified
+    if [ "${extensions[0]}" != "" ] && [ "${extensions[0]}" != "null" ] ; then
+        set +e
+        for extension in "${extensions[@]}"; do
+            "$INSTALL_LOCATION/bin/codium-server" --install-extension "${extension}"
+        done
+        set -e
+    fi
+
+    # Get VSCodium/VS Code settings
+    settings="$(jq -M '[
+        .mergedConfiguration.customizations?.vscodium[]?.settings?,
+        .mergedConfiguration.settings?
+        ] | add
+    ' /server/configuration.json)"
+
+    # Apply settings if any are specified
+    if [ "${settings}" != "" ] && [ "${settings}" != "null" ]; then
+        echo "${settings}" > "$HOME/.vscodium-server/data/Machine/settings.json"
+    fi
+
+    rm -rf "${tmp_dir}" /server/configuration.json
+
+    # Start VSCodium server
+    echo "Starting VSCodium Remote Server..."
+    "$INSTALL_LOCATION/bin/codium-server" --host 0.0.0.0 --port 8000 --without-connection-token --accept-server-license-terms
+else
+    echo -e "\nVSCodium server is already running.\n\nConnect using: http://localhost:8000\n"
+fi

--- a/example-usage/tool-vscodium-server/start.sh
+++ b/example-usage/tool-vscodium-server/start.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -xe
+
+cd "$(dirname $0)"
+pwd
+
+remove_flag=""
+if [ "$1" = "true" ]; then
+    remove_flag="--remove-existing-container"
+fi
+
+chmod +x server/init-vscodium-server.sh
+
+npm install -g @devcontainers/cli
+
+
+# Resolves any variables like ${containerWorkspaceFolder}
+# Processes any referenced configurations
+# Expands environment variables
+# etc.
+# Save off effective config for use in the container
+devcontainer read-configuration --include-merged-configuration --log-format json --workspace-folder ../workspace > server/configuration.json
+
+# Mount server script and start container. The .devcontainer/ folder is under ../workspace.  We need to be there.
+# devcontainer up $remove_flag --mount "type=bind,source=$(pwd)/server,target=/server" \
+#     --workspace-mount type=bind,source=/workspaces/devcontainers-cli-fork/example-usage/workspace,target=/workspace \
+#     --workspace-folder ../workspace
+
+devcontainer up $remove_flag --mount "type=bind,source=$(pwd)/server,target=/server" \
+    --mount type=bind,source=$(realpath ../workspace),target=/workspace \
+    --workspace-folder ../workspace
+
+
+# Initialize VSCodium server (wont return until server is stopped)
+devcontainer exec --workspace-folder ../workspace /server/init-vscodium-server.sh

--- a/example-usage/tool-vscodium-server/tool-vscodium-server_README.md
+++ b/example-usage/tool-vscodium-server/tool-vscodium-server_README.md
@@ -1,0 +1,109 @@
+# VSCodium Remote Server Example
+
+This example demonstrates how to use VSCodium's Remote Server with Dev Containers. It provides a fully open-source alternative to the VS Code Server.
+
+## Usage
+
+1. Start the container with VSCodium Remote Server:
+   ```bash
+   ./start.sh
+   ```
+
+2. Access VSCodium Remote Server in your browser:
+   ```
+   http://localhost:8000
+   ```
+
+If you want to recreate the container (e.g., when switching between different server examples), use:
+```bash
+./start.sh true
+```
+
+## Configuration
+
+The server supports the following customization options in your `devcontainer.json`:
+
+```jsonc
+{
+    "customizations": {
+        "vscodium": {
+            "settings": {
+                // VSCodium/VS Code settings here
+            },
+            "extensions": [
+                // Extension IDs here
+            ]
+        }
+    }
+}
+```
+
+Note: The server also respects VS Code settings under the `vscode` customization key for compatibility.
+
+## Environment Variables
+
+- `VSCODIUM_VERSION`: Set this to use a specific version of VSCodium Remote Server (defaults to latest stable)
+
+## Features
+
+- VSCodium Remote Server support
+- Extension installation support
+- Settings synchronization
+- Compatible with many VS Code settings and extensions
+- Open-source alternative to VS Code Server
+
+- Serves client vscodium 
+-  
+
+## vscodium client settings 
+
+Must install the "remote oss (xaberus)" extension installed. The extension ID is `xaberus.remote-oss`. See  https://github.com/xaberus/vscode-remote-oss/blob/main/README.md for general explanation.
+
+- The vscodium version used for this test is `VSCODIUM_VERSION="1.96.4.25017"`.
+- The client version and the remote server version number must be the same.
+- To match the server settings in `/example-usage/tool-vscodium-server/` these client vscodium settings will suffice:
+
+`~/.config/VSCodium/User/settings.json`
+```json
+{
+    "remote.OSS.hosts": [
+        {
+            "type": "manual",
+            "name": "vscodium-server",
+            "host": "localhost",
+            "port": 8000,
+            "connectionToken": "false",
+            "folders": [
+                {
+                    "name": "workspace",
+                    "path": "/workspace"
+                }
+            ]
+        }
+    ],
+}
+```
+
+`~/.vscode-oss/argv.json`
+```json
+{
+    "enable-crash-reporter": false,
+    "enable-proposed-api": [
+        "xaberus.remote-oss"
+    ]
+}
+```
+
+## Test
+
+After successfully conection from the client, the bottom left connection icon should say 
+```
+remoss-server
+```
+
+In a vscoddium terminal window, `cd /workspace`, then 
+```
+vscode ➜ /workspace $ go run main.go
+Hello world!
+```
+

--- a/example-usage/workspace/.devcontainer/devcontainer.json
+++ b/example-usage/workspace/.devcontainer/devcontainer.json
@@ -22,6 +22,13 @@
 				"streetsidesoftware.code-spell-checker"
 			],
 			"settings": { }
+		},
+		// 👇 Config only used for vscodium-server
+		"vscodium": {
+			"extensions": [
+				"streetsidesoftware.code-spell-checker"
+			],
+			"settings": { }
 		}
 	},
 	


### PR DESCRIPTION
Changes to be committed:
	new file:   example-usage/tool-vscodium-server/server/init-vscodium-server.sh
	new file:   example-usage/tool-vscodium-server/start.sh
	new file:   example-usage/tool-vscodium-server/tool-vscodium-server_README.md
	modified:   example-usage/workspace/.devcontainer/devcontainer.json