### PR TITLE
Node.js 20 upgrade for dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License. See License.txt in the project root for license information.
-ARG VARIANT="16-bullseye"
+ARG VARIANT="20-bookworm"
 FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}
 
 RUN mkdir -p /workspaces && chown node:node /workspaces

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.16.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
+      "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			"VARIANT": "18-bookworm"
+			"VARIANT": "20-bookworm"
 		}
 	},
 	"mounts": [


### PR DESCRIPTION
## Summary

This PR upgrades the dev container configuration from Node.js 16/18 to Node.js 20.

## Changes

- Updated Dockerfile base image variant from `16-bullseye` to `20-bookworm`
- Updated devcontainer.json build argument from Node.js 18 to Node.js 20
- Added devcontainer-lock.json to pin feature versions

## Modified Files

- `.devcontainer/Dockerfile` - Base image variant update
- `.devcontainer/devcontainer.json` - Build argument update
- `.devcontainer/devcontainer-lock.json` - New lock file for feature versioning