### PR TITLE
feat: env var to define control manifest url

### DIFF
--- a/src/spec-configuration/controlManifest.ts
+++ b/src/spec-configuration/controlManifest.ts
@@ -82,9 +82,10 @@ async function updateControlManifest(controlManifestPath: string, oldManifest: D
 }
 
 async function fetchControlManifest(output: Log) {
+	const controlManifestURL = process.env.DEVCONTAINERS_CONTROL_MANIFEST_URL ?? 'https://containers.dev/static/devcontainer-control-manifest.json';
 	return request({
 		type: 'GET',
-		url: 'https://containers.dev/static/devcontainer-control-manifest.json',
+		url: controlManifestURL,
 		headers: {
 			'user-agent': 'devcontainers-vscode',
 			'accept': 'application/json',


### PR DESCRIPTION
When using dev containers inside an air gapped environment, this PR make possible to define an internal URL to download control manifest.