### PR TITLE
Allow colons in default values for environment variables

### DIFF
--- a/src/spec-common/variableSubstitution.ts
+++ b/src/spec-common/variableSubstitution.ts
@@ -85,7 +85,8 @@ function evaluateSingleVariable(replace: Replace, match: string, variable: strin
 	const parts = variable.split(':');
 	if (parts.length > 1) {
 		variable = parts[0];
-		args = parts.slice(1);
+		// Preserve colons in the default value (e.g. `${localEnv:VAR:image:tag}`).
+		args = parts.length > 2 ? [parts[1], parts.slice(2).join(':')] : [parts[1]];
 	}
 
 	return replace(match, variable, args);

--- a/src/test/variableSubstitution.test.ts
+++ b/src/test/variableSubstitution.test.ts
@@ -131,7 +131,7 @@ describe('Variable substitution', function () {
 			env: {
 			},
 		}, raw);
-		assert.strictEqual(result.foo, 'bardefaultbar');
+		assert.strictEqual(result.foo, 'bardefault:a:b:cbar');
 	});
 
 	it(`container environment variables with default value if they do not exist`, async () => {


### PR DESCRIPTION
Anything after a third colon is silently ignored in variable substitution, which prevents using default values with colons in them (e.g. URLs or image:tag).

This limits the split at 3 parts by joining any additional parts back together.

A similar fix was previously proposed in #882 a couple years ago. Open to exploring different solutions (e.g. quoting the entire default value or escaping colons) if there is still a desire to retain the ability to introduce more than 2 arguments in variable substitution.

Fixes #719, #883.