### PR TITLE
Explictly set platform flag to prevent mismatches and errors for `docker` commands

### DIFF
--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 
-import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, getDockerfilePath, getDockerContextPath, DockerResolverParameters, isDockerFileConfig, uriToWSLFsPath, WorkspaceConfiguration, getFolderImageName, inspectDockerImage, logUMask, SubstitutedConfig, checkDockerSupportForGPU, isBuildKitImagePolicyError, isBuildxCacheToInline } from './utils';
+import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, getDockerfilePath, getDockerContextPath, DockerResolverParameters, isDockerFileConfig, uriToWSLFsPath, WorkspaceConfiguration, getFolderImageName, inspectDockerImage, logUMask, SubstitutedConfig, checkDockerSupportForGPU, isBuildKitImagePolicyError, isBuildxCacheToInline, toPlatformString } from './utils';
 import { ContainerProperties, setupInContainer, ResolverProgress, ResolverParameters } from '../spec-common/injectHeadless';
 import { ContainerError, toErrorText } from '../spec-common/errors';
 import { ContainerDetails, listContainers, DockerCLIParameters, inspectContainers, dockerCLI, dockerPtyCLI, toPtyExecParameters, ImageDetails, toExecParameters, removeContainer } from '../spec-shutdown/dockerUtils';
@@ -405,11 +405,13 @@ while sleep 1 & wait $!; do :; done`, '-']; // `wait $!` allows for the `trap` t
 		cmd.push(...details.Config.Cmd || []);
 	}
 
+	const platformArgs = ['--platform', toPlatformString(params.platformInfo)];
 	const args = [
 		'run',
 		'--sig-proxy=false',
 		'-a', 'STDOUT',
 		'-a', 'STDERR',
+		...platformArgs,
 		...exposed,
 		...cwdMount,
 		...additionalMount,

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -240,6 +240,11 @@ export function isBuildKitImagePolicyError(err: any): boolean {
 		|| (errStderr && typeof errStderr === 'string' && (errStderr.includes(imagePolicyErrorString) || errStderr.includes(sourceDeniedString)));
 }
 
+export function toPlatformString(platformInfo: PlatformInfo): string {
+	const base = `${platformInfo.os}/${platformInfo.arch}`;
+	return platformInfo.variant ? `${base}/${platformInfo.variant}` : base;
+}
+
 export async function inspectDockerImage(params: DockerResolverParameters | DockerCLIParameters, imageName: string, pullImageOnError: boolean) {
 	try {
 		return await inspectImage(params, imageName);
@@ -254,7 +259,8 @@ export async function inspectDockerImage(params: DockerResolverParameters | Dock
 			output.write(`Error fetching image details: ${err2?.message}`);
 		}
 		try {
-			await retry(async () => dockerPtyCLI(params, 'pull', imageName), { maxRetries: 5, retryIntervalMilliseconds: 1000, output });
+			const platformString = toPlatformString(params.platformInfo);
+			await retry(async () => dockerPtyCLI(params, 'pull', '--platform', platformString, imageName), { maxRetries: 5, retryIntervalMilliseconds: 1000, output });
 		} catch (_err) {
 			if (err.stdout) {
 				output.write(err.stdout.toString());


### PR DESCRIPTION
We've seen an uptick of errors like these being reported from various Codespaces (https://github.com/microsoft/CopilotAdventures/issues/39). A user was able to [fix this](https://github.com/heckenmann/docker-swarm-dashboard/pull/934/changes) by explicitly setting the `--platform=linux/amd64` runArg for docker. This PR adds that for all relevant docker commands to see if this will help fix the issue.

```
Configuration starting...
Cloning...
Creating container...
$ devcontainer up --id-label Type=codespaces --workspace-folder /var/lib/docker/codespacemount/workspace/CopilotAdventures --mount type=bind,source=/.codespaces/agent/mount/cache,target=/vscode --user-data-folder /var/lib/docker/codespacemount/.persistedshare --container-data-folder .vscode-remote/data/Machine --container-system-data-folder /var/vscode-remote --log-level trace --log-format json --update-remote-user-uid-default never --mount-workspace-git-root false --omit-config-remote-env-from-metadata --skip-non-blocking-commands --skip-post-create --config "/var/lib/docker/codespacemount/workspace/CopilotAdventures/.devcontainer/devcontainer.json" --override-config /root/.codespaces/shared/merged_devcontainer.json --default-user-env-probe loginInteractiveShell --container-session-data-folder /workspaces/.codespaces/.persistedshare/devcontainers-cli/cache --secrets-file /root/.codespaces/shared/user-secrets-envs.json
[165 ms] @devcontainers/cli 0.80.3. Node.js v18.20.6. linux 6.8.0-1030-azure x64.
{"outcome":"error","message":"Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/dotnet:8.0-noble","description":"An error occurred setting up the container."}
Error: Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/dotnet:8.0-noble
    at y6 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:467:1253)
    at Cx (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:467:997)
    at async P6 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:485:3842)
    at async CC (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:485:4957)
    at async w7 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:666:202)
    at async D7 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:665:14804)
    at async /.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:485:1188
devcontainer process exited with exit code 1
Failed to create container.
Error: Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/dotnet:8.0-noble
Error code: 1302 (UnifiedContainersErrorFatalCreatingContainer)
Container creation failed.

Creating recovery container.
Creating container...
$ devcontainer up --id-label Type=codespaces --workspace-folder /var/lib/docker/codespacemount/workspace/CopilotAdventures --mount type=bind,source=/.codespaces/agent/mount/cache,target=/vscode --user-data-folder /var/lib/docker/codespacemount/.persistedshare --container-data-folder .vscode-remote/data/Machine --container-system-data-folder /var/vscode-remote --log-level trace --log-format json --update-remote-user-uid-default never --mount-workspace-git-root false --omit-config-remote-env-from-metadata --skip-non-blocking-commands --skip-post-create --config "/var/lib/docker/codespacemount/workspace/CopilotAdventures/.devcontainer/devcontainer.json" --override-config /root/.codespaces/shared/merged_devcontainer.json --default-user-env-probe loginInteractiveShell --container-session-data-folder /workspaces/.codespaces/.persistedshare/devcontainers-cli/cache --secrets-file /root/.codespaces/shared/user-secrets-envs.json
[154 ms] @devcontainers/cli 0.80.3. Node.js v18.20.6. linux 6.8.0-1030-azure x64.
{"outcome":"error","message":"Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/base:alpine","description":"An error occurred setting up the container."}
Error: Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/base:alpine
    at y6 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:467:1253)
    at Cx (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:467:997)
    at async P6 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:485:3842)
    at async CC (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:485:4957)
    at async w7 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:666:202)
    at async D7 (/.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:665:14804)
    at async /.codespaces/agent/bin/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:485:1188
devcontainer process exited with exit code 1
Failed to create container.
Error: Command failed: docker inspect --type image mcr.microsoft.com/devcontainers/base:alpine
Error code: 1302 (UnifiedContainersErrorFatalCreatingContainer)
```