### PR TITLE
BUGFIX: fix the UID update logic

### DIFF
--- a/scripts/updateUID.Dockerfile
+++ b/scripts/updateUID.Dockerfile
@@ -9,7 +9,7 @@ ARG REMOTE_USER
 ARG NEW_UID
 ARG NEW_GID
 SHELL ["/bin/sh", "-c"]
-RUN eval $(sed -n "s/${REMOTE_USER}:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/OLD_UID=\1;OLD_GID=\2;HOME_FOLDER=\3/p" /etc/passwd); \
+RUN eval $(sed -n "s/^${REMOTE_USER}:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/OLD_UID=\1;OLD_GID=\2;HOME_FOLDER=\3/p" /etc/passwd); \
 	eval $(sed -n "s/\([^:]*\):[^:]*:${NEW_UID}:.*/EXISTING_USER=\1/p" /etc/passwd); \
 	eval $(sed -n "s/\([^:]*\):[^:]*:${NEW_GID}:.*/EXISTING_GROUP=\1/p" /etc/group); \
 	if [ -z "$OLD_UID" ]; then \
@@ -24,7 +24,7 @@ RUN eval $(sed -n "s/${REMOTE_USER}:[^:]*:\([^:]*\):\([^:]*\):[^:]*:\([^:]*\).*/
 			NEW_GID="$OLD_GID"; \
 		fi; \
 		echo "Updating UID:GID from $OLD_UID:$OLD_GID to $NEW_UID:$NEW_GID."; \
-		sed -i -e "s/\(${REMOTE_USER}:[^:]*:\)[^:]*:[^:]*/\1${NEW_UID}:${NEW_GID}/" /etc/passwd; \
+		sed -i -e "s/^\(${REMOTE_USER}:[^:]*:\)[^:]*:[^:]*/\1${NEW_UID}:${NEW_GID}/" /etc/passwd; \
 		if [ "$OLD_GID" != "$NEW_GID" ]; then \
 			sed -i -e "s/\([^:]*:[^:]*:\)${OLD_GID}:/\1${NEW_GID}:/" /etc/group; \
 		fi; \


### PR DESCRIPTION
The current logic matches wrongly matches usernames which only contain the string defined as the remote user. (eg: foo-admin matches for admin). This leads to duplicates UIDs being used unexpectedly.

Steps to reproduce the issue:
 - Add a user `foo-admin` using eg: `RUN useradd -M foo-admin`
 - Add a second user (the expected remote_user) called `admin` via `RUN useradd admin`
 - Set the `remote_user` to `admin` in your devcontainer.json
 - Before applying the fix both users will have the same updated UID.