### PR TITLE
Fix Dockerfile ARG continuation parsing

### DIFF
--- a/src/spec-node/dockerfileUtils.ts
+++ b/src/spec-node/dockerfileUtils.ts
@@ -11,7 +11,7 @@ const findFromLines = new RegExp(/^(?<line>\s*FROM.*)/, 'gmi');
 const parseFromLine = /FROM\s+(?<platform>--platform=\S+\s+)?(?<image>"?[^\s]+"?)(\s+AS\s+(?<label>[^\s]+))?/i;
 
 const fromStatement = /^\s*FROM\s+(?<platform>--platform=\S+\s+)?(?<image>"?[^\s]+"?)(\s+AS\s+(?<label>[^\s]+))?/mi;
-const argEnvUserStatements = /^\s*(?<instruction>ARG|ENV|USER)\s+(?<name>[^\s=]+)([ =]+("(?<value1>\S+)"|(?<value2>\S+)))?/gmi;
+const argEnvUserStatements = /^\s*(?<instruction>ARG|ENV|USER)\s+(?<arguments>[^\r\n]*)/gmi;
 const directives = /^\s*#\s*(?<name>\S+)\s*=\s*(?<value>.+)/;
 
 const argumentExpression = /\$\{?(?<variable>[a-zA-Z0-9_]+)(?<isVarExp>:(?<option>-|\+)(?<word>[^\}]+))?\}?/g;
@@ -135,15 +135,28 @@ function extractDirectives(preambleStr: string) {
 }
 
 function extractInstructions(stageStr: string) {
-	return [...stageStr.matchAll(argEnvUserStatements)]
-		.map(match => {
-			const groups = match.groups!;
-			return {
-				instruction: groups.instruction.toUpperCase(),
-				name: groups.name,
-				value: groups.value1 || groups.value2,
-			};
-		});
+	// Docker joins lines ending in a continuation escape before parsing an instruction.
+	const normalizedStageStr = stageStr.replace(/\\[ \t]*(?:\r?\n|\r)/g, ' ');
+	return [...normalizedStageStr.matchAll(argEnvUserStatements)].flatMap(match => {
+		const groups = match.groups!;
+		const instruction = groups.instruction.toUpperCase();
+		const declarations = groups.arguments.matchAll(/([^\s=]+)(?:[ =]+("\S+"|\S+))?/g);
+		const parsed = [];
+		for (const declaration of declarations) {
+			if (declaration[1].startsWith('#')) {
+				break;
+			}
+			parsed.push({
+				instruction,
+				name: declaration[1],
+				value: declaration[2]?.replace(/^"|"$/g, ''),
+			});
+			if (instruction !== 'ARG' && parsed.length === 1) {
+				break;
+			}
+		}
+		return parsed;
+	});
 }
 
 function getExpressionValue(option: string, isSet: boolean, word: string, value: string) {

--- a/src/test/dockerfileUtils.test.ts
+++ b/src/test/dockerfileUtils.test.ts
@@ -245,8 +245,22 @@ FROM base-\${TARGETARCH}
 });
 
 describe('findBaseImage', () => {
+	it('resolves ARG declarations split across continuation lines', () => {
+		const dockerfile = [
+			'ARG VERSION_UNUSED=x \\',
+			'    VERSION_BASE=latest',
+			'FROM alpine:${VERSION_BASE}',
+		].join('\n');
+		const extracted = extractDockerfile(dockerfile);
+		assert.deepEqual(extracted.preamble.instructions, [
+			{ instruction: 'ARG', name: 'VERSION_UNUSED', value: 'x' },
+			{ instruction: 'ARG', name: 'VERSION_BASE', value: 'latest' },
+		]);
+		assert.strictEqual(findBaseImage(extracted, {}, undefined), 'alpine:latest');
+		assert.strictEqual(findBaseImage(extracted, { VERSION_BASE: '3.20' }, undefined), 'alpine:3.20');
+	});
 
-    it('simple FROM', async () => {
+	it('simple FROM', async () => {
         const dockerfile = `FROM image1
 USER user1
 `;


### PR DESCRIPTION
Fixes #1286

## Summary

- join Dockerfile lines that use the default backslash continuation before scanning instructions
- collect every declaration from a continued `ARG` instruction
- preserve the existing single-declaration behavior for `ENV` and `USER`
- add regression coverage for default and `buildArgs`-overridden values

## Root cause

The lightweight Dockerfile scanner matched physical lines and recorded only one name/value pair for each `ARG` instruction. Docker joins continuation lines before parsing, so the second declaration was invisible to the CLI even though Docker/BuildKit accepted it. A later `FROM` reference therefore resolved to an empty value and produced an invalid image reference.

## Validation

- focused `dockerfileUtils` suite: 70 passing
- `npm run type-check`: passed
- `npm run lint`: passed
- `git diff --check`: passed

The repository-wide `npm test` script uses Unix `env`/`rm` commands and is not directly runnable from the current Windows shell. The focused parser suite covers the changed module; upstream CI should provide the remaining platform and integration validation.

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
