### PR TITLE
Use npm trusted publishing for CLI releases

### DIFF
--- a/.github/workflows/publish-dev-containers.yml
+++ b/.github/workflows/publish-dev-containers.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   actions: read
+  id-token: write
 
 jobs:
   main:
@@ -18,7 +19,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: '20.x'
+        node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
         scope: '@devcontainers'
     - name: Verify Versions
@@ -46,5 +47,3 @@ jobs:
         path: .
     - name: Publish TGZ
       run: npm publish ${TGZ} --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- grant the release workflow permission to request an OIDC token
- use Node.js 24 for a trusted-publishing-compatible npm version
- remove long-lived npm token authentication

## Configuration required before merge
Configure `@devcontainers/cli` on npmjs.com with the trusted publisher `devcontainers/cli` and workflow `publish-dev-containers.yml`.

## Related issue
- https://github.com/microsoft/vscode-internalbacklog/issues/8537

## Testing
Not run: trusted publishing can only be validated by publishing a new package version.