### PR TITLE
fix: always write devcontainer.metadata label as JSON array

### DIFF
--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -498,8 +498,8 @@ export function getDevcontainerMetadataLabel(devContainerMetadata: SubstitutedCo
 		return '';
 	}
 	const imageMetadataLabelValue = `[${metadata
-		.map(feature => ` \\\n${toLabelString(feature)}`)
-		.join(',')} \\\n]`;
+		.map(feature => `\\\n${toLabelString(feature)}`)
+		.join(',')}\\\n]`;
 	return `LABEL ${imageMetadataLabel}="${imageMetadataLabelValue}"`;
 }
 

--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -497,11 +497,9 @@ export function getDevcontainerMetadataLabel(devContainerMetadata: SubstitutedCo
 	if (!metadata.length) {
 		return '';
 	}
-	const imageMetadataLabelValue = metadata.length !== 1
-		? `[${metadata
-			.map(feature => ` \\\n${toLabelString(feature)}`)
-			.join(',')} \\\n]`
-		: toLabelString(metadata[0]);
+	const imageMetadataLabelValue = `[${metadata
+		.map(feature => ` \\\n${toLabelString(feature)}`)
+		.join(',')} \\\n]`;
 	return `LABEL ${imageMetadataLabel}="${imageMetadataLabelValue}"`;
 }
 

--- a/src/spec-node/imageMetadata.ts
+++ b/src/spec-node/imageMetadata.ts
@@ -498,8 +498,8 @@ export function getDevcontainerMetadataLabel(devContainerMetadata: SubstitutedCo
 		return '';
 	}
 	const imageMetadataLabelValue = `[${metadata
-		.map(feature => `\\\n${toLabelString(feature)}`)
-		.join(',')}\\\n]`;
+		.map(feature => ` \\\n${toLabelString(feature)}`)
+		.join(',')} \\\n]`;
 	return `LABEL ${imageMetadataLabel}="${imageMetadataLabelValue}"`;
 }
 

--- a/src/test/imageMetadata.test.ts
+++ b/src/test/imageMetadata.test.ts
@@ -432,6 +432,22 @@ describe('Image Metadata', function () {
 			assert.strictEqual(label.replace(/ \\\n/g, ''), `LABEL devcontainer.metadata="${JSON.stringify(expected).replace(/"/g, '\\"')}"`);
 		});
 
+		it('should create array label for single metadata entry (docker-compose with Dockerfile, no features)', () => {
+			// When there is only one metadata entry, the label should still be a JSON array.
+			// Regression test for https://github.com/devcontainers/cli/issues/1054
+			const label = getDevcontainerMetadataLabel(configWithRaw([
+				{
+					remoteUser: 'testUser',
+				}
+			]));
+			const expected = [
+				{
+					remoteUser: 'testUser',
+				}
+			];
+			assert.strictEqual(label.replace(/ \\\n/g, ''), `LABEL devcontainer.metadata="${JSON.stringify(expected).replace(/"/g, '\\"')}"`);
+		});
+
 		it('should merge metadata from devcontainer.json and features', () => {
 			const merged = mergeConfiguration({
 				configFilePath: URI.parse('file:///devcontainer.json'),


### PR DESCRIPTION
The `getDevcontainerMetadataLabel` function wrote a bare JSON object when there was only one metadata entry (e.g. docker-compose devcontainer with no features), but an array when there were multiple entries
- The [spec](https://containers.dev/implementors/json_reference/) states the label "can contain an **array** of json snippets"
- Tools like [Zed](https://github.com/zed-industries/zed) ([parsing code](https://github.com/zed-industries/zed/blob/b6562e8afadaeb73828dfd7dfa94fe8cf8876e18/crates/dev_container/src/docker.rs#L488)) or [envbuilder](https://github.com/coder/envbuilder) that follow the spec and expect an array fail 

The reading side (`internalGetImageMetadata0`) already handles both formats, but the writing side was inconsistent. In this PR we propose to always write an array of objects for simplicity. For backwards compatibility we leave the parsing, which supports both. Changing this makes the code follow the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle) by being strict what is returned (always an array). 

## Test instructions

Create the following project: 
```
/tmp/zed-devcontainer-repro
└── .devcontainer
    ├── devcontainer.json
    ├── docker-compose.yml
    └── Dockerfile
```

devcontainer.json:
```
{
  "name": "repro",
  "dockerComposeFile": "docker-compose.yml",
  "service": "app",
  "remoteUser": "root"
}
```
docker-compose.yml:
```
services:
  app:
    build:
      context: .
      dockerfile: Dockerfile
    command: sleep infinity
    volumes:
      - ..:/workspace
```
Dockerfile
```
FROM ubuntu:24.04
```

With the latest release the metadata is: 
```
> devcontainer up --workspace-folder /tmp/zed-devcontainer-repro
[...]
> docker inspect --format='{{index .Config.Labels "devcontainer.metadata"}}' \
    $(docker ps -q --filter "label=devcontainer.local_folder=/tmp/zed-devcontainer-repro")

{"remoteUser":"root"}
```

After this change: 

```
[{"remoteUser":"root"}]
```

Fixes #1054