### PR TITLE
Resolve local feature paths relative to the config file's directory

### DIFF
--- a/src/spec-configuration/containerFeaturesConfiguration.ts
+++ b/src/spec-configuration/containerFeaturesConfiguration.ts
@@ -843,13 +843,18 @@ export async function processFeatureIdentifier(params: CommonParams, configPath:
 		}
 		const featureFolderPath = path.join(path.dirname(configPath), userFeature.userFeatureId);
 
-		// Ensure we aren't escaping .devcontainer folder
-		const parent = path.join(_workspaceRoot, '.devcontainer');
+		// Ensure we aren't escaping the directory containing the devcontainer config.
+		// The local-features spec resolves paths relative to the config file's directory
+		// (see `featureFolderPath` above), so the escape check must be anchored there
+		// rather than at `${workspaceRoot}/.devcontainer`. Otherwise, configs supplied
+		// via `--config` that live outside the workspace's `.devcontainer/` folder would
+		// reject all of their own sibling features.
+		const parent = path.dirname(configPath);
 		const child = featureFolderPath;
 		const relative = path.relative(parent, child);
 		output.write(`${parent} -> ${child}:   Relative Distance = '${relative}'`, LogLevel.Trace);
 		if (relative.indexOf('..') !== -1) {
-			output.write(`Local file path parse error. Resolved path must be a child of the .devcontainer/ folder.  Parsed: ${featureFolderPath}`, LogLevel.Error);
+			output.write(`Local file path parse error. Resolved path must be a child of the config file's folder.  Parsed: ${featureFolderPath}`, LogLevel.Error);
 			return undefined;
 		}
 

--- a/src/test/container-features/featureHelpers.test.ts
+++ b/src/test/container-features/featureHelpers.test.ts
@@ -188,6 +188,30 @@ describe('validate processFeatureIdentifier', async function () {
 			assert.deepEqual(featureSet?.sourceInformation, { type: 'file-path', resolvedFilePath: path.join(workspaceRoot, '.devcontainer', 'featureB'), userFeatureId: './.devcontainer/featureB' });
 		});
 
+		it('local-path should parse when config file is outside the workspace .devcontainer folder', async function () {
+			// Regression: when `--config` points to a devcontainer.json that lives
+			// outside `${workspaceRoot}/.devcontainer/`, local-path features
+			// resolved relative to that config must still be accepted. Previously
+			// the parent-escape check was anchored at `${workspaceRoot}/.devcontainer`,
+			// which rejected every local feature in this layout.
+			const userFeature: DevContainerFeature = {
+				userFeatureId: './featureA',
+				options: {},
+			};
+
+			const externalConfigDir = '/some/other/place';
+			const customConfigPath = path.join(externalConfigDir, 'devcontainer.json');
+
+			const featureSet = await processFeatureIdentifier(params, customConfigPath, workspaceRoot, userFeature);
+			assert.exists(featureSet);
+			assert.strictEqual(featureSet?.features[0].id, 'featureA');
+			assert.deepEqual(featureSet?.sourceInformation, {
+				type: 'file-path',
+				resolvedFilePath: path.join(externalConfigDir, 'featureA'),
+				userFeatureId: './featureA',
+			});
+		});
+
 		it('should process oci registry (without tag)', async function () {
 			const userFeature: DevContainerFeature = {
 				userFeatureId: 'ghcr.io/codspace/features/ruby',


### PR DESCRIPTION
## Problem

The Dev Container CLI's validation for local feature paths is anchored at a hardcoded location (`${workspaceRoot}/.devcontainer`), but according to the [official Dev Container specification](https://containers.dev/implementors/features-distribution#addendum-locally-referenced), local-path features should be resolved **relative to the folder containing the `devcontainer.json` file itself**.

This causes a critical issue: when `--config` points to a `devcontainer.json` that lives **outside** the standard workspace `.devcontainer/` directory (e.g., [an editor integration providing an external config](https://github.com/IamTheCarl/nvim-dev-container)), all local features are rejected, even though their resolved paths are valid siblings of the config file.

**Example of broken scenario:**
```
/workspace/                          (project root)
/workspace/.devcontainer/            (standard location)
/editor/configs/                      (external configs)
/editor/configs/my-devcontainer.json  (--config points here)
/editor/configs/features/myFeature/   (feature location)
```

With a feature reference of `./features/myFeature`:
- **Expected behavior:** Resolved relative to `/editor/configs/` → valid
- **Current behavior:** Validated against `/workspace/.devcontainer/` → rejected incorrectly

## Solution

Anchor the parent-escape validation check at `path.dirname(configPath)` instead of the hardcoded workspace root. This ensures that:

1. **Spec compliance:** Validation mirrors the actual path resolution logic
2. **Security preserved:** Directory escape attempts (e.g., `../../../etc/passwd`) are still caught
3. **Out-of-tree configs work:** Editor integrations and custom configs can supply local features

The fix changes the validation anchor from:
```typescript
const parent = path.join(_workspaceRoot, '.devcontainer');
```

To:
```typescript
const parent = path.dirname(configPath);
```

## References

- [Dev Containers Spec: Locally Referenced Features](https://containers.dev/implementors/features-distribution#addendum-locally-referenced) — Defines local features as relative to the containing `devcontainer.json`
- [Dev Containers Spec: Features Reference](https://containers.dev/implementors/features#referencing-a-feature) — Documents local feature resolution semantics

## Testing

- Added regression test in `src/test/container-features/featureHelpers.test.ts` that exercises an external config directory scenario
- Existing escape-hatch tests remain valid; security checks still function correctly
- Test case: `./featureA` in config at `/some/other/place/devcontainer.json` now correctly resolves to `/some/other/place/featureA` and is accepted

## Changes

- **Modified:** `src/spec-configuration/containerFeaturesConfiguration.ts` — Updated escape check anchor point with clarifying comments
- **Added:** Regression test in `src/test/container-features/featureHelpers.test.ts`
