### PR TITLE
fix: harden OCI Bearer authentication against SSRF and credential forwarding

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -61,10 +61,11 @@ jobs:
           "src/test/cli.podman.test.ts",
           "src/test/cli.test.ts",
           "src/test/cli.up.test.ts",
+          "src/test/httpOCIRegistry.test.ts",
           "src/test/imageMetadata.test.ts",
           "src/test/container-features/containerFeaturesOCIPush.test.ts",
           # Run all except the above:
-          "--exclude src/test/container-features/containerFeaturesOrder.test.ts --exclude src/test/container-features/registryCompatibilityOCI.test.ts --exclude src/test/container-features/containerFeaturesOCIPush.test.ts --exclude src/test/container-features/e2e.test.ts --exclude src/test/container-features/featuresCLICommands.test.ts --exclude src/test/cli.build.test.ts --exclude src/test/cli.exec.buildKit.1.test.ts --exclude src/test/cli.exec.buildKit.2.test.ts --exclude src/test/cli.exec.nonBuildKit.1.test.ts --exclude src/test/cli.exec.nonBuildKit.2.test.ts --exclude src/test/cli.podman.test.ts --exclude src/test/cli.test.ts --exclude src/test/cli.up.test.ts --exclude src/test/imageMetadata.test.ts 'src/test/**/*.test.ts'",
+          "--exclude src/test/container-features/containerFeaturesOrder.test.ts --exclude src/test/container-features/registryCompatibilityOCI.test.ts --exclude src/test/container-features/containerFeaturesOCIPush.test.ts --exclude src/test/container-features/e2e.test.ts --exclude src/test/container-features/featuresCLICommands.test.ts --exclude src/test/cli.build.test.ts --exclude src/test/cli.exec.buildKit.1.test.ts --exclude src/test/cli.exec.buildKit.2.test.ts --exclude src/test/cli.exec.nonBuildKit.1.test.ts --exclude src/test/cli.exec.nonBuildKit.2.test.ts --exclude src/test/cli.podman.test.ts --exclude src/test/cli.test.ts --exclude src/test/cli.up.test.ts --exclude src/test/httpOCIRegistry.test.ts --exclude src/test/imageMetadata.test.ts 'src/test/**/*.test.ts'",
         ]
     steps:
     - name: Checkout

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -337,6 +337,16 @@ export function getCollectionRef(output: Log, registry: string, namespace: strin
 export async function fetchOCIManifestIfExists(params: CommonParams, ref: OCIRef | OCICollectionRef, manifestDigest?: string): Promise<ManifestContainer | undefined> {
 	const { output } = params;
 
+	const registryHostname = ref.registry.startsWith('[')
+		? ref.registry.slice(1, ref.registry.indexOf(']'))
+		: ref.registry.split(':', 1)[0];
+	// Preserve legacy owner/repository/feature IDs while allowing explicit local and IP registries.
+	if (!registryHostname.includes('.')
+		&& registryHostname !== 'localhost'
+		&& isIP(registryHostname) === 0) {
+		return;
+	}
+
 	// TODO: Always use the manifest digest (the canonical digest)
 	//       instead of the `ref.version` by referencing some lock file (if available).
 	let reference = ref.version;

--- a/src/spec-configuration/containerCollectionsOCI.ts
+++ b/src/spec-configuration/containerCollectionsOCI.ts
@@ -3,6 +3,7 @@ import * as semver from 'semver';
 import * as tar from 'tar';
 import * as jsonc from 'jsonc-parser';
 import * as crypto from 'crypto';
+import { isIP } from 'net';
 
 import { Log, LogLevel } from '../spec-utils/log';
 import { isLocalFile, mkdirpLocal, readLocalFile, writeLocalFile } from '../spec-utils/pfs';
@@ -116,6 +117,55 @@ const regexForPath = /^[a-z0-9]+([._-][a-z0-9]+)*(\/[a-z0-9]+([._-][a-z0-9]+)*)*
 // MUST be at most 128 characters in length and MUST match the following regular expression:
 const regexForVersionOrDigest = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/;
 
+// Validate authority syntax only; local and private registries remain supported by policy.
+function isValidRegistryAuthority(registry: string): boolean {
+	let hostname = registry;
+	let port: string | undefined;
+
+	if (registry.startsWith('[')) {
+		// IPv6 literals must use bracketed URL-authority form so the port is unambiguous.
+		const match = /^\[([^\]]+)\](?::([0-9]+))?$/.exec(registry);
+		if (!match || isIP(match[1]) !== 6) {
+			return false;
+		}
+		hostname = match[1];
+		port = match[2];
+	} else {
+		const firstColon = registry.indexOf(':');
+		if (firstColon !== -1) {
+			if (firstColon !== registry.lastIndexOf(':')) {
+				return false;
+			}
+			hostname = registry.slice(0, firstColon);
+			port = registry.slice(firstColon + 1);
+		}
+
+		if (isIP(hostname) === 0) {
+			if (hostname.length === 0 || hostname.length > 253) {
+				return false;
+			}
+			const labels = hostname.split('.');
+			if (!labels.every(label => label.length > 0
+				&& label.length <= 63
+				&& /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label))) {
+				return false;
+			}
+		}
+	}
+
+	if (port !== undefined) {
+		if (!/^[0-9]+$/.test(port)) {
+			return false;
+		}
+		const portNumber = Number(port);
+		if (portNumber < 1 || portNumber > 65535) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 // https://go.dev/doc/install/source#environment
 // Expected by OCI Spec as seen here: https://github.com/opencontainers/image-spec/blob/main/image-index.md#image-index-property-descriptions
 export function mapNodeArchitectureToGOARCH(arch: NodeJS.Architecture): GoARCH {
@@ -214,6 +264,10 @@ export function getRef(output: Log, input: string): OCIRef | undefined {
 	const namespace = splitOnSlash.slice(1, -1).join('/');
 
 	const path = `${namespace}/${id}`;
+	if (!isValidRegistryAuthority(registry)) {
+		output.write(`Registry '${registry}' for input '${input}' failed validation.`, LogLevel.Error);
+		return;
+	}
 
 	if (!regexForPath.exec(path)) {
 		output.write(`Path '${path}' for input '${input}' failed validation.  Expected path to match regex '${regexForPath}'.`, LogLevel.Error);
@@ -252,6 +306,10 @@ export function getCollectionRef(output: Log, registry: string, namespace: strin
 	// Normalize input by downcasing entire string
 	registry = registry.toLowerCase();
 	namespace = namespace.toLowerCase();
+	if (!isValidRegistryAuthority(registry)) {
+		output.write(`Registry '${registry}' failed validation.`, LogLevel.Error);
+		return;
+	}
 
 	const path = namespace;
 	const resource = `${registry}/${path}`;
@@ -278,12 +336,6 @@ export function getCollectionRef(output: Log, registry: string, namespace: strin
 // Specification: https://github.com/opencontainers/distribution-spec/blob/v1.0.1/spec.md#pulling-manifests
 export async function fetchOCIManifestIfExists(params: CommonParams, ref: OCIRef | OCICollectionRef, manifestDigest?: string): Promise<ManifestContainer | undefined> {
 	const { output } = params;
-
-	// Simple mechanism to avoid making a DNS request for
-	// something that is not a domain name.
-	if (ref.registry.indexOf('.') < 0 && !ref.registry.startsWith('localhost')) {
-		return;
-	}
 
 	// TODO: Always use the manifest digest (the canonical digest)
 	//       instead of the `ref.version` by referencing some lock file (if available).

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -483,20 +483,26 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 		output.write(`[httpOci] Attempting to fetch bearer token from:  ${httpOptions.url}`, LogLevel.Trace);
 	}
 
-	let res = await requestResolveHeadersNoRedirects(httpOptions, output);
-	if (sentCredentials && (res.statusCode === 401 || res.statusCode === 403)) {
-		output.write(`[httpOci] ${res.statusCode}: Credentials for '${service}' may be expired. Attempting request anonymously.`, LogLevel.Info);
-		const body = res.resBody?.toString();
-		if (body) {
-			output.write(`${res.resBody.toString()}.`, LogLevel.Info);
-		}
-
-		// Build a fresh GET so neither an Authorization header nor a refresh-token POST body is reused.
-		httpOptions = createGetHttpOptions();
+	let res: Awaited<ReturnType<typeof requestResolveHeadersNoRedirects>>;
+	try {
 		res = await requestResolveHeadersNoRedirects(httpOptions, output);
+		if (sentCredentials && (res.statusCode === 401 || res.statusCode === 403)) {
+			output.write(`[httpOci] ${res.statusCode}: Credentials for '${service}' may be expired. Attempting request anonymously.`, LogLevel.Info);
+			const body = res.resBody?.toString();
+			if (body) {
+				output.write(`${res.resBody.toString()}.`, LogLevel.Info);
+			}
+
+			// Build a fresh GET so neither an Authorization header nor a refresh-token POST body is reused.
+			httpOptions = createGetHttpOptions();
+			res = await requestResolveHeadersNoRedirects(httpOptions, output);
+		}
+	} catch (err) {
+		output.write(`[httpOci] Failed to request bearer token for '${service}': ${err}`, LogLevel.Error);
+		return;
 	}
 
-	if (!res || res.statusCode > 299 || !res.resBody) {
+	if (res.statusCode > 299 || !res.resBody) {
 		output.write(`[httpOci] ${res.statusCode}: Failed to fetch bearer token for '${service}': ${res.resBody.toString()}`, LogLevel.Error);
 		return;
 	}

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -165,6 +165,7 @@ export async function requestEnsureAuthenticated(params: CommonParams, httpOptio
 			}
 			// Reject the challenge before credential lookup or token-endpoint I/O.
 			if (!isAllowedTokenServiceRealm(realmGroup[1], ociRef.registry)) {
+				delete cachedAuthHeader[ociRef.registry];
 				output.write(`[httpOci] ERR: Refusing bearer token realm '${realmGroup[1]}' for registry '${ociRef.registry}'.`, LogLevel.Error);
 				return;
 			}

--- a/src/spec-configuration/httpOCIRegistry.ts
+++ b/src/spec-configuration/httpOCIRegistry.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as jsonc from 'jsonc-parser';
 
 import { runCommandNoPty, plainExec } from '../spec-common/commonUtils';
-import { requestResolveHeaders } from '../spec-utils/httpRequest';
+import { requestResolveHeaders, requestResolveHeadersNoRedirects } from '../spec-utils/httpRequest';
 import { LogLevel } from '../spec-utils/log';
 import { isLocalFile, readLocalFile } from '../spec-utils/pfs';
 import { CommonParams, OCICollectionRef, OCIRef } from './containerCollectionsOCI';
@@ -34,6 +34,69 @@ interface CredentialHelperResult {
 const realmRegex = /realm="([^"]+)"/;
 const serviceRegex = /service="([^"]+)"/;
 const scopeRegex = /scope="([^"]+)"/;
+
+type RegistryCredentialType = 'basic' | 'refreshToken';
+
+// Endpoint admission and credential forwarding are separate policies: an allowed
+// token service does not automatically receive credentials stored for the registry.
+export function canForwardCredentialToTokenService(realm: string, registry: string, credentialType: RegistryCredentialType): boolean {
+	let realmUrl: URL;
+	try {
+		realmUrl = new URL(realm);
+	} catch {
+		return false;
+	}
+
+	const normalizedRegistry = registry.toLowerCase();
+	if (realmUrl.host.toLowerCase() === normalizedRegistry) {
+		// Preserve HTTP localhost registries used for local Feature development.
+		return realmUrl.protocol === 'https:'
+			|| realmUrl.protocol === 'http:' && realmUrl.hostname.toLowerCase() === 'localhost';
+	}
+
+	// Docker Hub is the only supported cross-authority credential exchange.
+	return credentialType === 'basic'
+		&& realmUrl.protocol === 'https:'
+		&& !realmUrl.port
+		&& realmUrl.hostname.toLowerCase() === 'auth.docker.io'
+		&& (normalizedRegistry === 'docker.io'
+			|| normalizedRegistry === 'registry.docker.io'
+			|| normalizedRegistry === 'registry-1.docker.io');
+}
+
+// Pin registry-directed token requests to the registry authority or known OCI token services.
+export function isAllowedTokenServiceRealm(realm: string, registry: string): boolean {
+	let realmUrl: URL;
+	try {
+		realmUrl = new URL(realm);
+	} catch {
+		return false;
+	}
+
+	const sameAuthority = realmUrl.host.toLowerCase() === registry.toLowerCase();
+	if (realmUrl.protocol !== 'https:') {
+		return realmUrl.protocol === 'http:'
+			&& realmUrl.hostname.toLowerCase() === 'localhost'
+			&& sameAuthority;
+	}
+
+	if (sameAuthority) {
+		return true;
+	}
+
+	if (realmUrl.port) {
+		return false;
+	}
+
+	// Cross-authority services must use their standard HTTPS authority.
+	const hostname = realmUrl.hostname.toLowerCase();
+	const azureRegistryLabels = hostname.endsWith('.azurecr.io')
+		? hostname.slice(0, -'.azurecr.io'.length).split('.')
+		: [];
+	return hostname === 'auth.docker.io'
+		|| hostname === 'ghcr.io'
+		|| azureRegistryLabels.length > 0 && azureRegistryLabels.every(Boolean);
+}
 
 // https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate
 export async function requestEnsureAuthenticated(params: CommonParams, httpOptions: { type: string; url: string; headers: HEADERS; data?: Buffer }, ociRef: OCIRef | OCICollectionRef) {
@@ -98,6 +161,11 @@ export async function requestEnsureAuthenticated(params: CommonParams, httpOptio
 
 			if (!realmGroup || !serviceGroup) {
 				output.write(`[httpOci] WWW-Authenticate header is not in expected format. Got:  ${wwwAuthenticate}`, LogLevel.Trace);
+				return;
+			}
+			// Reject the challenge before credential lookup or token-endpoint I/O.
+			if (!isAllowedTokenServiceRealm(realmGroup[1], ociRef.registry)) {
+				output.write(`[httpOci] ERR: Refusing bearer token realm '${realmGroup[1]}' for registry '${ociRef.registry}'.`, LogLevel.Error);
 				return;
 			}
 
@@ -335,15 +403,6 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 	const { output } = params;
 	const { realm, service, scope } = wwwAuthenticateData;
 
-	// TODO: Remove this.
-	if (realm.includes('mcr.microsoft.com')) {
-		return undefined;
-	}
-
-	const headers: HEADERS = {
-		'user-agent': 'devcontainer'
-	};
-
 	// The token server should first attempt to authenticate the client using any authentication credentials provided with the request.
 	// From Docker 1.11 the Docker engine supports both Basic Authentication and OAuth2 for getting tokens. 
 	// Docker 1.10 and before, the registry client in the Docker Engine only supports Basic Authentication. 
@@ -353,12 +412,42 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 	const userCredential = await getCredential(params, ociRef);
 	const basicAuthCredential = userCredential?.base64EncodedCredential;
 	const refreshToken = userCredential?.refreshToken;
+	const canForwardBasicCredential = canForwardCredentialToTokenService(realm, ociRef.registry, 'basic');
+	const canForwardRefreshToken = canForwardCredentialToTokenService(realm, ociRef.registry, 'refreshToken');
 
 	let httpOptions: { type: string; url: string; headers: Record<string, string>; data?: Buffer };
+	let sentCredentials = false;
+
+	const createGetHttpOptions = (authorization?: string) => {
+		// URLSearchParams preserves existing realm parameters and encodes challenge values.
+		const url = new URL(realm);
+		url.searchParams.set('service', service);
+		url.searchParams.set('scope', scope);
+
+		const headers: Record<string, string> = {
+			'user-agent': 'devcontainer',
+		};
+		if (authorization) {
+			headers.authorization = authorization;
+		}
+
+		return {
+			type: 'GET',
+			url: url.toString(),
+			headers,
+		};
+	};
+
+	if (refreshToken && !canForwardRefreshToken) {
+		output.write(`[httpOci] Refusing to send refresh token to bearer token realm '${realm}' for registry '${ociRef.registry}'.`, LogLevel.Warning);
+	}
+	if (basicAuthCredential && !canForwardBasicCredential) {
+		output.write(`[httpOci] Refusing to send Basic credential to bearer token realm '${realm}' for registry '${ociRef.registry}'.`, LogLevel.Warning);
+	}
 
 	// There are several different ways registries expect to handle the oauth token exchange. 
 	// Depending on the type of credential available, use the most reasonable method.
-	if (refreshToken) {
+	if (refreshToken && canForwardRefreshToken) {
 		const form_url_encoded = new URLSearchParams();
 		form_url_encoded.append('client_id', 'devcontainer');
 		form_url_encoded.append('grant_type', 'refresh_token');
@@ -366,48 +455,44 @@ async function fetchRegistryBearerToken(params: CommonParams, ociRef: OCIRef | O
 		form_url_encoded.append('scope', scope);
 		form_url_encoded.append('refresh_token', refreshToken);
 
-		headers['content-type'] = 'application/x-www-form-urlencoded';
-
 		const url = realm;
 		output.write(`[httpOci] Attempting to fetch bearer token from:  ${url}`, LogLevel.Trace);
 
 		httpOptions = {
 			type: 'POST',
 			url,
-			headers: headers,
+			headers: {
+				'user-agent': 'devcontainer',
+				'content-type': 'application/x-www-form-urlencoded',
+			},
 			data: Buffer.from(form_url_encoded.toString())
 		};
+		sentCredentials = true;
 	} else {
-		if (basicAuthCredential) {
-			headers['authorization'] = `Basic ${basicAuthCredential}`;
-		}
-
 		// realm="https://auth.docker.io/token"
 		// service="registry.docker.io"
 		// scope="repository:samalba/my-app:pull,push"
 		// Example:
 		// https://auth.docker.io/token?service=registry.docker.io&scope=repository:samalba/my-app:pull,push
-		const url = `${realm}?service=${service}&scope=${scope}`;
-		output.write(`[httpOci] Attempting to fetch bearer token from:  ${url}`, LogLevel.Trace);
-
-		httpOptions = {
-			type: 'GET',
-			url: url,
-			headers: headers,
-		};
+		const authorization = basicAuthCredential && canForwardBasicCredential
+			? `Basic ${basicAuthCredential}`
+			: undefined;
+		httpOptions = createGetHttpOptions(authorization);
+		sentCredentials = !!authorization;
+		output.write(`[httpOci] Attempting to fetch bearer token from:  ${httpOptions.url}`, LogLevel.Trace);
 	}
 
-	let res = await requestResolveHeaders(httpOptions, output);
-	if (res && res.statusCode === 401 || res.statusCode === 403) {
+	let res = await requestResolveHeadersNoRedirects(httpOptions, output);
+	if (sentCredentials && (res.statusCode === 401 || res.statusCode === 403)) {
 		output.write(`[httpOci] ${res.statusCode}: Credentials for '${service}' may be expired. Attempting request anonymously.`, LogLevel.Info);
 		const body = res.resBody?.toString();
 		if (body) {
 			output.write(`${res.resBody.toString()}.`, LogLevel.Info);
 		}
 
-		// Try again without user credentials. If we're here, their creds are likely expired.
-		delete headers['authorization'];
-		res = await requestResolveHeaders(httpOptions, output);
+		// Build a fresh GET so neither an Authorization header nor a refresh-token POST body is reused.
+		httpOptions = createGetHttpOptions();
+		res = await requestResolveHeadersNoRedirects(httpOptions, output);
 	}
 
 	if (!res || res.statusCode > 299 || !res.resBody) {

--- a/src/spec-utils/httpRequest.ts
+++ b/src/spec-utils/httpRequest.ts
@@ -79,9 +79,25 @@ export async function headRequest(options: { url: string; headers: Record<string
 	});
 }
 
+type RequestResolveHeadersOptions = {
+	type: string;
+	url: string;
+	headers: Record<string, string>;
+	data?: Buffer;
+};
+
 // Send HTTP Request.
 // Does not throw on status code, but rather always returns 'statusCode', 'resHeaders', and 'resBody'.
-export async function requestResolveHeaders(options: { type: string; url: string; headers: Record<string, string>; data?: Buffer }, output: Log) {
+export async function requestResolveHeaders(options: RequestResolveHeadersOptions, output: Log) {
+	return requestResolveHeadersInternal(options, output);
+}
+
+// Token endpoints must not redirect around their validated authority boundary.
+export async function requestResolveHeadersNoRedirects(options: RequestResolveHeadersOptions, output: Log) {
+	return requestResolveHeadersInternal(options, output, 0);
+}
+
+async function requestResolveHeadersInternal(options: RequestResolveHeadersOptions, output: Log, maxRedirects?: number) {
 	const secureContext = await secureContextWithExtraCerts(output);
 	return new Promise<{ statusCode: number; resHeaders: Record<string, string>; resBody: Buffer }>((resolve, reject) => {
 		const parsed = new url.URL(options.url);
@@ -95,6 +111,9 @@ export async function requestResolveHeaders(options: { type: string; url: string
 			agent: new ProxyAgent(),
 			secureContext,
 		};
+		if (maxRedirects !== undefined) {
+			reqOptions.maxRedirects = maxRedirects;
+		}
 
 		const plainHTTP = parsed.protocol === 'http:' || parsed.hostname === 'localhost';
 		if (plainHTTP) {

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -46,6 +46,18 @@ describe('getCollectionRef()', async function () {
         assert.equal(collectionRef.tag, collectionRef.version);
     });
 
+    it('valid getCollectionRef() with localhost and IP registries', async () => {
+        assert.equal(getCollectionRef(output, 'localhost:5000', 'devcontainers/templates')?.registry, 'localhost:5000');
+        assert.equal(getCollectionRef(output, '127.0.0.1:5000', 'devcontainers/templates')?.registry, '127.0.0.1:5000');
+        assert.equal(getCollectionRef(output, '[::1]:5000', 'devcontainers/templates')?.registry, '[::1]:5000');
+    });
+
+    it('invalid getCollectionRef() with malformed registry authorities', async () => {
+        for (const registry of ['https://ghcr.io', 'user@ghcr.io', 'ghcr.io/path', '.ghcr.io', 'ghcr..io', 'ghcr_io', 'ghcr.io:', 'ghcr.io:0', 'ghcr.io:65536']) {
+            assert.isUndefined(getCollectionRef(output, registry, 'devcontainers/templates'), registry);
+        }
+    });
+
     it('invalid getCollectionRef() with an invalid character in path', async () => {
         const collectionRef = getCollectionRef(output, 'ghcr.io', 'devcont%ainers/templates');
         assert.isUndefined(collectionRef);
@@ -210,6 +222,18 @@ describe('getRef()', async function () {
         assert.equal(feat.path, 'a/b/c');
         assert.equal(feat.tag, 'latest'); // Defaults to 'latest' if not version supplied. 
         assert.equal(feat.tag, feat.version);
+    });
+
+    it('valid getRef() with localhost and IP registries', async () => {
+        assert.equal(getRef(output, 'localhost:5000/a/b/c')?.registry, 'localhost:5000');
+        assert.equal(getRef(output, '127.0.0.1:5000/a/b/c')?.registry, '127.0.0.1:5000');
+        assert.equal(getRef(output, '[::1]:5000/a/b/c')?.registry, '[::1]:5000');
+    });
+
+    it('invalid getRef() with malformed registry authorities', async () => {
+        for (const registry of ['user@ghcr.io', '.ghcr.io', 'ghcr..io', 'ghcr_io', 'ghcr.io:', 'ghcr.io:0', 'ghcr.io:65536']) {
+            assert.isUndefined(getRef(output, `${registry}/a/b/c`), registry);
+        }
     });
 
     it('invalid getRef() with duplicate version tags', async () => {

--- a/src/test/container-features/containerFeaturesOCI.test.ts
+++ b/src/test/container-features/containerFeaturesOCI.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { getRef, getManifest, getBlob, getCollectionRef } from '../../spec-configuration/containerCollectionsOCI';
+import { fetchOCIManifestIfExists, getRef, getManifest, getBlob, getCollectionRef } from '../../spec-configuration/containerCollectionsOCI';
 import { createPlainLog, LogLevel, makeLog } from '../../spec-utils/log';
 
 export const output = makeLog(createPlainLog(text => process.stdout.write(text), () => LogLevel.Trace));
@@ -72,6 +72,14 @@ describe('getCollectionRef()', async function () {
 
 describe('getRef()', async function () {
     this.timeout('120s');
+
+    it('does not fetch an OCI manifest for a legacy single-label Feature ID', async () => {
+        const featureRef = getRef(output, 'codspace/myfeatures/helloworld');
+        assert.isDefined(featureRef);
+
+        const manifest = await fetchOCIManifestIfExists({ env: {}, output }, featureRef!);
+        assert.isUndefined(manifest);
+    });
 
     it('valid getRef() with a tag', async () => {
         const feat = getRef(output, 'ghcr.io/devcontainers/templates/docker-from-docker:latest');

--- a/src/test/httpOCIRegistry.test.ts
+++ b/src/test/httpOCIRegistry.test.ts
@@ -152,21 +152,16 @@ describe('OCI registry authentication', () => {
 				version: 'latest',
 			};
 
-			let error: NodeJS.ErrnoException | undefined;
-			try {
-				await requestEnsureAuthenticated({
-					env: { DEVCONTAINERS_OCI_AUTH: `${registry}|user|token` },
-					output: nullLog,
-				}, {
-					type: 'GET',
-					url: `http://${registry}/v2/test/features/manifests/latest`,
-					headers: {},
-				}, ociRef);
-			} catch (err) {
-				error = err;
-			}
+			const result = await requestEnsureAuthenticated({
+				env: { DEVCONTAINERS_OCI_AUTH: `${registry}|user|token` },
+				output: nullLog,
+			}, {
+				type: 'GET',
+				url: `http://${registry}/v2/test/features/manifests/latest`,
+				headers: {},
+			}, ociRef);
 
-			assert.equal(error?.code, 'ERR_FR_TOO_MANY_REDIRECTS');
+			assert.isUndefined(result);
 			assert.equal(registryRequests, 2);
 			assert.equal(redirectTargetRequests, 0);
 		} finally {

--- a/src/test/httpOCIRegistry.test.ts
+++ b/src/test/httpOCIRegistry.test.ts
@@ -1,0 +1,247 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+
+import { assert } from 'chai';
+
+import { OCICollectionRef } from '../spec-configuration/containerCollectionsOCI';
+import { canForwardCredentialToTokenService, isAllowedTokenServiceRealm, requestEnsureAuthenticated } from '../spec-configuration/httpOCIRegistry';
+import { nullLog } from '../spec-utils/log';
+
+describe('OCI registry authentication', () => {
+	describe('isAllowedTokenServiceRealm', () => {
+		const cases = [
+			{ realm: 'https://registry.example/token', registry: 'registry.example', expected: true },
+			{ realm: 'https://REGISTRY.EXAMPLE/token', registry: 'registry.example', expected: true },
+			{ realm: 'https://registry.example:8443/token', registry: 'registry.example:8443', expected: true },
+			{ realm: 'https://registry.example:8443/token', registry: 'registry.example', expected: false },
+			{ realm: 'https://registry.example/token', registry: 'registry.example:8443', expected: false },
+			{ realm: 'http://registry.example/token', registry: 'registry.example', expected: false },
+			{ realm: 'http://localhost:5000/token', registry: 'localhost:5000', expected: true },
+			{ realm: 'http://localhost:5001/token', registry: 'localhost:5000', expected: false },
+			{ realm: 'not-a-url', registry: 'registry.example', expected: false },
+			{ realm: '/token', registry: 'registry.example', expected: false },
+			{ realm: 'https://auth.docker.io/token', registry: 'registry-1.docker.io', expected: true },
+			{ realm: 'https://auth.docker.io/token', registry: 'docker.io', expected: true },
+			{ realm: 'https://auth.docker.io/token', registry: 'attacker.example', expected: true },
+			{ realm: 'http://auth.docker.io/token', registry: 'registry-1.docker.io', expected: false },
+			{ realm: 'https://ghcr.io/token', registry: 'ghcr.io', expected: true },
+			{ realm: 'https://ghcr.io/token', registry: 'containers.example', expected: true },
+			{ realm: 'http://ghcr.io/token', registry: 'containers.example', expected: false },
+			{ realm: 'https://registry.azurecr.io/oauth2/token', registry: 'registry.azurecr.io', expected: true },
+			{ realm: 'https://registry.azurecr.io/oauth2/token', registry: 'containers.example', expected: true },
+			{ realm: 'http://registry.azurecr.io/oauth2/token', registry: 'containers.example', expected: false },
+			{ realm: 'https://nested.registry.azurecr.io/oauth2/token', registry: 'nested.registry.azurecr.io', expected: true },
+			{ realm: 'https://nested.registry.azurecr.io/oauth2/token', registry: 'containers.example', expected: true },
+			{ realm: 'https://azurecr.io/oauth2/token', registry: 'containers.example', expected: false },
+			{ realm: 'https://.azurecr.io/oauth2/token', registry: 'containers.example', expected: false },
+			{ realm: 'https://registry.azurecr.io.attacker.example/token', registry: 'containers.example', expected: false },
+			{ realm: 'https://auth.docker.io.attacker.example/token', registry: 'containers.example', expected: false },
+			{ realm: 'https://auth.docker.io:8443/token', registry: 'containers.example', expected: false },
+			{ realm: 'http://127.0.0.1/token', registry: 'attacker.example', expected: false },
+			{ realm: 'http://169.254.169.254/token', registry: 'attacker.example', expected: false },
+		];
+
+		for (const { realm, registry, expected } of cases) {
+			it(`${expected ? 'allows' : 'rejects'} '${realm}' for '${registry}'`, () => {
+				assert.equal(isAllowedTokenServiceRealm(realm, registry), expected);
+			});
+		}
+	});
+
+	describe('canForwardCredentialToTokenService', () => {
+		it('allows Basic and refresh credentials for exact HTTP localhost authority', () => {
+			const realm = 'http://localhost:5000/token';
+			assert.isTrue(canForwardCredentialToTokenService(realm, 'localhost:5000', 'basic'));
+			assert.isTrue(canForwardCredentialToTokenService(realm, 'localhost:5000', 'refreshToken'));
+		});
+
+		it('rejects credentials over remote HTTP even for the same authority', () => {
+			const realm = 'http://registry.example/token';
+			assert.isFalse(canForwardCredentialToTokenService(realm, 'registry.example', 'basic'));
+			assert.isFalse(canForwardCredentialToTokenService(realm, 'registry.example', 'refreshToken'));
+		});
+
+		it('allows only Basic credentials for the Docker Hub token service', () => {
+			const realm = 'https://auth.docker.io/token';
+			assert.isTrue(canForwardCredentialToTokenService(realm, 'registry-1.docker.io', 'basic'));
+			assert.isFalse(canForwardCredentialToTokenService(realm, 'registry-1.docker.io', 'refreshToken'));
+		});
+
+		it('rejects credentials for token services owned by another registry', () => {
+			assert.isFalse(canForwardCredentialToTokenService('https://auth.docker.io/token', 'attacker.example', 'basic'));
+			assert.isFalse(canForwardCredentialToTokenService('https://ghcr.io/token', 'attacker.example', 'basic'));
+			assert.isFalse(canForwardCredentialToTokenService('https://registry.azurecr.io/token', 'attacker.example', 'refreshToken'));
+		});
+	});
+
+	it('does not request a rejected bearer token realm', async () => {
+		let registryRequests = 0;
+		let tokenRequests = 0;
+		const tokenServer = http.createServer((_request, response) => {
+			tokenRequests++;
+			response.end(JSON.stringify({ token: 'internal-secret' }));
+		});
+		const tokenPort = await listen(tokenServer);
+		const registryServer = http.createServer((_request, response) => {
+			registryRequests++;
+			response.writeHead(401, {
+				'WWW-Authenticate': `Bearer realm="http://localhost:${tokenPort}/token",service="attacker.example",scope="repository:test:pull"`,
+			});
+			response.end();
+		});
+		const registryPort = await listen(registryServer);
+
+		try {
+			const registry = `127.0.0.1:${registryPort}`;
+			const ociRef: OCICollectionRef = {
+				registry,
+				path: 'test/features',
+				resource: `${registry}/test/features`,
+				tag: 'latest',
+				version: 'latest',
+			};
+			const cachedAuthHeader: Record<string, string> = {};
+
+			const result = await requestEnsureAuthenticated({ env: {}, output: nullLog, cachedAuthHeader }, {
+				type: 'GET',
+				url: `http://${registry}/v2/test/features/manifests/latest`,
+				headers: {},
+			}, ociRef);
+
+			assert.isUndefined(result);
+			assert.equal(registryRequests, 1);
+			assert.equal(tokenRequests, 0);
+			assert.notProperty(cachedAuthHeader, registry);
+		} finally {
+			await Promise.all([close(registryServer), close(tokenServer)]);
+		}
+	});
+
+	it('does not follow redirects from a bearer token realm', async () => {
+		let redirectTargetRequests = 0;
+		const redirectTargetServer = http.createServer((_request, response) => {
+			redirectTargetRequests++;
+			response.end(JSON.stringify({ token: 'internal-secret' }));
+		});
+		const redirectTargetPort = await listen(redirectTargetServer);
+
+		let registryRequests = 0;
+		const registryServer = http.createServer((request, response) => {
+			registryRequests++;
+			if (request.url?.startsWith('/token')) {
+				response.writeHead(302, { location: `http://localhost:${redirectTargetPort}/token` });
+				response.end();
+				return;
+			}
+
+			const registryPort = (registryServer.address() as AddressInfo).port;
+			response.writeHead(401, {
+				'WWW-Authenticate': `Bearer realm="http://localhost:${registryPort}/token",service="localhost:${registryPort}",scope="repository:test:pull"`,
+			});
+			response.end();
+		});
+		const registryPort = await listen(registryServer);
+		const registry = `localhost:${registryPort}`;
+
+		try {
+			const ociRef: OCICollectionRef = {
+				registry,
+				path: 'test/features',
+				resource: `${registry}/test/features`,
+				tag: 'latest',
+				version: 'latest',
+			};
+
+			let error: NodeJS.ErrnoException | undefined;
+			try {
+				await requestEnsureAuthenticated({
+					env: { DEVCONTAINERS_OCI_AUTH: `${registry}|user|token` },
+					output: nullLog,
+				}, {
+					type: 'GET',
+					url: `http://${registry}/v2/test/features/manifests/latest`,
+					headers: {},
+				}, ociRef);
+			} catch (err) {
+				error = err;
+			}
+
+			assert.equal(error?.code, 'ERR_FR_TOO_MANY_REDIRECTS');
+			assert.equal(registryRequests, 2);
+			assert.equal(redirectTargetRequests, 0);
+		} finally {
+			await Promise.all([close(registryServer), close(redirectTargetServer)]);
+		}
+	});
+
+	it('encodes bearer token service and scope query values', async () => {
+		const service = 'registry.example&injected=service#fragment';
+		const scope = 'repository:test:pull&injected=scope#fragment';
+		const token = 'registry-token';
+		let registryRequests = 0;
+		let tokenRequests = 0;
+		const registryServer = http.createServer((request, response) => {
+			const registryPort = (registryServer.address() as AddressInfo).port;
+			if (request.url?.startsWith('/token')) {
+				tokenRequests++;
+				const tokenUrl = new URL(request.url, `http://localhost:${registryPort}`);
+				assert.equal(tokenUrl.searchParams.get('existing'), 'value');
+				assert.equal(tokenUrl.searchParams.get('service'), service);
+				assert.equal(tokenUrl.searchParams.get('scope'), scope);
+				assert.isFalse(tokenUrl.searchParams.has('injected'));
+				response.end(JSON.stringify({ token }));
+				return;
+			}
+
+			registryRequests++;
+			if (request.headers.authorization === `Bearer ${token}`) {
+				response.writeHead(200);
+				response.end();
+				return;
+			}
+
+			response.writeHead(401, {
+				'WWW-Authenticate': `Bearer realm="http://localhost:${registryPort}/token?existing=value#realm-fragment",service="${service}",scope="${scope}"`,
+			});
+			response.end();
+		});
+		const registryPort = await listen(registryServer);
+		const registry = `localhost:${registryPort}`;
+
+		try {
+			const ociRef: OCICollectionRef = {
+				registry,
+				path: 'test/features',
+				resource: `${registry}/test/features`,
+				tag: 'latest',
+				version: 'latest',
+			};
+
+			const result = await requestEnsureAuthenticated({ env: {}, output: nullLog }, {
+				type: 'GET',
+				url: `http://${registry}/v2/test/features/manifests/latest`,
+				headers: {},
+			}, ociRef);
+
+			assert.equal(result?.statusCode, 200);
+			assert.equal(registryRequests, 2);
+			assert.equal(tokenRequests, 1);
+		} finally {
+			await close(registryServer);
+		}
+	});
+});
+
+function listen(server: http.Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			server.removeListener('error', reject);
+			resolve((server.address() as AddressInfo).port);
+		});
+	});
+}
+
+function close(server: http.Server): Promise<void> {
+	return new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+}


### PR DESCRIPTION
## Summary

This PR hardens OCI Feature and Template authentication against registry-controlled Bearer token endpoints. The origin of this PR is [this security issue](https://github.com/github/codespaces/issues/24328).

Previously, an OCI registry could return a `WWW-Authenticate: Bearer` challenge containing an arbitrary `realm`. The CLI would request that URL without validating its scheme or authority, potentially:

- Issuing requests to loopback, link-local, private-network, or cloud metadata endpoints.
- Sending locally stored Basic credentials or OAuth refresh tokens to an attacker-selected endpoint.
- Following redirects from an initially accepted token endpoint.
- Allowing `service` and `scope` values to inject additional query parameters or fragments.
- Returning a token-shaped response to the attacker-controlled registry as a Bearer credential.

This PR validates Bearer realms before credential lookup or token endpoint I/O, restricts credential forwarding separately from endpoint admission, disables token-request redirects, encodes challenge parameters, and validates OCI registry authority syntax.

## Security classification

- [CWE-918: Server-Side Request Forgery](https://cwe.mitre.org/data/definitions/918.html), client-side variant
- CWE-200: Exposure of Sensitive Information
- CWE-522: Insufficiently Protected Credentials
- CWE-319: Cleartext Transmission of Sensitive Information

The vulnerable flow can be reached through Feature or Template identifiers supplied by an untrusted workspace's `devcontainer.json`.

## Threat model

A victim opens or builds an untrusted repository containing an attacker-selected OCI Feature or Template reference.

The Dev Container CLI may run directly through commands such as `devcontainer up` and `devcontainer build`, or transitively through the VS Code Dev Containers extension, Codespaces, or prebuild tooling.

The attacker controls the registry response and its `WWW-Authenticate` challenge. Before this change, that challenge could direct the victim's machine to an arbitrary Bearer token endpoint.

## Changes

### Validate Bearer token realms

`requestEnsureAuthenticated()` now validates the challenge `realm` before:

- Looking up registry credentials.
- Sending Basic credentials.
- Sending a refresh token.
- Making any token endpoint request.

Malformed, relative, or disallowed realms terminate authentication without contacting the token endpoint.

The following realm policy is applied:

| Realm | Result |
| --- | --- |
| HTTPS with the exact registry authority, including port | Allowed |
| HTTP with the exact `localhost` authority and matching port | Allowed |
| `https://auth.docker.io` without a custom port | Allowed |
| `https://ghcr.io` without a custom port | Allowed |
| Proper `*.azurecr.io` HTTPS authority without a custom port | Allowed |
| Remote HTTP endpoint | Rejected |
| HTTP IP literal | Rejected |
| Different `localhost` port | Rejected |
| Arbitrary cross-authority HTTPS endpoint | Rejected |
| Relative or malformed URL | Rejected |
| Known service with a custom port | Rejected |
| Forged suffix such as `auth.docker.io.attacker.example` | Rejected |
| Bare or malformed Azure authority | Rejected |

Authority comparisons are case-insensitive, and ports remain part of exact-authority matching.

### Separate endpoint admission from credential forwarding

Token endpoint admission and credential forwarding are intentionally separate policies.

An endpoint may be safe to contact anonymously without being allowed to receive credentials stored for the registry. This prevents an attacker-controlled registry from naming a known token service and causing credentials for the attacker registry to be forwarded there.

Basic credentials and refresh tokens may be sent only when:

- The realm uses HTTPS and exactly matches the registry authority.
- The realm uses HTTP on exact same-authority `localhost`, including the same port.

Docker Hub requires a compatibility exception because its registries authenticate through a separate authority:

- Basic credentials may be sent from `docker.io`, `registry.docker.io`, or `registry-1.docker.io` to `https://auth.docker.io`.
- Refresh tokens are not forwarded across that authority boundary.
- Custom ports are not accepted for the Docker Hub token service.

When credentials cannot be forwarded, the CLI logs a warning and attempts anonymous token acquisition.

### Rebuild anonymous fallback requests

A credentialed token request that receives `401` or `403` is retried anonymously.

The anonymous retry is constructed as a fresh GET request rather than reusing the credentialed request. This ensures that neither of the following can be replayed:

- A Basic `Authorization` header.
- A refresh-token POST body.

Anonymous requests are not redundantly retried after `401` or `403`.

### Disable redirects for Bearer token requests

A dedicated `requestResolveHeadersNoRedirects()` wrapper now sends Bearer token requests with `maxRedirects: 0`.

This applies to:

- Basic-authenticated token GET requests.
- Refresh-token POST requests.
- Anonymous token GET requests.
- Anonymous fallback requests.

This prevents an accepted token endpoint from redirecting the request to another authority.

Normal HTTP operations retain their existing redirect behavior. Redirect suppression is limited to token requests whose validated authority forms a security boundary.

### Encode `service` and `scope`

Bearer token GET requests now use `URL` and `URL.searchParams.set()` instead of interpolating challenge values into a URL string.

This:

- Percent-encodes `service` and `scope`.
- Prevents query parameter injection.
- Prevents fragment injection through challenge values.
- Preserves unrelated query parameters already present in the realm.
- Replaces existing `service` and `scope` parameters deterministically.

Refresh-token POST bodies continue to use `URLSearchParams`.

### Validate registry authority syntax

`getRef()` and `getCollectionRef()` now validate registry authority syntax before constructing an OCI reference.

Accepted registry forms include:

- Valid DNS hostnames.
- Syntactically valid single-label authorities.
- IPv4 literals.
- Bracketed IPv6 literals.
- Optional numeric ports from `1` through `65535`.
- Local registries such as `localhost:5000`.

Rejected forms include:

- Schemes such as `https://`.
- User information such as `user@registry`.
- Path, query, or fragment-shaped authorities.
- Empty or malformed DNS labels.
- DNS labels beginning or ending with `-`.
- Unbracketed IPv6 literals.
- Missing, non-numeric, zero, or out-of-range ports.

This validation checks authority shape only. It does not impose a global network trust policy on user-configured registries.

### Preserve legacy Feature resolution

The original implementation contained an early check that prevented single-label identifiers from being resolved as OCI registries. Removing it caused legacy Feature identifiers such as:

```text
codspace/myfeatures/helloworld
```

to trigger a request to:

```text
https://codspace/v2/myfeatures/helloworld/manifests/latest
```

This caused existing tests and configurations to fail with errors such as:

```text
getaddrinfo EAI_AGAIN codspace
```

The compatibility behavior has therefore been restored at manifest resolution time.

Single-label references continue to fall back to the legacy GitHub Releases Feature flow, except for explicitly supported local or IP-literal registries:

- `localhost`
- IPv4 literals
- Bracketed IPv6 literals

The authority parser can still validate single-label authorities, but OCI manifest probing preserves the historical interpretation of ambiguous three-segment Feature identifiers.

### Remove the MCR substring workaround

The previous special case:

```ts
if (realm.includes('mcr.microsoft.com')) {
    return undefined;
}
```

has been removed.

Substring matching is not a valid security boundary and could also match attacker-controlled hosts such as:

```text
mcr.microsoft.com.attacker.example
```

MCR realms are now governed by the same parsed URL, protocol, authority, redirect, and credential-forwarding policies as other registries.

## Deviations from the original remediation

### Exact-authority localhost HTTP remains supported

The original recommendation proposed rejecting every non-HTTPS realm and requiring an explicit opt-in for localhost.

This PR retains HTTP only when:

- The hostname is exactly `localhost`.
- The token realm authority exactly matches the registry authority.
- The port matches.

This preserves established local Feature and Template development workflows using registries such as:

```text
http://localhost:<port>
```

The exception does not permit:

- Remote HTTP registries.
- HTTP IP-literal realms.
- A different localhost port.
- Cross-authority HTTP token services.

### Local, private, and IP-literal registries remain supported

The original recommendation proposed rejecting loopback, private-network, and IP-literal registries at the source.

This PR intentionally performs syntax validation rather than globally blocking those registries because the CLI supports:

- Local development registries.
- On-premises registries.
- Private-network registries.
- IPv4 registries.
- Bracketed IPv6 registries.

Rejecting these authorities globally would be a breaking policy change. It would also not completely prevent DNS-based SSRF without resolving addresses and enforcing network policy across every connection and redirect hop.

The fix is instead applied at the vulnerable secondary-request boundary: a registry-controlled Bearer challenge cannot pivot token acquisition to an arbitrary internal or attacker-selected authority.

### No `--allow-insecure-registry` option was introduced

The original recommendation suggested adding an explicit insecure-registry option.

This PR does not add a new CLI configuration surface. It preserves the existing exact-authority localhost workflow while rejecting remote HTTP Bearer realms.

A broader insecure-registry policy can be considered separately if explicit configuration becomes necessary.

### Known token services remain available

The realm policy allows standard HTTPS endpoints used by Docker Hub, GHCR, and Azure Container Registry:

- `auth.docker.io`
- `ghcr.io`
- Proper subdomains of `azurecr.io`

This follows the compatibility allowance in the original recommendation.

These endpoints may receive anonymous token requests, but credential forwarding is evaluated independently. An attacker-controlled registry therefore cannot use the endpoint allow-list to send its stored credentials to one of these services.

### Registry validation does not reject every single-label authority

The authority validator accepts syntactically valid single-label names because they can represent valid local or enterprise authorities.

However, during Feature manifest probing, ambiguous single-label identifiers continue to use the historical legacy GitHub Releases fallback. This avoids breaking existing Feature references such as `codspace/myfeatures/helloworld`.

### Workspace trust behavior is unchanged

The original report suggested considering an explicit workspace-trust prompt before resolving Features from non-default registries.

This PR does not change workspace trust or introduce interactive prompts. Such a change would affect broader product behavior beyond OCI authentication and should be evaluated independently.

## Tests

A focused OCI authentication suite was added covering:

- Exact registry authority matching.
- Case-insensitive host matching.
- Port matching and mismatching.
- HTTPS enforcement.
- Exact-authority localhost HTTP compatibility.
- Localhost port isolation.
- Rejection of malformed and relative realms.
- Docker Hub token endpoint handling.
- GHCR token endpoint handling.
- Azure Container Registry endpoint handling.
- Rejection of forged hostname suffixes.
- Rejection of custom ports on known token services.
- Rejection of loopback and metadata-address HTTP realms.
- Basic credential forwarding policy.
- Refresh-token forwarding policy.
- Docker Hub's Basic-only cross-authority exception.
- Rejection before token endpoint I/O.
- Prevention of token endpoint redirects.
- Encoding of `service` and `scope`.
- Preservation of existing realm query parameters.
- Successful Bearer authentication after safe token acquisition.

OCI reference tests were extended to cover:

- `localhost` registries.
- IPv4 registries.
- Bracketed IPv6 registries.
- Schemes in registry authorities.
- User information.
- Malformed DNS labels.
- Invalid and out-of-range ports.
- Legacy single-label Feature identifiers.
- Prevention of OCI DNS requests for `codspace/myfeatures/helloworld`.

## CI integration

`src/test/httpOCIRegistry.test.ts` has a dedicated entry in the GitHub Actions test matrix.

It is excluded from the catch-all test entry so it runs exactly once and receives an independent matrix result.

The existing parser and legacy Feature regression tests continue to run through the catch-all test shard.

## Validation

Local validation completed successfully:

- OCI authentication suite: 36 passing.
- Focused OCI reference and legacy fallback suite: 27 passing.
- `yarn type-check`
- `yarn lint`
- `yarn package`
- GitHub Actions workflow diagnostics

## Files changed

- `src/spec-configuration/httpOCIRegistry.ts`
  - Bearer realm validation.
  - Credential forwarding policy.
  - Safe anonymous fallback.
  - Structured token query construction.
  - Removal of the MCR substring workaround.

- `src/spec-utils/httpRequest.ts`
  - Dedicated no-redirect request path for Bearer token exchanges.

- `src/spec-configuration/containerCollectionsOCI.ts`
  - Registry authority syntax validation.
  - Legacy single-label Feature fallback.
  - Localhost and IP registry compatibility.

- `src/test/httpOCIRegistry.test.ts`
  - Focused security and authentication tests.

- `src/test/container-features/containerFeaturesOCI.test.ts`
  - Registry parser and legacy fallback regression tests.

- `.github/workflows/dev-containers.yml`
  - Dedicated authentication test matrix entry.
  - Exclusion from the catch-all shard.

## Security outcome

After this change, a malicious OCI registry cannot use its Bearer challenge to:

- Send the CLI to an arbitrary loopback, link-local, private-network, metadata, or attacker-selected token endpoint.
- Downgrade a remote token request to HTTP.
- Redirect a validated token request to another authority.
- Forward registry credentials to an unrelated token endpoint.
- Replay a refresh-token POST body during anonymous fallback.
- Inject additional token query parameters through `service` or `scope`.
- Exploit the removed MCR substring special case.

The CLI continues to support legitimate local, private, Docker Hub, GHCR, Azure Container Registry, and legacy Feature workflows.

## References

- [CWE-918: Server-Side Request Forgery](https://cwe.mitre.org/data/definitions/918.html)
- CWE-200: Exposure of Sensitive Information
- CWE-522: Insufficiently Protected Credentials
- CWE-319: Cleartext Transmission of Sensitive Information
- [Docker Registry Token Authentication Specification](https://docs.docker.com/registry/spec/auth/token/)
- CVE-2024-52308
- GHSA-p2h2-3vg9-4p87