### PR TITLE
Adding precautionary check for DockerHub registry availability in dev container cli

### DIFF
--- a/src/spec-node/containerFeatures.ts
+++ b/src/spec-node/containerFeatures.ts
@@ -11,7 +11,7 @@ import { LogLevel, makeLog } from '../spec-utils/log';
 import { FeaturesConfig, getContainerFeaturesBaseDockerFile, getFeatureInstallWrapperScript, getFeatureLayers, getFeatureMainValue, getFeatureValueObject, generateFeaturesConfig, Feature, generateContainerEnvs } from '../spec-configuration/containerFeaturesConfiguration';
 import { readLocalFile } from '../spec-utils/pfs';
 import { includeAllConfiguredFeatures } from '../spec-utils/product';
-import { createFeaturesTempFolder, DockerResolverParameters, getCacheFolder, getFolderImageName, getEmptyContextFolder, SubstitutedConfig, ensureDockerfileFrontendAccessible } from './utils';
+import { createFeaturesTempFolder, DockerResolverParameters, getCacheFolder, getFolderImageName, getEmptyContextFolder, SubstitutedConfig, ensureDockerHubImageAccessible } from './utils';
 import { isEarlierVersion, parseVersion, runCommandNoPty } from '../spec-common/commonUtils';
 import { getDevcontainerMetadata, getDevcontainerMetadataLabel, getImageBuildInfoFromImage, ImageBuildInfo, ImageMetadataEntry, imageMetadataLabel, MergedDevContainerConfig } from './imageMetadata';
 import { supportsBuildContexts } from './dockerfileUtils';
@@ -195,7 +195,7 @@ export interface ImageBuildOptions {
 
 async function getImageBuildOptions(params: DockerResolverParameters, config: SubstitutedConfig<DevContainerConfig>, dstFolder: string, baseName: string, imageBuildInfo: ImageBuildInfo): Promise<ImageBuildOptions> {
     const syntax = imageBuildInfo.dockerfile?.preamble.directives.syntax;
-    const dockerHubAccessible = syntax ? await ensureDockerfileFrontendAccessible(params, 'docker/dockerfile', '1.4') : false;
+    const dockerHubAccessible = syntax ? await ensureDockerHubImageAccessible(params, 'docker/dockerfile', '1.4') : false;
     return {
         dstFolder,
         dockerfileContent: `
@@ -265,7 +265,7 @@ async function getFeaturesBuildOptions(params: DockerResolverParameters, devCont
 		;
     const syntax = imageBuildInfo.dockerfile?.preamble.directives.syntax;
     const omitSyntaxDirective = common.omitSyntaxDirective; // Can be removed when https://github.com/moby/buildkit/issues/4556 is fixed
-    const dockerHubAccessible = !omitSyntaxDirective ? await ensureDockerfileFrontendAccessible(params, 'docker/dockerfile', '1.4') : false;
+    const dockerHubAccessible = !omitSyntaxDirective ? await ensureDockerHubImageAccessible(params, 'docker/dockerfile', '1.4') : false;
     const dockerfilePrefixContent = `${omitSyntaxDirective ? '' :
         useBuildKitBuildContexts && dockerHubAccessible && !(imageBuildInfo.dockerfile && supportsBuildContexts(imageBuildInfo.dockerfile)) ? '# syntax=docker/dockerfile:1.4' :
         syntax ? `# syntax=${syntax}` : ''}

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -619,7 +619,7 @@ function getDockerHubRegistryUrl(imageName: string, version: string): string {
   return `https://registry-1.docker.io/v2/${imageName}/manifests/${version}`;
 }
 
-async function checkDockerfileFrontendAccessible(params: DockerResolverParameters, imageName: string, version: string): Promise<void> {
+async function checkDockerHubImageAccessible(params: DockerResolverParameters, imageName: string, version: string): Promise<void> {
   const { output } = params.common;
   
   const authUrl = getDockerHubAuthUrl(imageName, version);
@@ -659,11 +659,11 @@ async function checkDockerfileFrontendAccessible(params: DockerResolverParameter
   }
 }
 
-export async function ensureDockerfileFrontendAccessible(params: DockerResolverParameters, imageName: string, version: string): Promise<boolean> {
+export async function ensureDockerHubImageAccessible(params: DockerResolverParameters, imageName: string, version: string): Promise<boolean> {
   const { output } = params.common;
   try {
     await retry(
-      async () => { await checkDockerfileFrontendAccessible(params, imageName, version); },
+      async () => { await checkDockerHubImageAccessible(params, imageName, version); },
       { maxRetries: DOCKERFILE_FRONTEND_CHECK_MAX_RETRIES, retryIntervalMilliseconds: DOCKERFILE_FRONTEND_CHECK_RETRY_INTERVAL_MS, output }
     );
     output.write('Dockerfile frontend is accessible in DockerHub registry.', LogLevel.Info);


### PR DESCRIPTION
Ref: https://github.com/github/codespaces/issues/22031

**Description of changes:** 

- The above codespace availability incident was created to address the multiple outages noticed in DockerHub registry which caused downtime for codepaces as devcontainer up and build commands injects syntax directive `# syntax=docker/dockerfile:1.4` which forces devcontainer cli to download `docker/dockerfile:1.4` parser image from DockerHub registry. This change was added in [PR](https://github.com/devcontainers/cli/pull/13) with #syntax directives + buildkit + user namespace remapping by auto-injecting the #syntax directive in dev container build. This is not required for docker engine version v23 onwards as the default moby buildkit version includes `docker/dockerfile:1.4` or higher version of the parser. As part of this PR adding precautionary check to call DockerHub registry URL and confirm the availability before auto-injecting the #syntax directive. 

**Changelog:**

- Changed `src/spec-node/utils.ts` by changing the faulty error logging in retry function. 
- Added a new precautionary check as described above, in `src/spec-node/containerFeatures.ts` file. 

**Checklist:**
- [x] All checks are passed. 