### PR TITLE
Fix isLocalFolder() to allow symlinks to directories

### DIFF
--- a/src/spec-utils/pfs.ts
+++ b/src/spec-utils/pfs.ts
@@ -15,7 +15,7 @@ export function isLocalFile(filepath: string): Promise<boolean> {
 }
 
 export function isLocalFolder(filepath: string): Promise<boolean> {
-	return new Promise(r => fs.stat(filepath, (err, stat) => r(!err && stat.isDirectory())));
+	return new Promise(r => fs.realpath(filepath, (err,rpath) => r(!err && fs.stat(rpath, (err, stat) => r(!err && stat.isDirectory())))));
 }
 
 export const readLocalFile = promisify(fs.readFile);

--- a/src/spec-utils/pfs.ts
+++ b/src/spec-utils/pfs.ts
@@ -15,7 +15,7 @@ export function isLocalFile(filepath: string): Promise<boolean> {
 }
 
 export function isLocalFolder(filepath: string): Promise<boolean> {
-	return new Promise(r => fs.realpath(filepath, (err,rpath) => r(!err && fs.stat(rpath, (err, stat) => r(!err && stat.isDirectory())))));
+	return new Promise(r => fs.realpath(filepath, (err,rpath) => r(!err && fs.stat(rpath, (err, stat) => (!err && stat.isDirectory())))));
 }
 
 export const readLocalFile = promisify(fs.readFile);


### PR DESCRIPTION
I'm trying to layer in a local feature for my developers to apply custom preferences to their devcontainers without polluting eachother's devcontainers.

I want to use a symlink from `~/.devcontainer/personal-config` to the local repository's `.devcontainer/personal-config` and add:

```
{
    ...
    "features": {
        "./personal-config": {}
    }
}
```

To the local repository's `.devcontainer/devcontainer.json`. Unfortunately, the current `isLocalFolder()` chokes on symlinks. This patch should allow symlinked directories for local features.

I'm not a TypeScript programmer, and I'm not sure this is the exact implementation.