### PR TITLE
fix: relative symlink resolution in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -424,7 +424,7 @@ set -e
 # Handle both direct execution and symlinked scenarios
 if [ -L "$0" ]; then
     # Follow symlink
-    SCRIPT_PATH="$(readlink "$0" 2>/dev/null || readlink -f "$0" 2>/dev/null || echo "$0")"
+    SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
 else
     SCRIPT_PATH="$0"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -422,16 +422,26 @@ set -e
 
 # Resolve the installation directory
 # Handle both direct execution and symlinked scenarios
-if [ -L "$0" ]; then
-    # Follow symlink
-    SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || readlink "$0" 2>/dev/null || echo "$0")"
-else
-    SCRIPT_PATH="$0"
-fi
+# Uses portable shell built-ins instead of GNU-specific readlink -f and realpath
+# Ignores inherited CDPATH, then resolves the script directory and its parent path
+SCRIPT_DIR="$(
+    CDPATH=
+    self=$0
 
-# Get absolute path to script directory
-SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
-INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
+    # follow the symlink chain one hop at a time so relative targets resolve correctly
+    while [ -L "$self" ]; do
+        cd -- "${self%/*}" >/dev/null || :
+        self=$(readlink "${self##*/}")
+    done
+
+    case "$self" in
+        (*/*) ;;
+        (*) self=./$self ;;
+    esac
+
+    cd -P -- "${self%/*}" >/dev/null && pwd
+)"
+INSTALL_DIR="$(dirname -- "$SCRIPT_DIR")"
 
 # Paths to bundled components
 NODE_BIN="$INSTALL_DIR/node/current/bin/node"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -422,7 +422,7 @@ set -e
 
 # Resolve the installation directory
 # Handle both direct execution and symlinked scenarios
-# Uses portable shell built-ins instead of GNU-specific readlink -f and realpath
+# Uses POSIX shell syntax and avoids GNU-specific readlink -f/realpath (requires readlink(1))
 # Ignores inherited CDPATH, then resolves the script directory and its parent path
 SCRIPT_DIR="$(
     CDPATH=
@@ -430,8 +430,9 @@ SCRIPT_DIR="$(
 
     # follow the symlink chain one hop at a time so relative targets resolve correctly
     while [ -L "$self" ]; do
-        cd -- "${self%/*}" >/dev/null || :
-        self=$(readlink "${self##*/}")
+        dir=${self%/*}; [ "$dir" = "$self" ] && dir=.
+        cd "$dir" >/dev/null 2>&1 || exit 1
+        self=$(readlink "${self##*/}") || exit 1
     done
 
     case "$self" in

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -592,6 +592,8 @@ test_wrapper_missing_cli
 printf '\n'
 test_wrapper_via_symlink
 printf '\n'
+test_wrapper_via_relative_symlink
+printf '\n'
 test_path_with_spaces
 printf '\n'
 test_version_equals_form

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -447,6 +447,37 @@ test_wrapper_via_symlink() {
     teardown
 }
 
+# ── Tests: wrapper via relative symlink from different directory ──
+
+test_wrapper_via_relative_symlink() {
+    printf '%b\n' "${C_BOLD}Wrapper works via relative symlink from different directory${C_RESET}"
+    setup
+
+    prefix="$TEST_TMPDIR/devcontainers"
+    cli_version="0.75.0"
+
+    sh "$INSTALL_SCRIPT" --prefix "$prefix" --version "$cli_version" >/dev/null 2>&1
+
+    # Create a RELATIVE symlink in a different directory
+    link_dir="$TEST_TMPDIR/bin"
+    mkdir -p "$link_dir"
+    
+    # Create relative symlink that points back to the wrapper
+    ln -s ../devcontainers/bin/devcontainer "$link_dir/devcontainer"
+    assert_symlink "$link_dir/devcontainer" "relative symlink created"
+
+    # Call from a different directory
+    cwd_before=$(pwd)
+    cd "$TEST_TMPDIR"
+    version_output=$("$link_dir/devcontainer" --version 2>/dev/null) && wrc=0 || wrc=$?
+    
+    cd "$cwd_before"
+    assert_exit_code "0" "$wrc" "relative symlink works from different directory"
+    assert_contains "$version_output" "$cli_version" "relative symlink wrapper reports version"
+
+    teardown
+}
+
 # ── Tests: install to path with spaces ────────────────────────────
 
 test_path_with_spaces() {


### PR DESCRIPTION
## Summary

Fixes relative symlink resolution in the install script for split local layouts (e.g. a launcher in `~/.local/bin` pointing to a payload in `~/.local/lib/devcontainers`). The wrapper now resolves its own location with **portable POSIX shell built-ins** instead of GNU-specific `readlink -f`, so `devcontainer` works regardless of the caller's working directory and shell environment (Linux, macOS, BSD).

Fixes [#1232](https://github.com/devcontainers/cli/issues/1232)

## Root Cause

A single `readlink` call plus `cd "$(dirname ...)" && pwd` resolved **relative** symlink targets against the caller's CWD rather than the link's own directory, and the `readlink -f` fallback isn't portable to macOS/BSD.

## Reproduction of error

~~~sh
./install.sh --prefix "$HOME/.local/lib/devcontainers"
ln -s ../lib/devcontainers/bin/devcontainer "$HOME/.local/bin/devcontainer"
export PATH="$HOME/.local/bin:$PATH"
cd "$HOME" && devcontainer --version   # cd: ../lib/devcontainers/bin: No such file or directory
~~~

## Fix

The script-location resolver now walks the symlink chain one hop at a time, `cd`-ing into each link's directory before reading the next target, then canonicalizes the final directory. This replaces the previous single `readlink` resolution.

## Why It Works

- **Correct relative resolution:** enters each link's directory before reading the next target, so relative symlinks resolve against the link, not the CWD.
- **CWD-independent:** finalized with `cd -P … && pwd` for an absolute, canonical path.
- **Portable:** POSIX-only (`readlink`, `${var%/*}`, `cd -P`, `pwd`) — no `readlink -f`/`realpath`.
- **Safe:** runs in a subshell with `CDPATH=` cleared; no leaked `cd` or stray output.

## Validation

Regression test confirms a relative symlink launched from another directory exits `0` and reports the installed CLI version.

## Scope & Risk

One resolution block; no install/download changes. Direct execution and absolute symlinks are unchanged. Low risk, plus improved cross-platform portability.

## Credits

Thanks to [@klmr](https://github.com/klmr) for the portable POSIX symlink-resolution approach.