### PR TITLE
Use Podman 5.5.2 for hosted integration tests

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -89,6 +89,19 @@ jobs:
         fi
         cat "$DAEMON_JSON"
         sudo systemctl restart docker
+    - name: Install Podman 5.5.2
+      if: matrix.mocha-args == 'src/test/cli.podman.test.ts'
+      run: |
+        docker build \
+          --build-arg PODMAN_VERSION=v5.5.2 \
+          --target podman \
+          --tag podman-5.5.2-builder \
+          'https://github.com/mgoltzsche/podman-static.git#9ccf992536ecf0a4a3b82ac27fc708f00ab141ab'
+        container_id=$(docker create podman-5.5.2-builder)
+        docker cp "${container_id}:/usr/local/bin/podman" podman
+        docker rm "${container_id}"
+        sudo install -m 0755 podman /usr/local/bin/podman
+        podman --version
     - name: Tools Info
       run: |
         docker info


### PR DESCRIPTION
## Summary

Use Podman 5.5.2 for the Podman Feature integration matrix until a supported newer package includes the upstream layered-build fix.

<details>
<summary>Session Context</summary>

Key decisions and findings from the development session:

- **Preserve rootless coverage**: The Podman tests and Feature workloads remain byte-for-byte identical to `main`; only the Podman executable used by that matrix entry changes.
- **Regression boundary**: Podman 5.5.2 / Buildah 1.40.1 passes. Podman 5.6.0-rc2 / Buildah 1.41.1 and Podman 5.8.6 / Buildah 1.43.2 reset `/tmp` permissions after layered `RUN --mount` and fail APT in the next Feature.
- **Newest release checked**: Podman 6.1.0 / Buildah 1.45.0 passes, but there is no official full-engine Linux binary, Ubuntu package, or `mgoltzsche/podman-static` 6.x bundle. Building it also requires Podman 6-specific recipe and storage configuration changes.
- **Temporary choice**: Use the matching published `mgoltzsche/podman-static` 5.5.2 recipe for now. This avoids disabling layers, changing production Dockerfile generation, or weakening the test to rootful Podman.
- **Supply-chain pinning**: The external `podman-static` build context is pinned to peeled commit `9ccf992536ecf0a4a3b82ac27fc708f00ab141ab`, not the mutable `v5.5.2` tag.

</details>

## Changes

- Build and install the Podman 5.5.2 static binary only for `src/test/cli.podman.test.ts`.
- Pin the external static-build recipe to an immutable commit.
- Make no changes to the Podman tests or Feature workloads.

## Validation

- Podman 5.5.2 / Buildah 1.40.1 passed unchanged rootless integration tests: https://github.com/devcontainers/cli/actions/runs/32339207308/job/96334703376
- Podman 5.8.6 comparison failed: https://github.com/devcontainers/cli/actions/runs/32232412407/job/96004905227
- Podman 6.1.0 comparison passed: https://github.com/devcontainers/cli/actions/runs/32233556192/job/96008438428
