### PR TITLE
fix: podman-compose build-arg handling

### DIFF
--- a/src/spec-node/dockerCompose.ts
+++ b/src/spec-node/dockerCompose.ts
@@ -6,7 +6,7 @@
 import * as yaml from 'js-yaml';
 import * as shellQuote from 'shell-quote';
 
-import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, DockerResolverParameters, inspectDockerImage, getEmptyContextFolder, getFolderImageName, SubstitutedConfig, checkDockerSupportForGPU, isBuildKitImagePolicyError } from './utils';
+import { createContainerProperties, startEventSeen, ResolverResult, getTunnelInformation, DockerResolverParameters, inspectDockerImage, getEmptyContextFolder, getFolderImageName, SubstitutedConfig, checkDockerSupportForGPU, isBuildKitImagePolicyError, envListToObj } from './utils';
 import { ContainerProperties, setupInContainer, ResolverProgress } from '../spec-common/injectHeadless';
 import { ContainerError } from '../spec-common/errors';
 import { Workspace } from '../spec-utils/workspaces';
@@ -144,7 +144,7 @@ export function getBuildInfoForService(composeService: any, cliHostPath: typeof 
 			dockerfilePath: (composeBuild.dockerfile as string | undefined) ?? 'Dockerfile',
 			context: (composeBuild.context as string | undefined) ?? cliHostPath.dirname(localComposeFiles[0]),
 			target: composeBuild.target as string | undefined,
-			args: composeBuild.args as Record<string, string> | undefined,
+			args: Array.isArray(composeBuild.args) ? envListToObj(composeBuild.args) : composeBuild.args as Record<string, string> | undefined,
 		}
 	};
 }


### PR DESCRIPTION
Passing build args to a compose file is broken when using `podman` and `podman-compose`.

`getBuildInfoForService` assumes build args are in the YAML map form, but `podman compose config` outputs build args in the YAML list form.  This adds a type check on `composeBuild.args` and converts it to key/value object if it's an array.