### PR TITLE
Fix flaky tests due to change in feature configuration.

### DIFF
--- a/src/test/container-features/containerFeaturesOrder.test.ts
+++ b/src/test/container-features/containerFeaturesOrder.test.ts
@@ -674,7 +674,8 @@ describe('Feature Dependencies', function () {
                 }
             });
 
-            assert.deepStrictEqual(actual.length, 3);
+            // The deprecated terraform shorthand resolves to terraform:1, which has github-cli as a hard dependency.
+            assert.deepStrictEqual(actual.length, 4);
             assert.deepStrictEqual(actual,
                 [
                     {
@@ -685,6 +686,12 @@ describe('Feature Dependencies', function () {
                         id: 'codspace/myfeatures/helloworld',
                         options: {
                             greeting: 'howdy'
+                        }
+                    },
+                    {
+                        id: 'ghcr.io/devcontainers/features/github-cli',
+                        options: {
+                            version: 'latest'
                         }
                     },
                     {

--- a/src/test/container-features/e2e.test.ts
+++ b/src/test/container-features/e2e.test.ts
@@ -88,7 +88,8 @@ describe('Dev Container Features E2E (remote)', function () {
                 const response = JSON.parse(res.stdout);
                 console.log(res.stderr);
 
-                assert.strictEqual(response.featuresConfiguration?.featureSets.length, 3);
+                // The deprecated terraform shorthand resolves to terraform:1, which has github-cli as a hard dependency.
+                assert.strictEqual(response.featuresConfiguration?.featureSets.length, 4);
 
                 const dind = response?.featuresConfiguration.featureSets.find((f: FeatureSet) => f?.features[0]?.id === 'docker-in-docker');
                 assert.exists(dind);


### PR DESCRIPTION
## Summary

Fixes two flaky/failing tests caused by a change in feature configuration. The deprecated `terraform` shorthand now resolves to `terraform:1`, which declares `github-cli` as a hard dependency. As a result, the resolved feature set includes an additional feature, so the expected counts in the affected tests needed to be updated.

## Changes

- **`src/test/container-features/containerFeaturesOrder.test.ts`**
  - Updated expected resolved feature count from `3` to `4`.
  - Added the expected `ghcr.io/devcontainers/features/github-cli` entry (pulled in transitively via `terraform:1`).
  - Added an inline comment explaining why the extra dependency is present.

- **`src/test/container-features/e2e.test.ts`**
  - Updated the expected `featureSets.length` assertion from `3` to `4` to account for the `github-cli` hard dependency.
  - Added an inline comment for clarity.

## Why

The `terraform` shorthand resolving to `terraform:1` introduces `github-cli` as a hard dependency during feature resolution. The tests were asserting the pre-change counts, causing them to fail intermittently/consistently. This PR realigns the assertions with the current, correct feature resolution behavior.

## Testing

- Verified the affected `Feature Dependencies` and `Dev Container Features E2E (remote)` tests pass with the updated expectations.

## Notes

- Test-only change; no production/runtime code is modified.
- Net diff: **2 files changed, +10 / -2**.