### PR TITLE
Inline buildx global build and target platform envvars when resolving base image and user

### DIFF
--- a/src/spec-node/configContainer.ts
+++ b/src/spec-node/configContainer.ts
@@ -60,7 +60,7 @@ async function resolveWithLocalFolder(params: DockerResolverParameters, parsedAu
 
 	const { dockerCLI, dockerComposeCLI } = params;
 	const { env } = common;
-	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output, platformInfo: params.platformInfo };
+	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output, buildPlatformInfo: params.buildPlatformInfo, targetPlatformInfo: params.targetPlatformInfo };
 	await ensureNoDisallowedFeatures(cliParams, config, additionalFeatures, idLabels);
 
 	await runInitializeCommand({ ...params, common: { ...common, output: common.lifecycleHook.output } }, config.initializeCommand, common.lifecycleHook.onDidInput);

--- a/src/spec-node/devContainers.ts
+++ b/src/spec-node/devContainers.ts
@@ -172,7 +172,12 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		output: common.output,
 	}, dockerPath, dockerComposePath);
 
-	const platformInfo = (() => {
+	const buildPlatformInfo = {
+		os: mapNodeOSToGOOS(cliHost.platform),
+		arch: mapNodeArchitectureToGOARCH(cliHost.arch),
+	};
+
+	const targetPlatformInfo = (() => {
 		if (common.buildxPlatform) {
 			const slash1 = common.buildxPlatform.indexOf('/');
 			const slash2 = common.buildxPlatform.indexOf('/', slash1 + 1);
@@ -204,7 +209,8 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		dockerComposeCLI,
 		env: cliHost.env,
 		output,
-		platformInfo
+		buildPlatformInfo,
+		targetPlatformInfo
 	}));
 
 	const dockerEngineVer = await dockerEngineVersion({
@@ -213,7 +219,8 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		dockerComposeCLI,
 		env: cliHost.env,
 		output,
-		platformInfo
+		buildPlatformInfo,
+		targetPlatformInfo
 	});	
 
 	return {
@@ -246,7 +253,8 @@ export async function createDockerParams(options: ProvisionOptions, disposables:
 		additionalLabels: options.additionalLabels,
 		buildxOutput: common.buildxOutput,
 		buildxCacheTo: common.buildxCacheTo,
-		platformInfo
+		buildPlatformInfo,
+		targetPlatformInfo
 	};
 }
 

--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -641,7 +641,7 @@ async function doBuild({
 			throw new ContainerError({ description: '--push true cannot be used with --output.' });
 		}
 
-		const buildParams: DockerCLIParameters = { cliHost, dockerCLI: params.dockerCLI, dockerComposeCLI, env, output, platformInfo: params.platformInfo };
+		const buildParams: DockerCLIParameters = { cliHost, dockerCLI: params.dockerCLI, dockerComposeCLI, env, output, buildPlatformInfo: params.buildPlatformInfo, targetPlatformInfo: params.targetPlatformInfo };
 		await ensureNoDisallowedFeatures(buildParams, config, additionalFeatures, undefined);
 
 		// Support multiple use of `--image-name`
@@ -1058,16 +1058,18 @@ async function readConfiguration({
 			env: cliHost.env,
 			output,
 		}, dockerCLI, dockerComposePath || 'docker-compose');
+		const buildPlatformInfo = {
+			os: mapNodeOSToGOOS(cliHost.platform),
+			arch: mapNodeArchitectureToGOARCH(cliHost.arch),
+		};
 		const params: DockerCLIParameters = {
 			cliHost,
 			dockerCLI,
 			dockerComposeCLI,
 			env: cliHost.env,
 			output,
-			platformInfo: {
-				os: mapNodeOSToGOOS(cliHost.platform),
-				arch: mapNodeArchitectureToGOARCH(cliHost.arch),
-			}
+			buildPlatformInfo,
+			targetPlatformInfo: buildPlatformInfo
 		};
 		const { container, idLabels } = await findContainerAndIdLabels(params, containerId, providedIdLabels, workspaceFolder, configPath?.fsPath);
 		if (container) {

--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -27,7 +27,7 @@ const serviceLabel = 'com.docker.compose.service';
 export async function openDockerComposeDevContainer(params: DockerResolverParameters, workspace: Workspace, config: SubstitutedConfig<DevContainerFromDockerComposeConfig>, idLabels: string[], additionalFeatures: Record<string, string | boolean | Record<string, string | boolean>>): Promise<ResolverResult> {
 	const { common, dockerCLI, dockerComposeCLI } = params;
 	const { cliHost, env, output } = common;
-	const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output, platformInfo: params.platformInfo };
+	const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env, output, buildPlatformInfo: params.buildPlatformInfo, targetPlatformInfo: params.targetPlatformInfo };
 	return _openDockerComposeDevContainer(params, buildParams, workspace, config, getRemoteWorkspaceFolder(config.config), idLabels, additionalFeatures);
 }
 
@@ -155,7 +155,7 @@ export async function buildAndExtendDockerCompose(configWithRaw: SubstitutedConf
 	const { cliHost, env, output } = common;
 	const { config } = configWithRaw;
 
-	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI: dockerComposeCLIFunc, env, output, platformInfo: params.platformInfo };
+	const cliParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI: dockerComposeCLIFunc, env, output, buildPlatformInfo: params.buildPlatformInfo, targetPlatformInfo: params.targetPlatformInfo };
 	const composeConfig = await readDockerComposeConfig(cliParams, localComposeFiles, envFile);
 	const composeService = composeConfig.services[config.service];
 

--- a/src/spec-node/dockerfileUtils.ts
+++ b/src/spec-node/dockerfileUtils.ts
@@ -81,7 +81,7 @@ export function extractDockerfile(dockerfile: string): Dockerfile {
 	} as Dockerfile;
 }
 
-export function findUserStatement(dockerfile: Dockerfile, buildArgs: Record<string, string>, baseImageEnv: Record<string, string>, target: string | undefined) {
+export function findUserStatement(dockerfile: Dockerfile, buildArgs: Record<string, string>, baseImageEnv: Record<string, string>, globalBuildxPlatformArgs: Record<string, string> = {}, target: string | undefined) {
 	let stage: Stage | undefined = target ? dockerfile.stagesByLabel[target] : dockerfile.stages[dockerfile.stages.length - 1];
 	const seen = new Set<Stage>();
 	while (stage) {
@@ -92,9 +92,9 @@ export function findUserStatement(dockerfile: Dockerfile, buildArgs: Record<stri
 
 		const i = findLastIndex(stage.instructions, i => i.instruction === 'USER');
 		if (i !== -1) {
-			return replaceVariables(dockerfile, buildArgs, baseImageEnv, stage.instructions[i].name, stage, i) || undefined;
+			return replaceVariables(dockerfile, buildArgs, baseImageEnv, globalBuildxPlatformArgs, stage.instructions[i].name, stage, i) || undefined;
 		}
-		const image = replaceVariables(dockerfile, buildArgs, baseImageEnv, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
+		const image = replaceVariables(dockerfile, buildArgs, baseImageEnv, globalBuildxPlatformArgs, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
 		stage = dockerfile.stagesByLabel[image];
 	}
 	return undefined;
@@ -109,7 +109,7 @@ export function findBaseImage(dockerfile: Dockerfile, buildArgs: Record<string, 
 		}
 		seen.add(stage);
 
-		const image = replaceVariables(dockerfile, buildArgs, globalBuildxPlatformArgs, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
+		const image = replaceVariables(dockerfile, buildArgs, /* not available in FROM instruction */ {}, globalBuildxPlatformArgs, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
 		const nextStage = dockerfile.stagesByLabel[image];
 		if (!nextStage) {
 			return image;
@@ -155,12 +155,12 @@ function getExpressionValue(option: string, isSet: boolean, word: string, value:
 	return operations[option](isSet, word, value).replace(/^['"]|['"]$/g, ''); // remove quotes from start and end of the string
 }
 
-function replaceVariables(dockerfile: Dockerfile, buildArgs: Record<string, string>, baseImageEnv: Record<string, string>, str: string, stage: { from?: From; instructions: Instruction[] }, beforeInstructionIndex: number) {			
+function replaceVariables(dockerfile: Dockerfile, buildArgs: Record<string, string>, baseImageEnv: Record<string, string>, globalBuildxPlatformArgs: Record<string, string> = {}, str: string, stage: { from?: From; instructions: Instruction[] }, beforeInstructionIndex: number) {			
 	return [...str.matchAll(argumentExpression)]
 		.map(match => {
 			const variable = match.groups!.variable;
 			const isVarExp = match.groups!.isVarExp ? true : false;
-			let value = findValue(dockerfile, buildArgs, baseImageEnv, variable, stage, beforeInstructionIndex) || '';
+			let value = findValue(dockerfile, buildArgs, baseImageEnv, globalBuildxPlatformArgs, variable, stage, beforeInstructionIndex) || '';
 			if (isVarExp) {
 				// Handle replacing variable expressions (${var:+word}) if they exist
 				const option = match.groups!.option;
@@ -178,7 +178,7 @@ function replaceVariables(dockerfile: Dockerfile, buildArgs: Record<string, stri
 		.reduce((str, { begin, end, value }) => str.substring(0, begin) + value + str.substring(end), str);
 }
 
-function findValue(dockerfile: Dockerfile, buildArgs: Record<string, string>, baseImageEnv: Record<string, string>, variable: string, stage: { from?: From; instructions: Instruction[] }, beforeInstructionIndex: number): string | undefined {
+function findValue(dockerfile: Dockerfile, buildArgs: Record<string, string>, baseImageEnv: Record<string, string>, globalBuildxPlatformArgs: Record<string, string> = {}, variable: string, stage: { from?: From; instructions: Instruction[] }, beforeInstructionIndex: number): string | undefined {
 	let considerArg = true;
 	const seen = new Set<typeof stage>();
 	while (true) {
@@ -191,22 +191,22 @@ function findValue(dockerfile: Dockerfile, buildArgs: Record<string, string>, ba
 		if (i !== -1) {
 			const instruction = stage.instructions[i];
 			if (instruction.instruction === 'ENV') {
-				return replaceVariables(dockerfile, buildArgs, baseImageEnv, instruction.value!, stage, i);
+				return replaceVariables(dockerfile, buildArgs, baseImageEnv, globalBuildxPlatformArgs, instruction.value!, stage, i);
 			}
 			if (instruction.instruction === 'ARG') {
-				return replaceVariables(dockerfile, buildArgs, baseImageEnv, buildArgs[instruction.name] ?? instruction.value, stage, i);
+				return replaceVariables(dockerfile, buildArgs, baseImageEnv, globalBuildxPlatformArgs, buildArgs[instruction.name] ?? instruction.value, stage, i);
 			}
 		}
 
 		if (!stage.from) {
-			const value = baseImageEnv[variable];
+			const value = baseImageEnv[variable] ?? globalBuildxPlatformArgs[variable];
 			if (typeof value === 'string') {
 				return value;
 			}
 			return undefined;
 		}
 
-		const image = replaceVariables(dockerfile, buildArgs, baseImageEnv, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
+		const image = replaceVariables(dockerfile, buildArgs, baseImageEnv, globalBuildxPlatformArgs, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
 		stage = dockerfile.stagesByLabel[image] || dockerfile.preamble;
 		beforeInstructionIndex = stage.instructions.length;
 		considerArg = stage === dockerfile.preamble;

--- a/src/spec-node/dockerfileUtils.ts
+++ b/src/spec-node/dockerfileUtils.ts
@@ -100,7 +100,7 @@ export function findUserStatement(dockerfile: Dockerfile, buildArgs: Record<stri
 	return undefined;
 }
 
-export function findBaseImage(dockerfile: Dockerfile, buildArgs: Record<string, string>, target: string | undefined) {
+export function findBaseImage(dockerfile: Dockerfile, buildArgs: Record<string, string>, target: string | undefined, globalBuildxPlatformArgs: Record<string, string> = {}) {
 	let stage: Stage | undefined = target ? dockerfile.stagesByLabel[target] : dockerfile.stages[dockerfile.stages.length - 1];
 	const seen = new Set<Stage>();
 	while (stage) {
@@ -109,7 +109,7 @@ export function findBaseImage(dockerfile: Dockerfile, buildArgs: Record<string, 
 		}
 		seen.add(stage);
 
-		const image = replaceVariables(dockerfile, buildArgs, /* not available in FROM instruction */ {}, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
+		const image = replaceVariables(dockerfile, buildArgs, globalBuildxPlatformArgs, stage.from.image, dockerfile.preamble, dockerfile.preamble.instructions.length);
 		const nextStage = dockerfile.stagesByLabel[image];
 		if (!nextStage) {
 			return image;

--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ContainerError } from '../spec-common/errors';
+import { PlatformInfo } from '../spec-common/commonUtils';
 import { LifecycleCommand, LifecycleHooksInstallMap } from '../spec-common/injectHeadless';
 import { DevContainerConfig, DevContainerConfigCommand, DevContainerFromDockerComposeConfig, DevContainerFromDockerfileConfig, DevContainerFromImageConfig, getDockerComposeFilePaths, getDockerfilePath, HostGPURequirements, HostRequirements, isDockerFileConfig, PortAttributes, UserEnvProbe } from '../spec-configuration/configuration';
 import { Feature, FeaturesConfig, Mount, parseMount, SchemaFeatureLifecycleHooks } from '../spec-configuration/containerFeaturesConfiguration';
@@ -349,7 +350,7 @@ export async function getImageBuildInfo(params: DockerResolverParameters | Docke
 		const cwdEnvFile = cliHost.path.join(cliHost.cwd, '.env');
 		const envFile = Array.isArray(config.dockerComposeFile) && config.dockerComposeFile.length === 0 && await cliHost.isFile(cwdEnvFile) ? cwdEnvFile : undefined;
 		const composeFiles = await getDockerComposeFilePaths(cliHost, config, cliHost.env, cliHost.cwd);
-		const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env: cliHost.env, output, platformInfo: params.platformInfo };
+		const buildParams: DockerCLIParameters = { cliHost, dockerCLI, dockerComposeCLI, env: cliHost.env, output, buildPlatformInfo: params.buildPlatformInfo, targetPlatformInfo: params.targetPlatformInfo };
 
 		const composeConfig = await readDockerComposeConfig(buildParams, composeFiles, envFile);
 		const services = Object.keys(composeConfig.services || {});
@@ -394,18 +395,40 @@ export async function getImageBuildInfoFromImage(params: DockerResolverParameter
 export async function getImageBuildInfoFromDockerfile(params: DockerResolverParameters | DockerCLIParameters, dockerfile: string, dockerBuildArgs: Record<string, string>, targetStage: string | undefined, substitute: SubstituteConfig) {
 	const { output } = 'output' in params ? params : params.common;
 	const omitSyntaxDirective = 'common' in params ? !!params.common.omitSyntaxDirective : false;
-	return internalGetImageBuildInfoFromDockerfile(imageName => inspectDockerImage(params, imageName, true), dockerfile, dockerBuildArgs, targetStage, substitute, output, omitSyntaxDirective);
+	return internalGetImageBuildInfoFromDockerfile(imageName => inspectDockerImage(params, imageName, true), dockerfile, dockerBuildArgs, targetStage, substitute, output, omitSyntaxDirective, params.buildPlatformInfo, params.targetPlatformInfo);
 }
 
-export async function internalGetImageBuildInfoFromDockerfile(inspectDockerImage: (imageName: string) => Promise<ImageDetails>, dockerfileText: string, dockerBuildArgs: Record<string, string>, targetStage: string | undefined, substitute: SubstituteConfig, output: Log, omitSyntaxDirective: boolean): Promise<ImageBuildInfo> {
+export async function internalGetImageBuildInfoFromDockerfile(inspectDockerImage: (imageName: string) => Promise<ImageDetails>, dockerfileText: string, dockerBuildArgs: Record<string, string>, targetStage: string | undefined, substitute: SubstituteConfig, output: Log, omitSyntaxDirective: boolean, buildPlatform: PlatformInfo, targetPlatform: PlatformInfo): Promise<ImageBuildInfo> {
 	const dockerfile = extractDockerfile(dockerfileText);
 	if (dockerfile.preamble.directives.syntax && omitSyntaxDirective) {
 		output.write(`Omitting syntax directive '${dockerfile.preamble.directives.syntax}' from Dockerfile.`, LogLevel.Trace);
 		delete dockerfile.preamble.directives.syntax;
 	}
-	const baseImage = findBaseImage(dockerfile, dockerBuildArgs, targetStage);
+	// https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#automatic-platform-args-in-the-global-scope
+	const globalBuildxPlatformArgs = {
+		// platform of the node performing the build.
+		BUILDPLATFORM: [buildPlatform.os, buildPlatform.arch, buildPlatform.variant].filter(Boolean).join("/"),
+		// OS component of BUILDPLATFORM
+		BUILDOS: buildPlatform.os,
+		// architecture component of BUILDPLATFORM
+		BUILDARCH: buildPlatform.arch,
+		// variant component of BUILDPLATFORM
+		BUILDVARIANT: buildPlatform.variant ?? "",
+		// platform of the build result. Eg linux/amd64, linux/arm/v7, windows/amd64.
+		TARGETPLATFORM: [targetPlatform.os, targetPlatform.arch, targetPlatform.variant].filter(Boolean).join("/"),
+		// OS component of TARGETPLATFORM
+		TARGETOS: targetPlatform.os,
+		// architecture component of TARGETPLATFORM
+		TARGETARCH: targetPlatform.arch,
+		// variant component of TARGETPLATFORM
+		TARGETVARIANT: targetPlatform.variant ?? "",
+	};
+	const baseImage = findBaseImage(dockerfile, dockerBuildArgs, targetStage, globalBuildxPlatformArgs);
 	const imageDetails = baseImage && await inspectDockerImage(baseImage) || undefined;
-	const dockerfileUser = findUserStatement(dockerfile, dockerBuildArgs, envListToObj(imageDetails?.Config.Env), targetStage);
+	const dockerfileUser = findUserStatement(dockerfile, dockerBuildArgs, {
+		...envListToObj(imageDetails?.Config.Env),
+		...globalBuildxPlatformArgs,
+	}, targetStage);
 	const user = dockerfileUser || imageDetails?.Config.User || 'root';
 	const metadata = imageDetails ? getImageMetadata(imageDetails, substitute, output) : { config: [], raw: [], substitute };
 	return {

--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -425,10 +425,7 @@ export async function internalGetImageBuildInfoFromDockerfile(inspectDockerImage
 	};
 	const baseImage = findBaseImage(dockerfile, dockerBuildArgs, targetStage, globalBuildxPlatformArgs);
 	const imageDetails = baseImage && await inspectDockerImage(baseImage) || undefined;
-	const dockerfileUser = findUserStatement(dockerfile, dockerBuildArgs, {
-		...envListToObj(imageDetails?.Config.Env),
-		...globalBuildxPlatformArgs,
-	}, targetStage);
+	const dockerfileUser = findUserStatement(dockerfile, dockerBuildArgs, envListToObj(imageDetails?.Config.Env), globalBuildxPlatformArgs, targetStage);
 	const user = dockerfileUser || imageDetails?.Config.User || 'root';
 	const metadata = imageDetails ? getImageMetadata(imageDetails, substitute, output) : { config: [], raw: [], substitute };
 	return {

--- a/src/spec-node/upgradeCommand.ts
+++ b/src/spec-node/upgradeCommand.ts
@@ -86,16 +86,18 @@ async function featuresUpgrade({
 			env: cliHost.env,
 			output,
 		}, dockerPath, dockerComposePath);
+		const buildPlatformInfo = {
+			os: mapNodeOSToGOOS(cliHost.platform),
+			arch: mapNodeArchitectureToGOARCH(cliHost.arch),
+		};
 		const dockerParams: DockerCLIParameters = {
 			cliHost,
 			dockerCLI: dockerPath,
 			dockerComposeCLI,
 			env: cliHost.env,
 			output,
-			platformInfo: {
-				os: mapNodeOSToGOOS(cliHost.platform),
-				arch: mapNodeArchitectureToGOARCH(cliHost.arch),
-			}
+			buildPlatformInfo,
+			targetPlatformInfo: buildPlatformInfo,
 		};
 
 		const workspace = workspaceFromPath(cliHost.path, workspaceFolder);

--- a/src/spec-node/utils.ts
+++ b/src/spec-node/utils.ts
@@ -134,7 +134,8 @@ export interface DockerResolverParameters {
 	additionalLabels: string[];
 	buildxOutput: string | undefined;
 	buildxCacheTo: string | undefined;
-	platformInfo: PlatformInfo;
+	buildPlatformInfo: PlatformInfo;
+	targetPlatformInfo: PlatformInfo;
 }
 
 export interface ResolverResult {
@@ -250,7 +251,7 @@ export async function inspectDockerImage(params: DockerResolverParameters | Dock
 			throw inspectErr;
 		}
 		try {
-			return await inspectImageInRegistry(output, params.platformInfo, imageName);
+			return await inspectImageInRegistry(output, params.targetPlatformInfo, imageName);
 		} catch (inspectErr2) {
 			output.write(`Error fetching image details: ${inspectErr2?.message}`, LogLevel.Info);
 		}

--- a/src/spec-shutdown/dockerUtils.ts
+++ b/src/spec-shutdown/dockerUtils.ts
@@ -52,7 +52,8 @@ export interface DockerCLIParameters {
 	dockerComposeCLI: () => Promise<DockerComposeCLI>;
 	env: NodeJS.ProcessEnv;
 	output: Log;
-	platformInfo: PlatformInfo;
+	buildPlatformInfo: PlatformInfo;
+	targetPlatformInfo: PlatformInfo;
 }
 
 export interface PartialExecParameters {

--- a/src/test/dockerfileUtils.test.ts
+++ b/src/test/dockerfileUtils.test.ts
@@ -178,7 +178,7 @@ FROM ubuntu:latest as dev
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
             return details;
-        }, dockerfile, {}, undefined, testSubstitute, nullLog, false);
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, {} as any, {} as any);
         assert.strictEqual(info.user, 'imageUser');
         assert.strictEqual(info.metadata.config.length, 1);
         assert.strictEqual(info.metadata.config[0].id, 'testid-substituted');
@@ -206,8 +206,41 @@ USER dockerfileUserB
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
             return details;
-        }, dockerfile, {}, undefined, testSubstitute, nullLog, false);
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, {} as any, {} as any);
         assert.strictEqual(info.user, 'dockerfileUserB');
+        assert.strictEqual(info.metadata.config.length, 0);
+        assert.strictEqual(info.metadata.raw.length, 0);
+    });
+
+    it('for a USER in a multiarch image', async () => {
+        const dockerfile = `
+FROM ubuntu:latest as base-amd64
+USER amd64_user
+
+FROM ubuntu:latest as base-arm64
+USER arm64_user
+
+FROM base-\${TARGETARCH}
+
+ARG TARGETARCH
+`;
+        const details: ImageDetails = {
+            Id: '123',
+            Config: {
+                User: 'imageUser',
+                Env: null,
+                Labels: null,
+                Entrypoint: null,
+                Cmd: null
+            },
+						Os: 'linux',
+						Architecture: 'amd64'
+        };
+        const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
+            assert.strictEqual(imageName, 'ubuntu:latest');
+            return details;
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, {} as any, { os: 'linux', arch: 'amd64' });
+        assert.strictEqual(info.user, 'amd64_user');
         assert.strictEqual(info.metadata.config.length, 0);
         assert.strictEqual(info.metadata.raw.length, 0);
     });

--- a/src/test/dockerfileUtils.test.ts
+++ b/src/test/dockerfileUtils.test.ts
@@ -178,7 +178,7 @@ FROM ubuntu:latest as dev
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
             return details;
-        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, {} as any, {} as any);
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, { os: 'linux', arch: 'arm64' }, { os: 'linux', arch: 'amd64' });
         assert.strictEqual(info.user, 'imageUser');
         assert.strictEqual(info.metadata.config.length, 1);
         assert.strictEqual(info.metadata.config[0].id, 'testid-substituted');
@@ -206,7 +206,7 @@ USER dockerfileUserB
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
             return details;
-        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, {} as any, {} as any);
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, { os: 'linux', arch: 'arm64' }, { os: 'linux', arch: 'amd64' });
         assert.strictEqual(info.user, 'dockerfileUserB');
         assert.strictEqual(info.metadata.config.length, 0);
         assert.strictEqual(info.metadata.raw.length, 0);
@@ -221,8 +221,6 @@ FROM ubuntu:latest as base-arm64
 USER arm64_user
 
 FROM base-\${TARGETARCH}
-
-ARG TARGETARCH
 `;
         const details: ImageDetails = {
             Id: '123',
@@ -239,7 +237,7 @@ ARG TARGETARCH
         const info = await internalGetImageBuildInfoFromDockerfile(async (imageName) => {
             assert.strictEqual(imageName, 'ubuntu:latest');
             return details;
-        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, {} as any, { os: 'linux', arch: 'amd64' });
+        }, dockerfile, {}, undefined, testSubstitute, nullLog, false, { os: 'linux', arch: 'arm64' }, { os: 'linux', arch: 'amd64' });
         assert.strictEqual(info.user, 'amd64_user');
         assert.strictEqual(info.metadata.config.length, 0);
         assert.strictEqual(info.metadata.raw.length, 0);
@@ -424,7 +422,7 @@ describe('findUserStatement', () => {
 USER user1
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user1');
     });
 
@@ -434,7 +432,7 @@ ARG IMAGE_USER=user2
 USER $IMAGE_USER
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user2');
     });
 
@@ -446,7 +444,7 @@ USER $IMAGE_USER
         const extracted = extractDockerfile(dockerfile);
         const user = findUserStatement(extracted, {
             IMAGE_USER: 'user3'
-        }, {}, undefined);
+        }, {}, {}, undefined);
         assert.strictEqual(user, 'user3');
     });
 
@@ -462,7 +460,7 @@ FROM image4 as stage4
 USER user4
 `;
         const extracted = extractDockerfile(dockerfile);
-        const image = findUserStatement(extracted, {}, {}, 'stage2');
+        const image = findUserStatement(extracted, {}, {}, {}, 'stage2');
         assert.strictEqual(image, 'user3_2');
     });
 
@@ -474,7 +472,7 @@ ARG USERNAME=user2
 USER \${USERNAME}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user2');
     });
 
@@ -488,7 +486,7 @@ FROM one as two
 USER \${USERNAME}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user1');
     });
 
@@ -499,7 +497,7 @@ FROM debian
 USER \${USERNAME}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user1');
     });
 
@@ -511,7 +509,7 @@ ARG USERNAME
 USER \${USERNAME}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user1');
     });
 
@@ -521,7 +519,7 @@ FROM debian
 USER \${USERNAME}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, undefined);
     });
 
@@ -533,7 +531,7 @@ ENV USERNAME=user2
 USER \${USERNAME}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user2');
     });
 
@@ -545,7 +543,7 @@ ENV USERNAME2=\${USERNAME1}
 USER \${USERNAME2}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'user1');
     });
 
@@ -557,7 +555,7 @@ ENV USERNAME2=user2
 USER A\${USERNAME1}A\${USERNAME2}A
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, {}, undefined);
+        const user = findUserStatement(extracted, {}, {}, {}, undefined);
         assert.strictEqual(user, 'Auser1Auser2A');
     });
 
@@ -567,7 +565,7 @@ FROM mybase
 USER \${USERNAME}
 `;
         const extracted = extractDockerfile(dockerfile);
-        const user = findUserStatement(extracted, {}, { USERNAME: 'user1' }, undefined);
+        const user = findUserStatement(extracted, {}, { USERNAME: 'user1' }, {}, undefined);
         assert.strictEqual(user, 'user1');
     });
 });

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -154,16 +154,18 @@ export async function createCLIParams(hostPath: string) {
 		env: cliHost.env,
 		output,
 	}, 'docker', 'docker-compose');
+	const buildPlatformInfo = {
+		os: mapNodeOSToGOOS(cliHost.platform),
+		arch: mapNodeArchitectureToGOARCH(cliHost.arch),
+	};
 	const cliParams: DockerCLIParameters = {
 		cliHost,
 		dockerCLI: 'docker',
 		dockerComposeCLI,
 		env: {},
 		output,
-		platformInfo: {
-			os: mapNodeOSToGOOS(cliHost.platform),
-			arch: mapNodeArchitectureToGOARCH(cliHost.arch),
-		}
+		buildPlatformInfo,
+		targetPlatformInfo: buildPlatformInfo,
 };
 	return cliParams;
 }


### PR DESCRIPTION
This PR ensures the buildkit [global platform ARGs](https://github.com/moby/buildkit/blob/d277c460081f97b3c3e7c7d08dab21a88bd2e343/frontend/dockerfile/docs/reference.md#automatic-platform-args-in-the-global-scope) are respected in `findBaseImage()` and `findUserStatement()` functions.

These variables are valid in `FROM` lines, e.g.:
```dockerfile

FROM ubuntu:latest as base-amd64
ENV MY_ARCH=amd64

FROM ubuntu:latest as base-arm64
ENV MY_ARCH=arm64

FROM base-${TARGETARCH}

ARG TARGETARCH
```

Without this change, the devcontainers CLI attempts to pull an image named `base-` rather than continue to walk the `FROM` tree to find `ubuntu:latest`.

Fixes https://github.com/devcontainers/cli/issues/275