### PR TITLE
Sort Features with more user-defined options first, per spec

### DIFF
--- a/src/spec-configuration/containerFeaturesOrder.ts
+++ b/src/spec-configuration/containerFeaturesOrder.ts
@@ -121,7 +121,7 @@ function optionsCompareTo(a: string | boolean | Record<string, string | boolean 
 		const aKeys = Object.keys(a);
 		const bKeys = Object.keys(b);
 		if (aKeys.length !== bKeys.length) {
-			return aKeys.length - bKeys.length;
+			return bKeys.length - aKeys.length;
 		}
 
 		aKeys.sort();

--- a/src/test/container-features/containerFeaturesOrder.test.ts
+++ b/src/test/container-features/containerFeaturesOrder.test.ts
@@ -156,35 +156,35 @@ describe('Feature Dependencies', function () {
                 [
                     {
                         userFeatureId: './b',
+                        options: {
+                            optA: 'a',
+                            optB: 'a'
+                        }
+                    },
+                    {
+                        userFeatureId: './b',
+                        options: {
+                            optA: 'a',
+                            optB: 'b'
+                        }
+                    },
+                    {
+                        userFeatureId: './b',
+                        options: {
+                            optA: 'b',
+                            optB: 'a'
+                        }
+                    },
+                    {
+                        userFeatureId: './b',
+                        options: {
+                            optA: 'b',
+                            optB: 'b'
+                        }
+                    },
+                    {
+                        userFeatureId: './b',
                         options: {}
-                    },
-                    {
-                        userFeatureId: './b',
-                        options: {
-                            optA: 'a',
-                            optB: 'a'
-                        }
-                    },
-                    {
-                        userFeatureId: './b',
-                        options: {
-                            optA: 'a',
-                            optB: 'b'
-                        }
-                    },
-                    {
-                        userFeatureId: './b',
-                        options: {
-                            optA: 'b',
-                            optB: 'a'
-                        }
-                    },
-                    {
-                        userFeatureId: './b',
-                        options: {
-                            optA: 'b',
-                            optB: 'b'
-                        }
                     },
                     {
                         userFeatureId: './d',


### PR DESCRIPTION
The Features spec's "Installation Order" rules state that Features in a round are sorted by "Greatest number of user-defined options", but optionsCompareTo compared option counts ascending, installing the Feature with the fewest options first.

Flip the length comparison so the Feature with the greatest number of options sorts first, and update the round-sorting test expectations accordingly. Equal-length option sets still tie-break by key/value comparison as before.

fixes https://github.com/devcontainers/spec/issues/755