### PR TITLE
Fix InvalidDefaultArgInFrom docker warning when updateRemoteUserUID is enabled

### DIFF
--- a/scripts/updateUID.Dockerfile
+++ b/scripts/updateUID.Dockerfile
@@ -1,6 +1,6 @@
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  Licensed under the MIT License. See License.txt in the project root for license information.
-ARG BASE_IMAGE
+ARG BASE_IMAGE="scratch"
 FROM $BASE_IMAGE
 
 USER root


### PR DESCRIPTION
This warning is silly as the `BASE_IMAGE` will always be set in this case.

It's however always emitted for end users, and they have no control over it, so it's better we supress it.

I could also use the `# check=skip=InvalidDefaultArgInFrom` comment, but it would apply to the whole file, so I think this is cleaner. `scratch` is an [empty docker image](https://hub.docker.com/_/scratch).

Otherwise this is what happens:

```
❯ devcontainer up
[1 ms] @devcontainers/cli 0.87.0. Node.js v24.16.0. linux 6.18.33.1-microsoft-standard-WSL2 x64.
[1489 ms] Start: Run: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-felipecrs/container-features/0.87.0-1781210986304/Dockerfile-with-features -t vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473 --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label /home/felipecrs/repos/renovate/.devcontainer
[+] Building 0.9s (5/5) FINISHED                                                                                                                                                    => => unpacking to docker.io/library/vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473:latest                                                                   0.0s
[+] Building 0.5s (6/6) FINISHED                                                                                                                                                   docker:default
 => [internal] load build definition from updateUID.Dockerfile-0.87.0                                                                                                                        0.0s
 => => transferring dockerfile: 1.52kB                                                                                                                                                       0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG $BASE_IMAGE results in empty or invalid base image name (line 4)                                                                    0.0s
 => [internal] load metadata for docker.io/library/vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473:latest                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                                                              0.0s
 => [1/2] FROM docker.io/library/vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473:latest@sha256:cf70fea25de31199889abe3d5dc00c363a305a8bfde9ae0ac2bf212f731779  0.0s
 => => resolve docker.io/library/vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473:latest@sha256:cf70fea25de31199889abe3d5dc00c363a305a8bfde9ae0ac2bf212f731779  0.0s
 => CACHED [2/2] RUN eval $(sed -n "s/vscode:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/OLD_UID=\1;OLD_GID=\2;HOME_FOLDER=\3/p" /etc/passwd);  eval $(sed -n "s/\([^:]*\):[^:]*:1000:.*/EX  0.0s
 => exporting to image                                                                                                                                                                       0.2s
 => => exporting layers                                                                                                                                                                      0.0s
 => => exporting manifest sha256:e976ccb6056c83df0b31a2f69edf62b7cd32980d5e77b91a5ac1a3e61a1c7be9                                                                                            0.0s
 => => exporting config sha256:f59ef12a5259d6f7694d7f8026c165350c4964d9bc96b1e1a898d61bd166a6ed                                                                                              0.0s
 => => exporting attestation manifest sha256:a2d195990b6025ea7678242093671c4c770fbf8fc2b39061afa6af9934c360d6                                                                                0.1s
 => => exporting manifest list sha256:187010cd4161135abc5c63be04723b1c943de9cd6627832a404d971cedf0d77b                                                                                       0.0s
 => => naming to docker.io/library/vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473-uid:latest                                                                  0.0s
 => => unpacking to docker.io/library/vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473-uid:latest                                                               0.0s

 1 warning found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG $BASE_IMAGE results in empty or invalid base image name (line 4)
[3205 ms] Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,source=/home/felipecrs/repos/renovate,target=/workspaces/renovate -l devcontainer.local_folder=/home/felipecrs/repos/renovate -l devcontainer.config_file=/home/felipecrs/repos/renovate/.devcontainer/devcontainer.json --init --entrypoint /bin/sh vsc-renovate-5b7a82b2b39863d1d56536de9374e335685b9382d25b97ba65ec78975c59e473-uid -c echo Container started
Container started
```